### PR TITLE
Change AWS CNI to AWS VPC CNI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,6 @@ For more information on this technology, see [Kubernetes Gateway API](https://ga
 A few things to keep in mind:
 
 * If you are new to the VPC Lattice service, keep in mind that names you use for objects must be unique across your entire account and not just across each cluster used by that account.
-* Your AWS CNI must be v1.8.0 or later to work with VPC Lattice.
+* Your AWS VPC CNI must be v1.8.0 or later to work with VPC Lattice.
 
 


### PR DESCRIPTION
**What type of PR is this?** Small fix to documentation. "AWS CNI" needs to be "AWS VPC CNI" in the index.md file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.