### PR TITLE
Add yaml examples for AWS Resource Access Manager sharing ServiceNetwork (gateway) between accounts

### DIFF
--- a/docs/ram-sharing.md
+++ b/docs/ram-sharing.md
@@ -1,0 +1,32 @@
+# Share Kubernetes Gateway (VPC lattice service network) between different AWS accounts
+
+AWS Resource Access Manager(RAM) helps you share your resources across AWS accounts, within your organization or
+organizational units (OUs). Now VPC lattice support 2 types of resource sharing: share VPC lattice service or sharing
+VPC lattice services, in the AWS Gateway API Controller now it only support sharing VPC lattice service network.
+
+Here in a example that account B (sharer account) could share it's service network with account A (sharee account), and
+account A could access all k8s services (vpc lattice target groups) and k8s httproutes(vpc lattice services) within this
+sharer account's service network.
+
+**Steps**
+
+1. Create a full connectivity setup example (include a gateway, a service and a httproute ) in the account B (sharer
+   account): `kubectl apply -f examples/second-account-gw1-full-setup.yaml`
+
+
+2. Go to accountB's aws "Resource Access Manager" console, create a `VPC Lattice Service Networks` type resource
+   sharing, share the service network that created from previous step's gateway(second-account-gw1)  (You could check
+   the VPC Lattice console to get the resource arn, service network name should also be second-account-gw1)
+
+3. Open the account A (sharee account)'s "aws Resource Access Manager" console, in the "Shared with me" section accept
+   the accountB's Service Network sharing invitation.
+
+4. Load the account A's aws credential in you command line, do `kubectl config use-context <accountA cluster>` to switch
+   to accountA's context
+
+5. Apply the same "second-account-gw1" account A (sharee account)'s cluster
+   by `kubectl apply -f examples/second-account-gw1-in-primary-account.yaml`
+
+6. All done, you could verify service network(gateway) sharing by: Attach to any pod in account A's cluster,
+   do `curl <vpc lattice service dns for 'second-account-gw1-httproute'>`, it should be able to get correct response "
+   second-account-gw1-svc handler pod" 

--- a/examples/second-account-gw1-full-setup.yaml
+++ b/examples/second-account-gw1-full-setup.yaml
@@ -1,0 +1,72 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: second-account-gw1
+  annotations:
+    application-networking.k8s.aws/lattice-vpc-association: "true"
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second-account-gw1-svc
+  labels:
+    app: second-account-gw1-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: second-account-gw1-svc
+  template:
+    metadata:
+      labels:
+        app: second-account-gw1-svc
+    spec:
+      containers:
+        - name: second-account-gw1-svc-app
+          image: public.ecr.aws/x2j8p8w7/http-server:latest
+          env:
+            - name: PodName
+              value: "second-account-gw1-svc handler pod"
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: second-account-gw1-svc
+spec:
+  selector:
+    app: second-account-gw1-svc
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8090
+
+---
+
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: second-account-gw1-httproute
+spec:
+  parentRefs:
+    - name:  second-account-gw1
+      sectionName: http
+  rules:
+    - backendRefs:
+        - name: second-account-gw1-svc
+          kind: Service
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+

--- a/examples/second-account-gw1-in-primary-account.yaml
+++ b/examples/second-account-gw1-in-primary-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: second-account-gw1
+  annotations:
+    application-networking.k8s.aws/lattice-vpc-association: "true"
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** test case examples

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: N/A


**What does this PR do / Why do we need it**:
Add yaml examples for AWS Resource Access Manager sharing ServiceNetwork (gateway) test scenario between aws accounts. AccountB do `kubectl apply -f examples/second-account-gw1-full-setup.yaml` and share created service network in  "Resource Access Manager" , then AccountA do `kubectl apply -f examples/second-account-gw1-in-primary-account.yaml`,  after that, pods in AccountA should be able to access httproute and services in AccountB

Why do we need it: It provides simple and seperate examples to test Resource Access Manager sharing ServiceNetwork

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:

- Do `kubectl apply -f examples/second-account-gw1-full-setup.yaml` in accountB(sharer account)
- Go to accountB's aws "Resource Access Manager" console, create a `VPC Lattice Service Networks` type resource sharing for this k8s gateway(second-account-gw1) created service network (You could check the VPC Lattice console to get the resource arn, it's name should also be `second-account-gw1`)
- Then, open the accountA(sharee account)'s "aws Resource Access Manager" console, in the `Shared with me` section accept the accountB's Service Network sharing invation.
-   load the  accountA's aws credential in you command line, do  `kubectl config use-context <accountA cluster>` to switch to  accountA's context
-  Do the `kubectl apply -f examples/second-account-gw1-in-primary-account.yaml` for accountA's k8s cluster, 
- Attach to any pod in current cluster, do `curl <vpc lattice service dns for 'second-account-gw1-httproute'>`, it should be able to get correct response `"second-account-gw1-svc handler pod"`


**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.