### PR TITLE
Fix HTTPRoute status to match API standard

### DIFF
--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -295,10 +295,10 @@ func (r *HTTPRouteReconciler) updateHTTPRouteStatus(ctx context.Context, dns str
 
 	httproute.Status.RouteStatus.Parents[0].ControllerName = config.LatticeGatewayControllerName
 
-	httproute.Status.RouteStatus.Parents[0].Conditions[0].Type = "httproute"
-	httproute.Status.RouteStatus.Parents[0].Conditions[0].Status = "True"
+	httproute.Status.RouteStatus.Parents[0].Conditions[0].Type = string(gateway_api.RouteConditionAccepted)
+	httproute.Status.RouteStatus.Parents[0].Conditions[0].Status = metav1.ConditionTrue
 	httproute.Status.RouteStatus.Parents[0].Conditions[0].Message = fmt.Sprintf("DNS Name: %s", dns)
-	httproute.Status.RouteStatus.Parents[0].Conditions[0].Reason = "Reconciled"
+	httproute.Status.RouteStatus.Parents[0].Conditions[0].Reason = string(gateway_api.RouteReasonAccepted)
 
 	if httproute.Status.RouteStatus.Parents[0].Conditions[0].LastTransitionTime == eventhandlers.ZeroTransitionTime {
 		httproute.Status.RouteStatus.Parents[0].Conditions[0].LastTransitionTime = metav1.NewTime(time.Now())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

This will make httproutes to be properly recognized as "accepted", in external integrations such as ExternalDNS.

**What does this PR do / Why do we need it**:

This is required if we go ExternalDNS integration path, and will also help later as we support more addons.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
In a manual test setting on `kubectl get httproute byoc-parking -o yaml`:

```yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  annotations:
    application-networking.k8s.aws/lattice-assigned-domain-name: byoc-parking-default-04dbcef00d405a0fd.7d67968.vpc-lattice-svcs.us-west-2.on.aws
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"HTTPRoute","metadata":{"annotations":{},"name":"byoc-parking","namespace":"default"},"spec":{"hostnames":["parking.my-test.com"],"parentRefs":[{"name":"my-hotel","sectionName":"http"}],"rules":[{"backendRefs":[{"kind":"Service","name":"parking-ver2","port":8090}]}]}}
  creationTimestamp: "2023-05-09T22:16:14Z"
  finalizers:
  - httproute.k8s.aws/resources
  generation: 1
  name: byoc-parking
  namespace: default
  resourceVersion: "1847234"
  uid: 32997b22-4b5e-4195-8373-92ea8ec8b6ab
spec:
  hostnames:
  - parking.my-test.com
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: my-hotel
    sectionName: http
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: parking-ver2
      port: 8090
      weight: 1
    matches:
    - path:
        type: PathPrefix
        value: /
status:
  parents:
  - conditions:
    - lastTransitionTime: "2023-05-09T22:16:39Z"
      message: 'DNS Name: byoc-parking-default-04dbcef00d405a0fd.7d67968.vpc-lattice-svcs.us-west-2.on.aws'
      reason: Accepted
      status: "True"
      type: Accepted
    controllerName: application-networking.k8s.aws/gateway-api-controller
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: my-hotel
```

**Automation added to e2e**:

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.