### PR TITLE
Add gateway api conformance test report

### DIFF
--- a/docs/conformance-test.md
+++ b/docs/conformance-test.md
@@ -1,0 +1,80 @@
+# Report on Gateway API Conformance Testing
+
+[Kubernetes Gateway API Conformance](https://gateway-api.sigs.k8s.io/concepts/conformance/?h=conformance)
+
+## Summary of Test Result
+
+| Category | Test Cases | Status | Notes |
+| - | - | - | - |
+| GatewayClass | [GatewayClassObservedGenerationBump](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gatewayclass-observed-generation-bump.go) | ok |
+| Gateway | [GatewayObservedGenerationBump](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-observed-generation-bump.go) | ok |
+| | [GatewayInvalidRouteKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-invalid-route-kind.go) | ok |
+| | [GatewayWithAttachedRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-with-attached-routes.go) | ok |
+| | | | |
+| | [GatewaySecretInvalidReferenceGrants](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-invalid-reference-grant.go) | NA | VPC Lattice supports ACM certs |
+| | [GatewaySecretMissingReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-missing-reference-grant.go) | NA | same as above
+| | [GatewaySecretReferenceGrantAllInNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go) | NA | same as above
+| | [GatewaySecretReferenceGrantSpecific](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-specific.go) | NA | same as above
+| | | | |
+| HTTPRoute | [HTTPRouteCrossNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-cross-namespace.go) | ok |
+| | [HTTPExactPathMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-exact-path-matching.go) | ok |
+| | [HTTPRouteHeaderMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-header-matching.go) | ok |
+| | [HTTPRouteSimpleSameNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-simple-same-namespace.go) | ok |
+| | [HTTPRouteListenerHostnameMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-listener-hostname-matching.go) | ok |
+| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | ok |
+| | [HTTPRouteMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching.go) | ok |
+| | [HTTPRouteObservedGenerationBump](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-observed-generation-bump.go) | ok |
+| | [HTTPRoutePathMatchOrder](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-path-match-order.go) | ok |
+| | [HTTPRouteReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-reference-grant.go) | ok |
+| | [HTTPRouteDisallowedKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-disallowed-kind.go) | ok |
+| | [HTTPRouteInvalidNonExistentBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-nonexistent.go) | ok |
+| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | ok |
+| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | ok |
+| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | ok |
+| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | ok |
+| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | ok |
+| | | | |
+| | [HTTPRouteMethodMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.go) | nok | not support in controller yet. [#123](https://github.com/aws/aws-application-networking-k8s/issues/123) |
+| | | | |
+| | [HTTPRouteHostnameIntersection](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-hostname-intersection.go) | NA | VPC lattice only support one hostname for BYOC
+| | HTTPRouteQueryParamMatching | NA | Not supported by lattice |
+| | HTTPRouteRedirectHostAndStatus | NA | same as above |
+| | HTTPRouteRedirectPath | NA | same as above |
+| | HTTPRouteRedirectPort | NA | same as above | 
+| | HTTPRouteRedirectScheme | NA | same as above |
+| | HTTPRouteRequestHeaderModifier | NA | same as above |
+| | HTTPRouteResponseHeaderModifier | NA | same as above |
+| | HTTPRouteRewriteHost | NA | same as above |
+| | HTTPRouteRewritePath | NA | same as above |
+
+## Running Gateway API Conformance
+
+### Running controller from cloud desktop
+
+```
+# create a gateway first in the cluster
+kubectl apply -f example my-hotel-gateway.yaml
+
+# run controller in following mode
+
+REGION=us-west-2 CLUSTER_LOCAL_GATEWAY=my-hotel TARGET_GROUP_NAME_LEN_MODE="long" \
+make run
+```
+
+### Run individual conformance test
+
+```
+# 
+# go test ./conformance/... --run TestConformance/<ShortName>
+
+
+ go test ./conformance/... --run TestConformance/HTTPRouteInvalidParentRefNotMatchingSectionName \
+ -args -gateway-class=amazon-vpc-lattice
+
+```
+
+
+
+
+
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
documentation

**Which issue does this PR fix**:
#9 

**What does this PR do / Why do we need it**:
This is a test report using code from  https://github.com/aws/aws-application-networking-k8s/pull/230 and latest gateway api conformance test

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.