### PR TITLE
add back event RBAC

### DIFF
--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -8,6 +8,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   verbs:
   - create


### PR DESCRIPTION
There was a manual addition of event RBAC permissions to the generated `deploy.yaml` that was removed in a previous commit. This adds those needed permissions back into the
`config/rbac/cluster-role-controller.yaml` file so that `make build-deploy` will generate the needed RBAC permissions for the controller's ClusterRole.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
