### PR TITLE
Add option to allow creating namespaced K8S resources and update path based to use non-default gateway

### DIFF
--- a/test/pkg/test/gateway.go
+++ b/test/pkg/test/gateway.go
@@ -5,10 +5,12 @@ import (
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func (env *Framework) NewGateway() *v1beta1.Gateway {
+func (env *Framework) NewGateway(name string, namespace string) *v1beta1.Gateway {
 	gateway := New(
 		&v1beta1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Namespace: namespace,
 				Annotations: map[string]string{
 					"application-networking.k8s.aws/lattice-vpc-association": "true",
 				},

--- a/test/pkg/test/httpapp.go
+++ b/test/pkg/test/httpapp.go
@@ -11,6 +11,7 @@ import (
 
 type HTTPAppOptions struct {
 	Name                string
+	Namespace           string // the object will be created in this namespace
 	Port                int
 	TargetPort          int
 	MergeFromDeployment []*appsv1.Deployment
@@ -25,6 +26,9 @@ func (env *Framework) NewHttpApp(options HTTPAppOptions) (*appsv1.Deployment, *v
 		options.TargetPort = 8090
 	}
 	deployment := New(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: lo.ToPtr(int32(1)),
 			Selector: &metav1.LabelSelector{
@@ -34,6 +38,7 @@ func (env *Framework) NewHttpApp(options HTTPAppOptions) (*appsv1.Deployment, *v
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Namespace: options.Namespace,
 					Labels: map[string]string{
 						"app":          options.Name,
 						DiscoveryLabel: "true",
@@ -56,6 +61,9 @@ func (env *Framework) NewHttpApp(options HTTPAppOptions) (*appsv1.Deployment, *v
 	service := New(&v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
 		},
 		Spec: v1.ServiceSpec{
 			Selector: map[string]string{

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("HTTPRoute header matches", func() {
 	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
-		gateway := testFramework.NewGateway()
+		gateway := testFramework.NewGateway("","")
 
 		deployment3, service3 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3"})
 		headerMatchHttpRoute := testFramework.NewHeaderMatchHttpRoute(gateway, []*v1.Service{service3})

--- a/test/suites/integration/httproute_path_match_test.go
+++ b/test/suites/integration/httproute_path_match_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("HTTPRoute path matches", func() {
 	It("HTTPRoute should support multiple path matches", func() {
-		gateway := testFramework.NewGateway()
+		gateway := testFramework.NewGateway("","")
 		deployment1, service1 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1"})
 		deployment2, service2 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2"})
 		pathMatchHttpRoute := testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http")

--- a/test/suites/integration/httproute_path_match_test.go
+++ b/test/suites/integration/httproute_path_match_test.go
@@ -15,12 +15,17 @@ import (
 	"time"
 )
 
+const (
+	k8snamespace = "non-default"
+)
+
 var _ = Describe("HTTPRoute path matches", func() {
 	It("HTTPRoute should support multiple path matches", func() {
-		gateway := testFramework.NewGateway("","")
-		deployment1, service1 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1"})
-		deployment2, service2 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2"})
-		pathMatchHttpRoute := testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http")
+		gateway := testFramework.NewGateway("",k8snamespace)
+		deployment1, service1 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: k8snamespace})
+		deployment2, service2 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: k8snamespace})
+		pathMatchHttpRoute := testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http",
+	"", k8snamespace)
 
 		// Create Kubernetes API Objects
 		testFramework.ExpectCreated(ctx,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature
**Which issue does this PR fix**:
enhance e2e test framework to allow non-default namespaced gateway and httproute

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
Ran 2 of 2 Specs in 583.398 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (584.30s)
PASS
ok  	github.com/aws/aws-application-networking-k8s/test/suites/integration	584.329s
```

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.