### PR TITLE
bug: issue #238 produce error if parentRef sectionName is not defined…

### DIFF
--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -285,7 +285,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			},
 		},
 		{
-			name:              "no section name ",
+			name:               "no section name ",
 			gwListenerPort:     *PortNumberPtr(80),
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -31,6 +31,7 @@ func PortNumberPtr(p int) *gateway_api.PortNumber {
 
 func Test_ListenerModelBuild(t *testing.T) {
 	var httpSectionName gateway_api.SectionName = "http"
+	var missingSectionName gateway_api.SectionName = "miss"
 	var serviceKind gateway_api.Kind = "Service"
 	var serviceimportKind gateway_api.Kind = "ServiceImport"
 	var backendRef = gateway_api.BackendRef{
@@ -268,6 +269,38 @@ func Test_ListenerModelBuild(t *testing.T) {
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
+							},
+						},
+					},
+					Rules: []gateway_api.HTTPRouteRule{
+						{
+							BackendRefs: []gateway_api.HTTPBackendRef{
+								{
+									BackendRef: backendRef,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "no section name ",
+			gwListenerPort:     *PortNumberPtr(80),
+			wantErrIsNil:       false,
+			k8sGetGatewayCall:  true,
+			k8sGatewayReturnOK: true,
+			httpRoute: &gateway_api.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "default",
+				},
+				Spec: gateway_api.HTTPRouteSpec{
+					CommonRouteSpec: gateway_api.CommonRouteSpec{
+						ParentRefs: []gateway_api.ParentReference{
+							{
+								Name:        "mesh1",
+								SectionName: &missingSectionName,
 							},
 						},
 					},


### PR DESCRIPTION
… in Gateway

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#238 

**What does this PR do / Why do we need it**:
checks to see if there was no match of the http route section to that the gateway listeners section.  If there was no match, it returns an error.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
added unit test case to confirm error produced when incorrect section name is used
**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
no
**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note
Issue #238 produce error if sectionName specified in parentRefs of HTTPRoute is not defined in Gateway
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.