### PR TITLE
remove random string prefix in LeaderElectionID

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "6288bc47.amazon-vpc-lattice.io",
+		LeaderElectionID:       "amazon-vpc-lattice.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* remove the random string prefix in `LeaderElectionID`.

Before
```
» kubectl -n system get lease
NAME                             HOLDER                                                                         AGE
6288bc47.amazon-vpc-lattice.io   gateway-api-controller-7fcfcf96c8-d9chk_b8d441c3-7e84-4f70-866f-ae65dd229cd0   131m
```

After
```
» kubectl -n system get lease
NAME                             HOLDER                                                                         AGE
amazon-vpc-lattice.io            gateway-api-controller-7f6567978-6lkv7_4682e004-cef2-415f-8e8a-b283806f08ec    47m
```

For reference, here are some other related projects and their `LeaderElectionID`
* EC2 ACK — ec2.services.k8s.aws
* IAM ACK — iam.services.k8s.aws
* AWS LB — aws-load-balancer-controller-leader
* Karpenter — karpenter-leader-election

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
