### PR TITLE
Fixed v1alpha1 references to v1beta1 in docs

### DIFF
--- a/docs/multi-sn.md
+++ b/docs/multi-sn.md
@@ -132,7 +132,7 @@ In workload cluster, exports k8s service to AWS VPC lattice
 
 ```
 # in workload cluster(s)
-apiVersion: multicluster.x-k8s.io/v1beta1
+apiVersion: multicluster.x-k8s.io/v1alpha1
 kind: ServiceExport
 metadata:
   name: service-1
@@ -144,7 +144,7 @@ metadata:
 
 ```
 # in config cluster
-apiVersion: multicluster.x-k8s.io/v1beta1
+apiVersion: multicluster.x-k8s.io/v1alpha1
 kind: ServiceImport
 metadata:
   name: service-1


### PR DESCRIPTION
*Description of changes:* Changed a couple of references to v1alpha1 to v1beta1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
