### PR TITLE
handle deletes of gateway, httproute if gatewayclass is deleted

### DIFF
--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -19,9 +19,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -152,6 +154,10 @@ func (r *HTTPRouteReconciler) cleanupHTTPRouteResources(ctx context.Context, htt
 }
 
 func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute *v1alpha2.HTTPRoute) bool {
+
+	if controllerutil.ContainsFinalizer(httpRoute, httpRouteFinalizer) {
+		return true
+	}
 
 	if len(httpRoute.Spec.ParentRefs) == 0 {
 		glog.V(6).Infof("Ignore HTTPRoute which has no ParentRefs gateway %v \n ", httpRoute.Spec)


### PR DESCRIPTION
*Issue #, if available:* #115

Tested and this resolves the reproduce steps in the issue above.

*Description of changes:*
This is much simpler change than it appears, due to removing a nested if/else

This changes the logic of 2 controllers: `Gateway` and `HTTPRoute` very simply.
* During a reconcile, the resource is considered in scope if it has the VPC Lattice finalizer on it

Before, the reconcile logic would skip any `Gateway` or `HTTPRoute` if there wasn't a matching `GatewayClass`. While this makes sense for all creates, it doesn't make sense for a delete when we _know_ it's relevant because the controller put a finalizer on it there is a VPC Lattice resources created.

The change in `controllers/httproute_controller.go` is very straightforward.

The logic change is the same for `controllers/gateway_controller.go` but there was nested if/else clauses

The `reconcile` function had a nested if/else:

```
if gwClass.Spec.ControllerName == config.LatticeGatewayControllerName {

	if !gw.DeletionTimestamp.IsZero() {
```

The `gwClass.Spec.ControllerName == config.LatticeGatewayControllerName` logic was moved to a new function `isGatewayRelevant` that makes it clear the conditions that decide whether to reconcile or ignore a Gateway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
