### PR TITLE
Fix TG creation when using named targetPorts

### DIFF
--- a/test/suites/integration/httproute_path_match_test.go
+++ b/test/suites/integration/httproute_path_match_test.go
@@ -2,17 +2,19 @@ package integration
 
 import (
 	"fmt"
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
-	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
+	"log"
+	"os"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/types"
-	"log"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
 const (
@@ -21,11 +23,11 @@ const (
 
 var _ = Describe("HTTPRoute path matches", func() {
 	It("HTTPRoute should support multiple path matches", func() {
-		gateway := testFramework.NewGateway("",k8snamespace)
+		gateway := testFramework.NewGateway("", k8snamespace)
 		deployment1, service1 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: k8snamespace})
 		deployment2, service2 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: k8snamespace})
 		pathMatchHttpRoute := testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http",
-	"", k8snamespace)
+			"", k8snamespace)
 
 		// Create Kubernetes API Objects
 		testFramework.ExpectCreated(ctx,
@@ -46,7 +48,7 @@ var _ = Describe("HTTPRoute path matches", func() {
 		Expect(*targetGroupV1.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
 		Expect(*targetGroupV1.Protocol).To(Equal("HTTP"))
 		targetsV1 := testFramework.GetTargets(ctx, targetGroupV1, deployment1)
-		Expect(*targetGroupV1.Port).To(BeEquivalentTo(service1.Spec.Ports[0].TargetPort.IntVal))
+		Expect(*targetGroupV1.Port).To(BeEquivalentTo(80))
 		for _, target := range targetsV1 {
 			Expect(*target.Port).To(BeEquivalentTo(service1.Spec.Ports[0].TargetPort.IntVal))
 			Expect(*target.Status).To(Or(
@@ -59,7 +61,7 @@ var _ = Describe("HTTPRoute path matches", func() {
 		Expect(*targetGroupV2.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
 		Expect(*targetGroupV2.Protocol).To(Equal("HTTP"))
 		targetsV2 := testFramework.GetTargets(ctx, targetGroupV2, deployment2)
-		Expect(*targetGroupV2.Port).To(BeEquivalentTo(service2.Spec.Ports[0].TargetPort.IntVal))
+		Expect(*targetGroupV2.Port).To(BeEquivalentTo(80))
 		for _, target := range targetsV2 {
 			Expect(*target.Port).To(BeEquivalentTo(service2.Spec.Ports[0].TargetPort.IntVal))
 			Expect(*target.Status).To(Or(

--- a/test/suites/integration/https_listener_weighted_rule_with_service_export_import_test.go
+++ b/test/suites/integration/https_listener_weighted_rule_with_service_export_import_test.go
@@ -2,17 +2,19 @@ package integration
 
 import (
 	"fmt"
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
-	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/samber/lo"
-	appsv1 "k8s.io/api/apps/v1"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
 var _ = Describe("Test 2 listeners gateway with weighted httproute rules and service export import", func() {
@@ -61,7 +63,7 @@ var _ = Describe("Test 2 listeners gateway with weighted httproute rules and ser
 				Expect(*retrievedTargetGroupSummary.Protocol).To(Equal("HTTP"))
 				targets := testFramework.GetTargets(ctx, retrievedTargetGroupSummary, deployments[i])
 				Expect(len(targets)).To(BeEquivalentTo(1))
-				Expect(*retrievedTargetGroupSummary.Port).To(BeEquivalentTo(service1.Spec.Ports[0].TargetPort.IntVal))
+				Expect(*retrievedTargetGroupSummary.Port).To(BeEquivalentTo(80))
 				for _, target := range targets {
 					Expect(*target.Port).To(BeEquivalentTo(service1.Spec.Ports[0].TargetPort.IntVal))
 					Expect(*target.Status).To(Or(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bugfix

**Which issue does this PR fix**:

Addresses #86. Currently named targetPorts cause error because it triggers CreateTargetGroup request with port 0. With this PR it will trigger request with port 80 instead.

**What does this PR do / Why do we need it**:

1. TargetPort actually does not matter at all. To understand this we need to understand how ports are working in Lattice TGs. Ports defined in Lattice TGs only acts as a "default port" when no port is specified in RegisterTargets API. Since we always populate port when creating targets, the port on TG does nothing. We do not need an accurate number on this field.

2. But can't we still query the endpoint and find the port name? This path seems complicated. For example, there could be multiple pods using the same port name but different port numbers. In this case picking any of the port number will be technically wrong. This way also requires an (practically unnecessary) update on targetGroup when just targets are changing.

3. Setting to port 80 matches [Lattice documentation](https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_TargetGroupConfig.html#vpclattice-Type-TargetGroupConfig-port) as well.

Overall I would treat this as a bugfix and deploy the simplest mitigation, unless we need this field in some way later.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
* `make e2etest`
* Gateway conformance tests
* manual testing to confirm service targetPort (either named or unnamed) does not matter on target registration.

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.