### PR TITLE
fix panic due to nil eventRecorder in GatewayReconciler

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -78,6 +78,7 @@ func NewGatewayReconciler(client client.Client, scheme *runtime.Scheme, eventRec
 		Scheme:            scheme,
 		gwClassReconciler: gwClassReconciler,
 		finalizerManager:  finalizerManager,
+		eventRecorder:     eventRecorder,
 		modelBuilder:      modelBuilder,
 		stackDeployer:     stackDeployer,
 		cloud:             cloud,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
set the eventRecorder when creating a new GatewayReconciler to avoid panic when trying to create an event

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
