### PR TITLE
fix broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 scripts/aws_sdk_model_override/aws-sdk-go
 coverage.out
 deploy.yaml
+
+# MkDocs documentation
+site*/
+

--- a/docs/configure/index.md
+++ b/docs/configure/index.md
@@ -1,3 +1,3 @@
 # Configure AWS Gateway API Controller
 Refer to this document to further configure your use of the AWS Gateway API Controller.
-The features here build on the examples shown in [Get Started Using the AWS Gateway API Controller](getstarted.md).
+The features here build on the examples shown in [Get Started Using the AWS Gateway API Controller](../getstarted.md).

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -1,6 +1,6 @@
 # Get Start Using the AWS Gateway API Controller
 
-Once you have [deployed the AWS Gateway API Controller](configure.md), this guide helps you get started using the controller.
+Once you have [deployed the AWS Gateway API Controller](configure/index.md), this guide helps you get started using the controller.
 
 The first part of this section provides an example of setting up of service-to-service communications on a single cluster.
 The second section extends that example by creating another inventory service on a second cluster on a different VPC, and spreading traffic to that service across the two clusters and VPCs.


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
The mkdocs build was failing because of some broken links in the docs. This fixes them.

Also, I added the "site/" dir to the gitignore, to ignore docs builds. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
