### PR TITLE
add missing values.yaml instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ git checkout -b release-$RELEASE_VERSION
 
 Open `helm/Chart.yaml` and change the `version` and `appVersion` to match the `$RELEASE_VERSION`.
 
+Open `helm/values.yaml` and change the `image.tag` value to match the `$RELEASE_VERSION`.
+
 3. Create a Git commit for the new release artifacts.
 
 ```bash


### PR DESCRIPTION
Adds missing instruction to update the `helm/values.yaml` file's `image.tag` configuration value to match the `$RELEASE_VERSION` in the README's release steps.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
