### PR TITLE
Add a capability that allow user to define a cluster local gateway 

### DIFF
--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"strings"
 
@@ -11,6 +12,8 @@ import (
 const (
 	LatticeGatewayControllerName = "application-networking.k8s.aws/gateway-api-controller"
 	defaultLogLevel              = "Info"
+	NoDefaultServiceNetwork      = ""
+	NO_DEFAULT_SERVICE_NETWORK   = "NO_DEFAULT_SERVICE_NETWORK"
 )
 
 // TODO endpoint, region
@@ -18,6 +21,7 @@ var VpcID = "vpc-xxxx"
 var AccountID = "yyyyyy"
 var Region = "us-west-2"
 var logLevel = defaultLogLevel
+var DefaultServiceNetwork = NoDefaultServiceNetwork
 
 func GetLogLevel() string {
 	logLevel = os.Getenv("GATEWAY_API_CONTROLLER_LOGLEVEL")
@@ -28,6 +32,14 @@ func GetLogLevel() string {
 		return "2"
 	}
 	return "2"
+}
+
+func GetClusterLocalGateway() (string, error) {
+	if DefaultServiceNetwork == NoDefaultServiceNetwork {
+		return NoDefaultServiceNetwork, errors.New(NO_DEFAULT_SERVICE_NETWORK)
+	}
+
+	return DefaultServiceNetwork, nil
 }
 
 func ConfigInit() {
@@ -48,6 +60,15 @@ func ConfigInit() {
 
 	logLevel = os.Getenv("GATEWAY_API_CONTROLLER_LOGLEVEL")
 	glog.V(2).Infoln("Logging Level:", os.Getenv("GATEWAY_API_CONTROLLER_LOGLEVEL"))
+
+	DefaultServiceNetwork = os.Getenv("CLUSTER_LOCAL_GATEWAY")
+
+	if DefaultServiceNetwork == NoDefaultServiceNetwork {
+		glog.V(2).Infoln("No CLUSTER_LOCAL_GATEWAY")
+	} else {
+
+		glog.V(2).Infoln("CLUSTER_LOCAL_GATEWAY", DefaultServiceNetwork)
+	}
 
 	sess, _ := session.NewSession()
 	metadata := NewEC2Metadata(sess)

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -8,6 +8,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
@@ -130,6 +131,10 @@ func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) 
 	for _, parentRef := range t.httpRoute.Spec.ParentRefs {
 		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, string(parentRef.Name))
 
+	}
+	defaultGateway, err := config.GetClusterLocalGateway()
+	if err == nil {
+		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, defaultGateway)
 	}
 
 	if len(t.httpRoute.Spec.Hostnames) > 0 {

--- a/pkg/gateway/model_build_servicenetwork.go
+++ b/pkg/gateway/model_build_servicenetwork.go
@@ -81,6 +81,12 @@ func (t *serviceNetworkModelBuildTask) buildServiceNetwork(ctx context.Context) 
 		}
 
 	}
+	_, err := config.GetClusterLocalGateway()
+
+	if err == nil {
+		// there is a default gateway for local cluster, all other gateways are not associate to VPC
+		spec.AssociateToVPC = false
+	}
 
 	if !t.gateway.DeletionTimestamp.IsZero() {
 		spec.IsDeleted = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature
**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
VPC Lattice today only allows VPC to associate to a single ServiceNetwork.  But K8S users might desire to define multiple gateway(s) and associate HTTPRoutes to different gateway(s).  And at meantime, K8S user want Pods in the cluster(s) to access their HTTPRoute(s) might belong to different gateway(s)

We add a capability to allow user to define a CLUSTER_LOCAL_GATEWAY where this CLUSTER_LOCAL_GATEWAY is associated to current VPC.  And controller will automatically associate lattice service(HTTPRoute)  to this CLUSTER_LOCAL_GATEWAY.  

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.