### PR TITLE
Change description of supported regions in the docs

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -3,7 +3,7 @@
 Follow these instructions to create a cluster and deploy the AWS Gateway API Controller.
 Run through them again for a second cluster to use with the extended example shown later.
 
-1. Set your region (`us-west-2` or `us-east-1`) as an environment variable. For example:
+1. Set your region as an environment variable. Nine regions are now supported, including `us-west-2` and `us-east-1`. For example:
    ```bash
    export AWS_REGION=us-west-2
    ```


### PR DESCRIPTION
*Description of changes:* In the previous version of the deploy.md docs, it said we only supported two regions. I'm told we now support nine regions. Instead of listing all nine, I just updated the description to say there were nine and gave two examples. If you don't like how I did this, let me know if you want to list all nine or point to a doc where they are described.

