### PR TITLE
Add capability to allow lattice target group name include current vpc and httproute 

### DIFF
--- a/controllers/eventhandlers/gateway.go
+++ b/controllers/eventhandlers/gateway.go
@@ -33,8 +33,8 @@ func NewEnqueueRequestGatewayEvent(client client.Client) handler.EventHandler {
 var ZeroTransitionTime = metav1.NewTime(time.Time{})
 
 func (h *enqueueRequestsForGatewayEvent) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
-	glog.V(6).Info("Gateway Create")
 	gwNew := e.Object.(*gateway_api.Gateway)
+	glog.V(2).Infof("Gateway Create and Spec is %v", gwNew.Spec)
 
 	// initialize transition time
 	gwNew.Status.Conditions[0].LastTransitionTime = ZeroTransitionTime
@@ -48,6 +48,8 @@ func (h *enqueueRequestsForGatewayEvent) Update(e event.UpdateEvent, queue workq
 	gwNew := e.ObjectNew.(*gateway_api.Gateway)
 
 	if !equality.Semantic.DeepEqual(gwOld.Spec, gwNew.Spec) {
+		glog.V(2).Infof("Gateway Update old spec %v to new spec %v",
+			gwOld.Spec, gwNew.Spec)
 		// initialize transition time
 		gwNew.Status.Conditions[0].LastTransitionTime = ZeroTransitionTime
 		h.enqueueImpactedHTTPRoute(queue, gwNew)
@@ -101,7 +103,7 @@ func (h *enqueueRequestsForGatewayEvent) enqueueImpactedHTTPRoute(queue workqueu
 		}
 
 		if gwClass.Spec.ControllerName == config.LatticeGatewayControllerName {
-			glog.V(6).Infof("Trigger HTTPRoute from Gateway event , httpRoute %s", httpRoute.Name)
+			glog.V(2).Infof("Trigger HTTPRoute from Gateway event , httpRoute %s", httpRoute.Name)
 			queue.Add(reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: httpRoute.Namespace,

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -238,7 +238,7 @@ func (r *GatewayReconciler) reconcileGatewayResources(ctx context.Context, gw *g
 	glog.V(6).Infof("serviceNetworkStatus : %v for %s  error %v \n", serviceNetworkStatus, gw.Name, err)
 
 	if err = r.updateGatewayStatus(ctx, &serviceNetworkStatus, gw); err != nil {
-		glog.V(2).Infof("Failed to updateGatewayStatus %v err %v\n", gw, err)
+		glog.V(2).Infof("Failed to updateGatewayStatus err %v, gw %v\n", err, gw)
 		return errors.New("failed to update gateway status")
 	}
 	return nil
@@ -273,6 +273,7 @@ func (r *GatewayReconciler) updateGatewayStatus(ctx context.Context, serviceNetw
 	//gw.Annotations["gateway.networking.k8s.io/aws-gateway-id"] = serviceNetworkStatus.ID
 
 	if err := r.Client.Status().Patch(ctx, gw, client.MergeFrom(gwOld)); err != nil {
+		glog.V(2).Infof("Failed to update gateway status %v for gateway %v", err, gw)
 		return errors.Wrapf(err, "failed to update gateway status")
 	}
 
@@ -299,6 +300,7 @@ func (r *GatewayReconciler) updateGatewayAcceptStatus(ctx context.Context, gw *g
 	gw.Status.Conditions[0].Type = string(gateway_api.GatewayConditionAccepted)
 
 	if err := r.Client.Status().Patch(ctx, gw, client.MergeFrom(gwOld)); err != nil {
+		glog.V(2).Infof("Failed to Patch acceptance status, err %v gw %v", err, gw)
 		return errors.Wrapf(err, "failed to update gateway status")
 	}
 
@@ -480,7 +482,7 @@ func UpdateGWListenerStatus(ctx context.Context, k8sclient client.Client, gw *ga
 	glog.V(6).Infof("After update, the snapshot of listener status %v", gw.Status.Listeners)
 
 	if err := k8sclient.Status().Patch(ctx, gw, client.MergeFrom(gwOld)); err != nil {
-		glog.V(2).Infof("liwwu1-failed to update gateway listener status %v, status %v", err, gw.Status.Listeners)
+		glog.V(2).Infof("Failed to update gateway listener err: %v, status: %v", err, gw.Status.Listeners)
 		return errors.Wrapf(err, "failed to update gateway status")
 	}
 

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -22,6 +22,7 @@ var AccountID = "yyyyyy"
 var Region = "us-west-2"
 var logLevel = defaultLogLevel
 var DefaultServiceNetwork = NoDefaultServiceNetwork
+var UseLongTGName = false
 
 func GetLogLevel() string {
 	logLevel = os.Getenv("GATEWAY_API_CONTROLLER_LOGLEVEL")
@@ -68,6 +69,16 @@ func ConfigInit() {
 	} else {
 
 		glog.V(2).Infoln("CLUSTER_LOCAL_GATEWAY", DefaultServiceNetwork)
+	}
+
+	tgNameLengthMode := os.Getenv("TARGET_GROUP_NAME_LEN_MODE")
+
+	glog.V(2).Infoln("TARGET_GROUP_NAME_LEN_MODE", tgNameLengthMode)
+
+	if tgNameLengthMode == "long" {
+		UseLongTGName = true
+	} else {
+		UseLongTGName = false
 	}
 
 	sess, _ := session.NewSession()

--- a/pkg/deploy/lattice/rule_manager.go
+++ b/pkg/deploy/lattice/rule_manager.go
@@ -183,7 +183,7 @@ func (r *defaultRuleManager) Create(ctx context.Context, rule *latticemodel.Rule
 	for _, tgRule := range rule.Spec.Action.TargetGroups {
 
 		tgName := latticestore.TargetGroupName(tgRule.Name, tgRule.Namespace)
-		tg, err := r.latticeDataStore.GetTargetGroup(tgName, tgRule.IsServiceImport)
+		tg, err := r.latticeDataStore.GetTargetGroup(tgName, tgRule.RouteName, tgRule.IsServiceImport)
 
 		if err != nil {
 			glog.V(2).Infof("Faild to create rule due to unknown tg %v, err %v\n", tgName, err)
@@ -487,7 +487,7 @@ func (r *defaultRuleManager) findMatchingRule(ctx context.Context, rule *lattice
 			for _, k8sTG := range rule.Spec.Action.TargetGroups {
 				// get k8sTG id
 				tgName := latticestore.TargetGroupName(k8sTG.Name, k8sTG.Namespace)
-				k8sTGinStore, err := r.latticeDataStore.GetTargetGroup(tgName, k8sTG.IsServiceImport)
+				k8sTGinStore, err := r.latticeDataStore.GetTargetGroup(tgName, rule.Spec.ServiceName, k8sTG.IsServiceImport)
 
 				if err != nil {
 					glog.V(6).Infof("Failed to find k8s tg %v in store \n", k8sTG)

--- a/pkg/deploy/lattice/rule_manager_test.go
+++ b/pkg/deploy/lattice/rule_manager_test.go
@@ -548,7 +548,7 @@ func Test_CreateRule(t *testing.T) {
 		if !tt.noTargetGroupID {
 			for _, tg := range tt.newRule.Spec.Action.TargetGroups {
 				tgName := latticestore.TargetGroupName(tg.Name, tg.Namespace)
-				latticeDataStore.AddTargetGroup(tgName, "vpc", "arn", "tg-id", tg.IsServiceImport)
+				latticeDataStore.AddTargetGroup(tgName, "vpc", "arn", "tg-id", tg.IsServiceImport, "")
 			}
 
 		}

--- a/pkg/deploy/lattice/service_network_synthesizer_test.go
+++ b/pkg/deploy/lattice/service_network_synthesizer_test.go
@@ -151,7 +151,6 @@ func Test_SynthesizeTriggeredGateways(t *testing.T) {
 				func(ctx context.Context, retGWList *gateway_api.GatewayList, arg3 ...interface{}) error {
 					// return empty gatway
 					for _, gw := range gwList.Items {
-						fmt.Printf("liwwu>>> test append %v\n", gw)
 						retGWList.Items = append(retGWList.Items, gw)
 					}
 					return nil

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -31,7 +31,7 @@ func NewTargetGroupManager(cloud lattice_aws.Cloud) *defaultTargetGroupManager {
 	}
 }
 
-func TG2LatticeTGName(targetGroup *latticemodel.TargetGroup) string {
+func getLatticeTGName(targetGroup *latticemodel.TargetGroup) string {
 	var tgName string
 	if config.UseLongTGName {
 		tgName = latticestore.TargetGroupLongName(targetGroup.Spec.Name,
@@ -64,7 +64,7 @@ func (s *defaultTargetGroupManager) Create(ctx context.Context, targetGroup *lat
 
 	glog.V(6).Infof("Create Target Group API call for name %s \n", targetGroup.Spec.Name)
 
-	latticeTGName := TG2LatticeTGName(targetGroup)
+	latticeTGName := getLatticeTGName(targetGroup)
 	// check if exists
 	tgSummary, err := s.findTGByName(ctx, latticeTGName)
 	if err != nil {
@@ -74,7 +74,7 @@ func (s *defaultTargetGroupManager) Create(ctx context.Context, targetGroup *lat
 		return latticemodel.TargetGroupStatus{TargetGroupARN: aws.StringValue(tgSummary.Arn), TargetGroupID: aws.StringValue(tgSummary.Id)}, err
 	}
 
-	glog.V(6).Infof("create targetgropu API here %v\n", targetGroup)
+	glog.V(6).Infof("create targetgroup API here %v\n", targetGroup)
 	port := int64(targetGroup.Spec.Config.Port)
 	tgConfig := &vpclattice.TargetGroupConfig{
 		Port:            &port,
@@ -134,7 +134,7 @@ func (s *defaultTargetGroupManager) Get(ctx context.Context, targetGroup *lattic
 	glog.V(6).Infof("Create Lattice Target Group API call for name %s \n", targetGroup.Spec.Name)
 
 	// check if exists
-	tgSummary, err := s.findTGByName(ctx, TG2LatticeTGName(targetGroup))
+	tgSummary, err := s.findTGByName(ctx, getLatticeTGName(targetGroup))
 	if err != nil {
 		return latticemodel.TargetGroupStatus{TargetGroupARN: "", TargetGroupID: ""}, err
 	}

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -32,15 +32,15 @@ func NewTargetGroupManager(cloud lattice_aws.Cloud) *defaultTargetGroupManager {
 }
 
 func TG2LatticeTGName(targetGroup *latticemodel.TargetGroup) string {
-	var tgname string
+	var tgName string
 	if config.UseLongTGName {
-		tgname = latticestore.TargetGroupLongName(targetGroup.Spec.Name,
+		tgName = latticestore.TargetGroupLongName(targetGroup.Spec.Name,
 			targetGroup.Spec.Config.K8SHTTPRouteName, config.VpcID)
 	} else {
-		tgname = targetGroup.Spec.Name
+		tgName = targetGroup.Spec.Name
 	}
 
-	return tgname
+	return tgName
 }
 
 // Create will try to create a target group
@@ -76,7 +76,7 @@ func (s *defaultTargetGroupManager) Create(ctx context.Context, targetGroup *lat
 
 	glog.V(6).Infof("create targetgropu API here %v\n", targetGroup)
 	port := int64(targetGroup.Spec.Config.Port)
-	TGconfig := &vpclattice.TargetGroupConfig{
+	tgConfig := &vpclattice.TargetGroupConfig{
 		Port:            &port,
 		Protocol:        &targetGroup.Spec.Config.Protocol,
 		ProtocolVersion: &targetGroup.Spec.Config.ProtocolVersion,
@@ -86,7 +86,7 @@ func (s *defaultTargetGroupManager) Create(ctx context.Context, targetGroup *lat
 	targetGroupType := string(targetGroup.Spec.Type)
 
 	createTargetGroupInput := vpclattice.CreateTargetGroupInput{
-		Config: TGconfig,
+		Config: tgConfig,
 		Name:   &latticeTGName,
 		Type:   &targetGroupType,
 		Tags:   make(map[string]*string),

--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -6,8 +6,6 @@ import (
 	"github.com/golang/glog"
 	"strings"
 
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -295,9 +293,6 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 		}
 
 		glog.V(2).Infof("Append stale SDK TG to stale list Name %v, routename %v, ARN %v",
-			*sdkTG.getTargetGroupOutput.Name, tgRouteName, *sdkTG.getTargetGroupOutput.Id)
-
-		fmt.Printf("liwwu>>>Append stale SDK TG to stale list Name %v, routename %v, ARN %v\n",
 			*sdkTG.getTargetGroupOutput.Name, tgRouteName, *sdkTG.getTargetGroupOutput.Id)
 
 		staleSDKTGs = append(staleSDKTGs, latticemodel.TargetGroup{

--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -107,8 +107,11 @@ func (t *targetGroupSynthesizer) SynthesizeTriggeredTargetGroup(ctx context.Cont
 				continue
 			}
 
+			// for serviceimport, the httproutename is ""
+
 			t.latticeDataStore.AddTargetGroup(resTargetGroup.Spec.Name,
-				resTargetGroup.Spec.Config.VpcID, tgStatus.TargetGroupARN, tgStatus.TargetGroupID, resTargetGroup.Spec.Config.IsServiceImport)
+				resTargetGroup.Spec.Config.VpcID, tgStatus.TargetGroupARN, tgStatus.TargetGroupID,
+				resTargetGroup.Spec.Config.IsServiceImport, "")
 
 			glog.V(6).Infof("targetGroup Synthesized successfully for %s: %v\n", resTargetGroup.Spec.Name, tgStatus)
 
@@ -121,7 +124,7 @@ func (t *targetGroupSynthesizer) SynthesizeTriggeredTargetGroup(ctx context.Cont
 					continue
 				} else {
 					glog.V(6).Infof("Synthersizing Target Group: successfully deleted target group %v\n", resTargetGroup)
-					t.latticeDataStore.DelTargetGroup(resTargetGroup.Spec.Name, false)
+					t.latticeDataStore.DelTargetGroup(resTargetGroup.Spec.Name, resTargetGroup.Spec.Config.K8SHTTPRouteName, false)
 				}
 
 			} else {
@@ -136,7 +139,9 @@ func (t *targetGroupSynthesizer) SynthesizeTriggeredTargetGroup(ctx context.Cont
 				}
 
 				t.latticeDataStore.AddTargetGroup(resTargetGroup.Spec.Name,
-					resTargetGroup.Spec.Config.VpcID, tgStatus.TargetGroupARN, tgStatus.TargetGroupID, resTargetGroup.Spec.Config.IsServiceImport)
+					resTargetGroup.Spec.Config.VpcID, tgStatus.TargetGroupARN,
+					tgStatus.TargetGroupID, resTargetGroup.Spec.Config.IsServiceImport,
+					resTargetGroup.Spec.Config.K8SHTTPRouteName)
 
 				glog.V(6).Infof("targetGroup Synthesized successfully for %v: %v\n", resTargetGroup.Spec, tgStatus)
 			}
@@ -167,6 +172,7 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 	glog.V(6).Infof("SynthesizeSDKTargetGroups: here is sdkTGs %v len %v \n", sdkTGs, len(sdkTGs))
 
 	for _, sdkTG := range sdkTGs {
+		tgRouteName := ""
 
 		if *sdkTG.getTargetGroupOutput.Config.VpcIdentifier != config.VpcID {
 			glog.V(6).Infof("Ignore target group ARN %v Name %v for other VPCs",
@@ -274,12 +280,14 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 					continue
 				} else {
 					glog.V(6).Infof("tgname %v is not used by httproute %v\n", tgName, httpRoute)
+					tgRouteName = *httpName
 				}
 			}
 
 		}
 
-		if tg, err := t.latticeDataStore.GetTargetGroup(*sdkTG.getTargetGroupOutput.Name, true); err == nil {
+		// the routename for serviceimport is ""
+		if tg, err := t.latticeDataStore.GetTargetGroup(*sdkTG.getTargetGroupOutput.Name, "", true); err == nil {
 			glog.V(6).Infof("Ignore target group created by service import %v\n", tg)
 			continue
 		}
@@ -289,7 +297,10 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 
 		staleSDKTGs = append(staleSDKTGs, latticemodel.TargetGroup{
 			Spec: latticemodel.TargetGroupSpec{
-				Name:      *sdkTG.getTargetGroupOutput.Name,
+				Name: *sdkTG.getTargetGroupOutput.Name,
+				Config: latticemodel.TargetGroupConfig{
+					K8SHTTPRouteName: tgRouteName,
+				},
 				LatticeID: *sdkTG.getTargetGroupOutput.Id,
 			},
 		})

--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -6,6 +6,8 @@ import (
 	"github.com/golang/glog"
 	"strings"
 
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -241,6 +243,7 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 				*sdkTG.getTargetGroupOutput.Arn, *sdkTG.getTargetGroupOutput.Name)
 
 			httpName, ok := tgTags.Tags[latticemodel.K8SHTTPRouteNameKey]
+			tgRouteName = *httpName
 
 			if !ok || httpName == nil {
 				glog.V(6).Infof("Ignore TargetGroup(triggered by httpRoute) %v, %v have no httproute name tag",
@@ -280,7 +283,6 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 					continue
 				} else {
 					glog.V(6).Infof("tgname %v is not used by httproute %v\n", tgName, httpRoute)
-					tgRouteName = *httpName
 				}
 			}
 
@@ -292,8 +294,11 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 			continue
 		}
 
-		glog.V(2).Infof("Append stale SDK TG to stale list Name %v, ARN %v",
-			*sdkTG.getTargetGroupOutput.Name, *sdkTG.getTargetGroupOutput.Id)
+		glog.V(2).Infof("Append stale SDK TG to stale list Name %v, routename %v, ARN %v",
+			*sdkTG.getTargetGroupOutput.Name, tgRouteName, *sdkTG.getTargetGroupOutput.Id)
+
+		fmt.Printf("liwwu>>>Append stale SDK TG to stale list Name %v, routename %v, ARN %v\n",
+			*sdkTG.getTargetGroupOutput.Name, tgRouteName, *sdkTG.getTargetGroupOutput.Id)
 
 		staleSDKTGs = append(staleSDKTGs, latticemodel.TargetGroup{
 			Spec: latticemodel.TargetGroupSpec{

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -152,7 +152,7 @@ func Test_SynthesizeTriggeredServiceExport(t *testing.T) {
 
 			assert.Nil(t, err)
 			tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
-			dsTG, err := ds.GetTargetGroup(tgName, false)
+			dsTG, err := ds.GetTargetGroup(tgName, "", false)
 
 			if tg.Spec.IsDeleted {
 				assert.NotNil(t, err)
@@ -290,11 +290,11 @@ func Test_SynthersizeTriggeredByServiceImport(t *testing.T) {
 			// check datastore
 			for _, tgImport := range tt.svcImportList {
 				if tgImport.mgrErr {
-					_, err := ds.GetTargetGroup(tgImport.name, true)
+					_, err := ds.GetTargetGroup(tgImport.name, "", true)
 					assert.NotNil(t, err)
 
 				} else {
-					tg, err := ds.GetTargetGroup(tgImport.name, true)
+					tg, err := ds.GetTargetGroup(tgImport.name, "", true)
 					assert.Nil(t, err)
 					assert.Equal(t, tgImport.tgARN, tg.ARN)
 					assert.Equal(t, tgImport.tgID, tg.ID)
@@ -731,11 +731,13 @@ func Test_SynthesizeTriggeredService(t *testing.T) {
 			// check datastore
 			for _, tg := range tt.svcList {
 				if tg.mgrErr {
-					_, err := ds.GetTargetGroup(tg.name, false)
+					//TODO, test routename
+					_, err := ds.GetTargetGroup(tg.name, "", false)
 					assert.NotNil(t, err)
 
 				} else {
-					dsTG, err := ds.GetTargetGroup(tg.name, false)
+					//TODO, test routename
+					dsTG, err := ds.GetTargetGroup(tg.name, "", false)
 					assert.Nil(t, err)
 					assert.Equal(t, tg.tgARN, dsTG.ARN)
 					assert.Equal(t, tg.tgID, dsTG.ID)

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -513,6 +513,9 @@ func Test_SynthesizeSDKTargetGroups(t *testing.T) {
 						LatticeID: sdkTG.id,
 					},
 				}
+				if sdkTG.hasHTTPRouteTypeTag {
+					tgSpec.Spec.Config.K8SHTTPRouteName = routename
+				}
 
 				if sdkTG.HTTPRouteExist {
 

--- a/pkg/deploy/lattice/targets_manager.go
+++ b/pkg/deploy/lattice/targets_manager.go
@@ -41,7 +41,7 @@ func (s *defaultTargetsManager) Create(ctx context.Context, targets *latticemode
 
 	// Need to find TargetGroup ID from datastore
 	tgName := latticestore.TargetGroupName(targets.Spec.Name, targets.Spec.Namespace)
-	tg, err := s.datastore.GetTargetGroup(tgName, false) // isServiceImport=false
+	tg, err := s.datastore.GetTargetGroup(tgName, targets.Spec.RouteName, false) // isServiceImport=false
 
 	if err != nil {
 		glog.V(6).Infof("Failed to Create targets, service ( name %v namespace %v) not found, retry later\n", targets.Spec.Name, targets.Spec.Namespace)

--- a/pkg/deploy/lattice/targets_manager_test.go
+++ b/pkg/deploy/lattice/targets_manager_test.go
@@ -55,7 +55,8 @@ func Test_RegisterTargets_RegisterSuccessfully(t *testing.T) {
 
 	latticeDataStore := latticestore.NewLatticeDataStore()
 	tgName := latticestore.TargetGroupName("test", "")
-	latticeDataStore.AddTargetGroup(tgName, "vpc-123456789", "123456789", "123456789", false)
+	//TODO routename
+	latticeDataStore.AddTargetGroup(tgName, "vpc-123456789", "123456789", "123456789", false, "")
 	c := gomock.NewController(t)
 	defer c.Finish()
 	ctx := context.TODO()
@@ -129,7 +130,8 @@ func Test_RegisterTargets_Registerfailed(t *testing.T) {
 
 	latticeDataStore := latticestore.NewLatticeDataStore()
 	tgName := latticestore.TargetGroupName("test", "")
-	latticeDataStore.AddTargetGroup(tgName, "vpc-123456789", "123456789", "123456789", false)
+	// routename
+	latticeDataStore.AddTargetGroup(tgName, "vpc-123456789", "123456789", "123456789", false, "")
 	c := gomock.NewController(t)
 	defer c.Finish()
 	ctx := context.TODO()
@@ -212,7 +214,8 @@ func Test_RegisterTargets_RegisterUnsuccessfully(t *testing.T) {
 
 	latticeDataStore := latticestore.NewLatticeDataStore()
 	tgName := latticestore.TargetGroupName("test", "")
-	latticeDataStore.AddTargetGroup(tgName, "vpc-123456789", "123456789", "123456789", false)
+	//routename
+	latticeDataStore.AddTargetGroup(tgName, "vpc-123456789", "123456789", "123456789", false, "")
 	c := gomock.NewController(t)
 	defer c.Finish()
 	ctx := context.TODO()

--- a/pkg/deploy/lattice/targets_synthesizer.go
+++ b/pkg/deploy/lattice/targets_synthesizer.go
@@ -60,7 +60,7 @@ func (t *targetsSynthesizer) SynthesizeTargets(ctx context.Context, resTargets [
 			})
 		}
 
-		t.latticeDataStore.UpdateTargetsForTargetGroup(tgName, targetList)
+		t.latticeDataStore.UpdateTargetsForTargetGroup(tgName, targets.Spec.RouteName, targetList)
 
 	}
 	return nil

--- a/pkg/deploy/lattice/targets_synthesizer_test.go
+++ b/pkg/deploy/lattice/targets_synthesizer_test.go
@@ -74,7 +74,8 @@ func Test_SynthesizeTargets(t *testing.T) {
 		ds := latticestore.NewLatticeDataStore()
 
 		tgName := latticestore.TargetGroupName(tt.srvExportName, tt.srvExportNamespace)
-		err := ds.AddTargetGroup(tgName, "", "", "", false)
+		// TODO routename
+		err := ds.AddTargetGroup(tgName, "", "", "", false, "")
 		assert.Nil(t, err)
 		ds.SetTargetGroupByServiceExport(tgName, false, true)
 
@@ -106,7 +107,8 @@ func Test_SynthesizeTargets(t *testing.T) {
 		err = targetsSynthesizer.SynthesizeTargets(ctx, resTargetsList)
 		assert.Nil(t, err)
 
-		dsTG, err := ds.GetTargetGroup(tgName, false)
+		// TODO routename
+		dsTG, err := ds.GetTargetGroup(tgName, "", false)
 		assert.Equal(t, tt.expectedTargetList, dsTG.EndPoints)
 
 		assert.Nil(t, err)

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -167,7 +167,7 @@ func (d *latticeTargetsStackDeploy) Deploy(ctx context.Context, stack core.Stack
 				targetList = append(targetList, t)
 
 			}
-			d.latticeDataStore.UpdateTargetsForTargetGroup(tgName, targetList)
+			d.latticeDataStore.UpdateTargetsForTargetGroup(tgName, targets.Spec.RouteName, targetList)
 		}
 
 	}

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -360,11 +360,10 @@ func Test_ListenerModelBuild(t *testing.T) {
 		fmt.Printf("task.buildListener err: %v \n", err)
 
 		if !tt.wantErrIsNil {
-			fmt.Printf("liwwu task.buildListener err: %v %v\n", err, err != nil)
 			// TODO why following is failing????
 			//assert.Equal(t, err!=nil, true)
 			//assert.Error(t, err)
-			fmt.Printf("liwwu task.buildListener tt : %v err: %v %v\n", tt.name, err, err != nil)
+			fmt.Printf("task.buildListener tt : %v err: %v %v\n", tt.name, err, err != nil)
 			continue
 		} else {
 			assert.NoError(t, err)

--- a/pkg/gateway/model_build_rule.go
+++ b/pkg/gateway/model_build_rule.go
@@ -145,6 +145,7 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 					}
 					ruleTG.Name = string(httpBackendRef.BackendObjectReference.Name)
 					ruleTG.Namespace = namespace
+					ruleTG.RouteName = t.httpRoute.Name
 					ruleTG.IsServiceImport = false
 					if httpBackendRef.Weight != nil {
 						ruleTG.Weight = int64(*httpBackendRef.Weight)
@@ -170,6 +171,8 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 					if httpBackendRef.BackendObjectReference.Namespace != nil {
 						ruleTG.Namespace = string(*httpBackendRef.BackendObjectReference.Namespace)
 					}
+					// the routename for serviceimport is always ""
+					ruleTG.RouteName = ""
 					ruleTG.IsServiceImport = true
 
 					if httpBackendRef.Weight != nil {

--- a/pkg/gateway/model_build_servicenetwork.go
+++ b/pkg/gateway/model_build_servicenetwork.go
@@ -82,9 +82,9 @@ func (t *serviceNetworkModelBuildTask) buildServiceNetwork(ctx context.Context) 
 		}
 
 	}
-	_, err := config.GetClusterLocalGateway()
+	defaultSN, err := config.GetClusterLocalGateway()
 
-	if err == nil {
+	if err == nil && defaultSN != t.gateway.Name {
 		// there is a default gateway for local cluster, all other gateways are not associate to VPC
 		spec.AssociateToVPC = false
 	}

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -150,7 +150,7 @@ func (t *latticeServiceModelBuildTask) buildTargets(ctx context.Context) error {
 				Client:      t.Client,
 				tgName:      string(httpBackendRef.Name),
 				tgNamespace: backendNamespace,
-				routename: t.httpRoute.Name,
+				routename:   t.httpRoute.Name,
 				stack:       t.stack,
 				datastore:   t.Datastore,
 			}

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -150,6 +150,7 @@ func (t *latticeServiceModelBuildTask) buildTargets(ctx context.Context) error {
 				Client:      t.Client,
 				tgName:      string(httpBackendRef.Name),
 				tgNamespace: backendNamespace,
+				routename: t.httpRoute.Name,
 				stack:       t.stack,
 				datastore:   t.Datastore,
 			}

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -216,6 +216,7 @@ func (t *targetGroupModelBuildTask) BuildTargetGroup(ctx context.Context) error 
 		t.Datastore.SetTargetGroupByServiceExport(tgName, false, true)
 	}
 
+	// for serviceexport, the routename is null
 	dsTG, err := t.Datastore.GetTargetGroup(tgName, "", false)
 
 	glog.V(6).Infof("TargetGroup cached in datastore: %v \n", dsTG)

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -247,7 +247,11 @@ func (t *latticeServiceModelBuildTask) buildTargetGroup(ctx context.Context, cli
 			}
 
 			// add targetgroup to localcache for service reconcile to reference
-			t.Datastore.AddTargetGroup(tgName, "", "", "", tgSpec.Config.IsServiceImport, t.httpRoute.Name)
+			if *httpBackendRef.Kind == "Service" {
+				t.Datastore.AddTargetGroup(tgName, "", "", "", tgSpec.Config.IsServiceImport, t.httpRoute.Name)
+			} else {
+				t.Datastore.AddTargetGroup(tgName, "", "", "", tgSpec.Config.IsServiceImport, "")
+			}
 
 			if t.httpRoute.DeletionTimestamp.IsZero() {
 				// to add

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -161,7 +161,8 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 			tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
 			assert.Equal(t, tgName, tg.Spec.Name)
 
-			dsTG, err := ds.GetTargetGroup(tgName, false)
+			// for serviceexport, the routename is ""
+			dsTG, err := ds.GetTargetGroup(tgName, "", false)
 			assert.Nil(t, err)
 			if tt.wantIsDeleted {
 				assert.Equal(t, false, dsTG.ByServiceExport)
@@ -415,13 +416,14 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 								fmt.Printf("--task.tgByResID[tgName] %v \n", tg)
 								assert.Equal(t, true, tg.Spec.IsDeleted)
 							} else {
-								dsTG, err := ds.GetTargetGroup(tgName, false)
+								dsTG, err := ds.GetTargetGroup(tgName, tt.httpRoute.Name, false)
 								assert.Equal(t, true, dsTG.ByBackendRef)
 								fmt.Printf("--dsTG %v\n", dsTG)
 								assert.Nil(t, err)
 							}
 						} else {
-							dsTG, err := ds.GetTargetGroup(tgName, true)
+							// the routename for serviceimport is ""
+							dsTG, err := ds.GetTargetGroup(tgName, "", true)
 							fmt.Printf("dsTG %v\n", dsTG)
 							assert.Nil(t, err)
 						}
@@ -595,13 +597,13 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 							fmt.Printf("--task.tgByResID[tgName] %v \n", tg)
 							assert.Equal(t, true, tg.Spec.IsDeleted)
 						} else {
-							dsTG, err := ds.GetTargetGroup(tgName, false)
+							dsTG, err := ds.GetTargetGroup(tgName, tt.httpRoute.Name, false)
 							assert.Equal(t, true, dsTG.ByBackendRef)
 							fmt.Printf("--dsTG %v\n", dsTG)
 							assert.Nil(t, err)
 						}
 					} else {
-						dsTG, err := ds.GetTargetGroup(tgName, true)
+						dsTG, err := ds.GetTargetGroup(tgName, "", true)
 						fmt.Printf("dsTG %v\n", dsTG)
 						if tt.wantIsDeleted {
 							tg := task.tgByResID[tgName]

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -539,6 +539,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		fmt.Printf("Test >>>> %v\n", tt.name)
 		c := gomock.NewController(t)
 		defer c.Finish()
 		ctx := context.Background()

--- a/pkg/gateway/model_build_targets_test.go
+++ b/pkg/gateway/model_build_targets_test.go
@@ -184,13 +184,13 @@ func Test_Targets(t *testing.T) {
 
 		if tt.inDataStore {
 			tgName := latticestore.TargetGroupName(tt.srvExportName, tt.srvExportNamespace)
-			err := ds.AddTargetGroup(tgName, "", "", "", false)
+			err := ds.AddTargetGroup(tgName, "", "", "", false, "")
 			assert.Nil(t, err)
 			if tt.refByServiceExport {
 				ds.SetTargetGroupByServiceExport(tgName, false, true)
 			}
 			if tt.refByService {
-				ds.SetTargetGroupByBackendRef(tgName, false, true)
+				ds.SetTargetGroupByBackendRef(tgName, "", false, true)
 			}
 
 		}

--- a/pkg/latticestore/latticestore.go
+++ b/pkg/latticestore/latticestore.go
@@ -296,8 +296,8 @@ func TargetGroupName(name string, namespace string) string {
 	return fmt.Sprintf("k8s-%0.20s-%0.20s", name, namespace)
 }
 
-func TargetGroupLongName(name string, namespace string, httprouteName string, vpcid string) string {
-	return fmt.Sprintf("k8s-%0.20s-%0.20s-%0.20s-%0.20s", name, namespace, httprouteName, vpcid)
+func TargetGroupLongName(k8sname string, routename string, vpcid string) string {
+	return fmt.Sprintf("k8s-%0.40s-%0.20s-%0.20s", k8sname, routename, vpcid)
 }
 
 // TODO , find out a good name

--- a/pkg/latticestore/latticestore.go
+++ b/pkg/latticestore/latticestore.go
@@ -70,6 +70,7 @@ type ListenerPool map[ListenerKey]*Listener
 
 type TargetGroupKey struct {
 	Name            string
+	RouteName       string
 	IsServiceImport bool
 }
 
@@ -290,9 +291,13 @@ func (ds *LatticeDataStore) GetLatticeService(name string, namespace string) (La
 
 }
 
-// the max tg name length is 63
+// the max tg name length is 127
 func TargetGroupName(name string, namespace string) string {
 	return fmt.Sprintf("k8s-%0.20s-%0.20s", name, namespace)
+}
+
+func TargetGroupLongName(name string, namespace string, httprouteName string, vpcid string) string {
+	return fmt.Sprintf("k8s-%0.20s-%0.20s-%0.20s-%0.20s", name, namespace, httprouteName, vpcid)
 }
 
 // TODO , find out a good name
@@ -303,7 +308,7 @@ func AWSServiceName(name string, namespace string) string {
 }
 
 func (ds *LatticeDataStore) AddTargetGroup(name string, vpc string, arn string, tgID string,
-	isServiceImport bool) error {
+	isServiceImport bool, routeName string) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
@@ -312,6 +317,7 @@ func (ds *LatticeDataStore) AddTargetGroup(name string, vpc string, arn string, 
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
+		RouteName:       routeName,
 		IsServiceImport: isServiceImport,
 	}
 
@@ -365,12 +371,13 @@ func (ds *LatticeDataStore) SetTargetGroupByServiceExport(name string, isService
 
 }
 
-func (ds *LatticeDataStore) SetTargetGroupByBackendRef(name string, isServiceImport bool, byBackendRef bool) error {
+func (ds *LatticeDataStore) SetTargetGroupByBackendRef(name string, routeName string, isServiceImport bool, byBackendRef bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
+		RouteName:       routeName,
 		IsServiceImport: isServiceImport,
 	}
 
@@ -385,7 +392,7 @@ func (ds *LatticeDataStore) SetTargetGroupByBackendRef(name string, isServiceImp
 
 }
 
-func (ds *LatticeDataStore) DelTargetGroup(name string, isServiceImport bool) error {
+func (ds *LatticeDataStore) DelTargetGroup(name string, routename string, isServiceImport bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
@@ -394,6 +401,7 @@ func (ds *LatticeDataStore) DelTargetGroup(name string, isServiceImport bool) er
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
+		RouteName:       routename,
 		IsServiceImport: isServiceImport,
 	}
 
@@ -410,12 +418,13 @@ func (ds *LatticeDataStore) DelTargetGroup(name string, isServiceImport bool) er
 
 }
 
-func (ds *LatticeDataStore) GetTargetGroup(name string, isServiceImport bool) (TargetGroup, error) {
+func (ds *LatticeDataStore) GetTargetGroup(name string, routename string, isServiceImport bool) (TargetGroup, error) {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
+		RouteName:       routename,
 		IsServiceImport: isServiceImport,
 	}
 
@@ -433,12 +442,26 @@ func (ds *LatticeDataStore) GetTargetGroup(name string, isServiceImport bool) (T
 
 }
 
-func (ds *LatticeDataStore) UpdateTargetsForTargetGroup(name string, targetList []Target) error {
+func (ds *LatticeDataStore) GetTargetGroupsByTG(name string) []TargetGroup {
+	tgs := make([]TargetGroup, 0)
+
+	for _, tg := range ds.targetGroups {
+		if tg.TargetGroupKey.Name == name && !tg.TargetGroupKey.IsServiceImport {
+			tgs = append(tgs, *tg)
+
+		}
+	}
+
+	return tgs
+}
+
+func (ds *LatticeDataStore) UpdateTargetsForTargetGroup(name string, routename string, targetList []Target) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
+		RouteName:       routename,
 		IsServiceImport: false, // only update target list in the local cluster
 	}
 

--- a/pkg/latticestore/latticestore.go
+++ b/pkg/latticestore/latticestore.go
@@ -296,8 +296,8 @@ func TargetGroupName(name string, namespace string) string {
 	return fmt.Sprintf("k8s-%0.20s-%0.20s", name, namespace)
 }
 
-func TargetGroupLongName(k8sname string, routename string, vpcid string) string {
-	return fmt.Sprintf("k8s-%0.40s-%0.20s-%0.20s", k8sname, routename, vpcid)
+func TargetGroupLongName(k8sName string, routeName string, vpcid string) string {
+	return fmt.Sprintf("k8s-%0.40s-%0.20s-%0.20s", k8sName, routeName, vpcid)
 }
 
 // TODO , find out a good name
@@ -392,7 +392,7 @@ func (ds *LatticeDataStore) SetTargetGroupByBackendRef(name string, routeName st
 
 }
 
-func (ds *LatticeDataStore) DelTargetGroup(name string, routename string, isServiceImport bool) error {
+func (ds *LatticeDataStore) DelTargetGroup(name string, routeName string, isServiceImport bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
@@ -401,7 +401,7 @@ func (ds *LatticeDataStore) DelTargetGroup(name string, routename string, isServ
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
-		RouteName:       routename,
+		RouteName:       routeName,
 		IsServiceImport: isServiceImport,
 	}
 
@@ -418,13 +418,13 @@ func (ds *LatticeDataStore) DelTargetGroup(name string, routename string, isServ
 
 }
 
-func (ds *LatticeDataStore) GetTargetGroup(name string, routename string, isServiceImport bool) (TargetGroup, error) {
+func (ds *LatticeDataStore) GetTargetGroup(name string, routeName string, isServiceImport bool) (TargetGroup, error) {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
-		RouteName:       routename,
+		RouteName:       routeName,
 		IsServiceImport: isServiceImport,
 	}
 
@@ -455,13 +455,13 @@ func (ds *LatticeDataStore) GetTargetGroupsByTG(name string) []TargetGroup {
 	return tgs
 }
 
-func (ds *LatticeDataStore) UpdateTargetsForTargetGroup(name string, routename string, targetList []Target) error {
+func (ds *LatticeDataStore) UpdateTargetsForTargetGroup(name string, routeName string, targetList []Target) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
 
 	targetGroupKey := TargetGroupKey{
 		Name:            name,
-		RouteName:       routename,
+		RouteName:       routeName,
 		IsServiceImport: false, // only update target list in the local cluster
 	}
 

--- a/pkg/latticestore/latticestore_test.go
+++ b/pkg/latticestore/latticestore_test.go
@@ -179,11 +179,11 @@ func Test_TargetGroup(t *testing.T) {
 	//byBackendRef := true
 	//byServiceExport := false
 	K8SService := false
-	routename := "httproute"
+	routeName := "httproute"
 
 	// GetTargetGroup on an unknown TG
 	tgName := TargetGroupName(name, namespace)
-	_, err := inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
+	_, err := inputDataStore.GetTargetGroup(tgName, routeName, serviceImport)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// Happy Path for a serviceImport
@@ -229,7 +229,7 @@ func Test_TargetGroup(t *testing.T) {
 
 	// add 2nd TG
 	tgName1 := TargetGroupName(name1, namespace1)
-	err = inputDataStore.AddTargetGroup(tgName1, vpc, arn, tgID, K8SService, routename)
+	err = inputDataStore.AddTargetGroup(tgName1, vpc, arn, tgID, K8SService, routeName)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
@@ -242,11 +242,11 @@ func Test_TargetGroup(t *testing.T) {
 	targets = append(targets, Target{TargetIP: "2.2.2.2", TargetPort: 20})
 	unknownTGName := TargetGroupName(unknowntg, namespace)
 	// Update an unknown TG
-	err = inputDataStore.UpdateTargetsForTargetGroup(unknownTGName, routename, targets)
+	err = inputDataStore.UpdateTargetsForTargetGroup(unknownTGName, routeName, targets)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// update with the correct name
-	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, routename, targets)
+	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, routeName, targets)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
@@ -254,21 +254,21 @@ func Test_TargetGroup(t *testing.T) {
 
 	// Update targets
 	targets = append(targets, Target{TargetIP: "3.3.3.3", TargetPort: 30})
-	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, routename, targets)
+	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, routeName, targets)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
 	fmt.Printf("store:%v \n", store)
 
 	// delete 2nd TG
-	err = inputDataStore.DelTargetGroup(tgName1, routename, K8SService)
+	err = inputDataStore.DelTargetGroup(tgName1, routeName, K8SService)
 	assert.Nil(t, err)
 
-	_, err = inputDataStore.GetTargetGroup(tgName1, routename, K8SService)
+	_, err = inputDataStore.GetTargetGroup(tgName1, routeName, K8SService)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// delete twice
-	err = inputDataStore.DelTargetGroup(tgName1, routename, K8SService)
+	err = inputDataStore.DelTargetGroup(tgName1, routeName, K8SService)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 }

--- a/pkg/latticestore/latticestore_test.go
+++ b/pkg/latticestore/latticestore_test.go
@@ -187,7 +187,7 @@ func Test_TargetGroup(t *testing.T) {
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// Happy Path for a serviceImport
-	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport, routename)
+	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport, "")
 	assert.Nil(t, err)
 
 	store := dumpCurrentLatticeDataStore(inputDataStore)
@@ -196,7 +196,7 @@ func Test_TargetGroup(t *testing.T) {
 	assert.Equal(t, 1, len(store.TargetGroups), "")
 
 	// Verify GetTargetGroup return TG just added
-	tg, err := inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
+	tg, err := inputDataStore.GetTargetGroup(tgName, "", serviceImport)
 	assert.Nil(t, err)
 	assert.Equal(t, vpc, tg.VpcID)
 	assert.Equal(t, arn, tg.ARN)
@@ -205,22 +205,22 @@ func Test_TargetGroup(t *testing.T) {
 	assert.Equal(t, false, tg.ByBackendRef)
 	assert.Equal(t, false, tg.ByServiceExport)
 
-	inputDataStore.SetTargetGroupByBackendRef(tgName, routename, serviceImport, true)
-	tg, err = inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
+	inputDataStore.SetTargetGroupByBackendRef(tgName, "", serviceImport, true)
+	tg, err = inputDataStore.GetTargetGroup(tgName, "", serviceImport)
 	assert.Nil(t, err)
 	assert.Equal(t, true, tg.ByBackendRef)
 
 	inputDataStore.SetTargetGroupByServiceExport(tgName, serviceImport, true)
-	tg, err = inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
+	tg, err = inputDataStore.GetTargetGroup(tgName, "", serviceImport)
 	assert.Nil(t, err)
 	assert.Equal(t, true, tg.ByServiceExport)
 
 	// Verify GetTargetGroup will fail if it is K8SService
-	_, err = inputDataStore.GetTargetGroup(tgName, routename, K8SService)
+	_, err = inputDataStore.GetTargetGroup(tgName, "", K8SService)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// Add same TG again, no impact
-	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport, routename)
+	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport, "")
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)

--- a/pkg/latticestore/latticestore_test.go
+++ b/pkg/latticestore/latticestore_test.go
@@ -179,14 +179,15 @@ func Test_TargetGroup(t *testing.T) {
 	//byBackendRef := true
 	//byServiceExport := false
 	K8SService := false
+	routename := "httproute"
 
 	// GetTargetGroup on an unknown TG
 	tgName := TargetGroupName(name, namespace)
-	_, err := inputDataStore.GetTargetGroup(tgName, serviceImport)
+	_, err := inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// Happy Path for a serviceImport
-	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport)
+	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport, routename)
 	assert.Nil(t, err)
 
 	store := dumpCurrentLatticeDataStore(inputDataStore)
@@ -195,7 +196,7 @@ func Test_TargetGroup(t *testing.T) {
 	assert.Equal(t, 1, len(store.TargetGroups), "")
 
 	// Verify GetTargetGroup return TG just added
-	tg, err := inputDataStore.GetTargetGroup(tgName, serviceImport)
+	tg, err := inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
 	assert.Nil(t, err)
 	assert.Equal(t, vpc, tg.VpcID)
 	assert.Equal(t, arn, tg.ARN)
@@ -204,22 +205,22 @@ func Test_TargetGroup(t *testing.T) {
 	assert.Equal(t, false, tg.ByBackendRef)
 	assert.Equal(t, false, tg.ByServiceExport)
 
-	inputDataStore.SetTargetGroupByBackendRef(tgName, serviceImport, true)
-	tg, err = inputDataStore.GetTargetGroup(tgName, serviceImport)
+	inputDataStore.SetTargetGroupByBackendRef(tgName, routename, serviceImport, true)
+	tg, err = inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
 	assert.Nil(t, err)
 	assert.Equal(t, true, tg.ByBackendRef)
 
 	inputDataStore.SetTargetGroupByServiceExport(tgName, serviceImport, true)
-	tg, err = inputDataStore.GetTargetGroup(tgName, serviceImport)
+	tg, err = inputDataStore.GetTargetGroup(tgName, routename, serviceImport)
 	assert.Nil(t, err)
 	assert.Equal(t, true, tg.ByServiceExport)
 
 	// Verify GetTargetGroup will fail if it is K8SService
-	_, err = inputDataStore.GetTargetGroup(tgName, K8SService)
+	_, err = inputDataStore.GetTargetGroup(tgName, routename, K8SService)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// Add same TG again, no impact
-	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport)
+	err = inputDataStore.AddTargetGroup(tgName, vpc, arn, tgID, serviceImport, routename)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
@@ -228,7 +229,7 @@ func Test_TargetGroup(t *testing.T) {
 
 	// add 2nd TG
 	tgName1 := TargetGroupName(name1, namespace1)
-	err = inputDataStore.AddTargetGroup(tgName1, vpc, arn, tgID, K8SService)
+	err = inputDataStore.AddTargetGroup(tgName1, vpc, arn, tgID, K8SService, routename)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
@@ -241,11 +242,11 @@ func Test_TargetGroup(t *testing.T) {
 	targets = append(targets, Target{TargetIP: "2.2.2.2", TargetPort: 20})
 	unknownTGName := TargetGroupName(unknowntg, namespace)
 	// Update an unknown TG
-	err = inputDataStore.UpdateTargetsForTargetGroup(unknownTGName, targets)
+	err = inputDataStore.UpdateTargetsForTargetGroup(unknownTGName, routename, targets)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// update with the correct name
-	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, targets)
+	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, routename, targets)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
@@ -253,21 +254,21 @@ func Test_TargetGroup(t *testing.T) {
 
 	// Update targets
 	targets = append(targets, Target{TargetIP: "3.3.3.3", TargetPort: 30})
-	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, targets)
+	err = inputDataStore.UpdateTargetsForTargetGroup(tgName1, routename, targets)
 	assert.Nil(t, err)
 
 	store = dumpCurrentLatticeDataStore(inputDataStore)
 	fmt.Printf("store:%v \n", store)
 
 	// delete 2nd TG
-	err = inputDataStore.DelTargetGroup(tgName1, K8SService)
+	err = inputDataStore.DelTargetGroup(tgName1, routename, K8SService)
 	assert.Nil(t, err)
 
-	_, err = inputDataStore.GetTargetGroup(tgName1, K8SService)
+	_, err = inputDataStore.GetTargetGroup(tgName1, routename, K8SService)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 	// delete twice
-	err = inputDataStore.DelTargetGroup(tgName1, K8SService)
+	err = inputDataStore.DelTargetGroup(tgName1, routename, K8SService)
 	assert.Equal(t, errors.New(DATASTORE_TG_NOT_EXIST), err)
 
 }

--- a/pkg/model/lattice/rule.go
+++ b/pkg/model/lattice/rule.go
@@ -48,6 +48,7 @@ type RuleAction struct {
 type RuleTargetGroup struct {
 	Name            string `json:"name"`
 	Namespace       string `json:"namespace"`
+	RouteName       string `json:"routename"`
 	IsServiceImport bool   `json:"isServiceImport"`
 	Weight          int64  `json:"weight"`
 }

--- a/pkg/model/lattice/targets.go
+++ b/pkg/model/lattice/targets.go
@@ -10,8 +10,9 @@ type Targets struct {
 }
 
 type TargetsSpec struct {
-	Name          string   `json:"name"`
-	Namespace     string   `json:"namespace"`
+	Name          string `json:"name"`
+	Namespace     string `json:"namespace"`
+	RouteName     string
 	TargetGroupID string   `json:"targetgroupID"`
 	TargetIPList  []Target `json:"targetIPlist"`
 }

--- a/pkg/model/lattice/targets.go
+++ b/pkg/model/lattice/targets.go
@@ -10,9 +10,9 @@ type Targets struct {
 }
 
 type TargetsSpec struct {
-	Name          string `json:"name"`
-	Namespace     string `json:"namespace"`
-	RouteName     string
+	Name          string   `json:"name"`
+	Namespace     string   `json:"namespace"`
+	RouteName     string   `json:"routename"`
 	TargetGroupID string   `json:"targetgroupID"`
 	TargetIPList  []Target `json:"targetIPlist"`
 }

--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -14,6 +14,8 @@ func HandleReconcileError(err error) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
+	fmt.Printf("HandleReconcileError handle Error %v \n", err)
+
 	retryErr := NewRetryError()
 	if errors.As(err, &retryErr) {
 		fmt.Printf(">>>>>> Retrying Reconcile after 20 seconds ...\n")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
cleanup and feature

**Which issue does this PR fix**:
#98 
#9

**What does this PR do / Why do we need it**:
* refactor internal cache(datastore) for target group 
       **  update key for target group to  <k8s service name, k8s service namespace, HTTProute name>  
       **   for serviceexport and serviceimport,  the HTTPRoute name is null
* introduce a mode `TARGET_GROUP_NAME_LEN_MODE`
       ** if `TARGET_GROUP_NAME_LEN_MODE` == "long"
                    The target group name is k8s-(K8S-service-name)-(k8s-service-namespace)-(HTTPRoutename)-(VPCid)
       ** otherwise
                     The target group name is k8s-(k8s-service-name)-(k8s-service-namespace)


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
make presubmit. <---- ok
```

**Automation added to e2e**:
```
make e2etest <--- ok
```
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.