### PR TITLE
Add a fix for crash on some deployment

### DIFF
--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -270,7 +270,7 @@ func (r *HTTPRouteReconciler) updateHTTPRouteStatus(ctx context.Context, dns str
 	glog.V(6).Infof("updateHTTPRouteStatus: httproute %v, dns %v\n", httproute, dns)
 	httprouteOld := httproute.DeepCopy()
 
-	if httproute.Status.RouteStatus.Parents == nil {
+	if len(httproute.Status.RouteStatus.Parents) == 0 {
 		httproute.Status.RouteStatus.Parents = make([]v1alpha2.RouteParentStatus, 1)
 		httproute.Status.RouteStatus.Parents[0].Conditions = make([]metav1.Condition, 1)
 		httproute.Status.RouteStatus.Parents[0].Conditions[0].LastTransitionTime = eventhandlers.ZeroTransitionTime


### PR DESCRIPTION
*Issue #, if available:*
In one deployment, the controller crashed and crash stack trace point the the line we fixed

*Description of changes:*
We made this change and provide the [docker image](public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller:Disney), and verified it has fixed their crash issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
