### PR TITLE
Fix gateway status update and add address

### DIFF
--- a/controllers/eventhandlers/service.go
+++ b/controllers/eventhandlers/service.go
@@ -2,6 +2,7 @@ package eventhandlers
 
 import (
 	"context"
+
 	"github.com/golang/glog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -152,8 +153,7 @@ func isServiceUsedByHTTPRoute(httpRoute gateway_api.HTTPRoute, ep *corev1.Servic
 				continue
 			}
 
-			namespace := "default"
-
+			namespace := httpRoute.Namespace
 			if httpBackendRef.BackendObjectReference.Namespace != nil {
 				namespace = string(*httpBackendRef.BackendObjectReference.Namespace)
 			}

--- a/controllers/eventhandlers/serviceimport.go
+++ b/controllers/eventhandlers/serviceimport.go
@@ -2,6 +2,7 @@ package eventhandlers
 
 import (
 	"context"
+
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -89,8 +90,7 @@ func isServiceImportUsedByHTTPRoute(httpRoute gateway_api.HTTPRoute, serviceImpo
 				continue
 			}
 
-			namespace := "default"
-
+			namespace := httpRoute.Namespace
 			if httpBackendRef.BackendObjectReference.Namespace != nil {
 				namespace = string(*httpBackendRef.BackendObjectReference.Namespace)
 			}

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -400,24 +400,18 @@ func UpdateGWListenerStatus(ctx context.Context, k8sclient client.Client, gw *ga
 	// Add one of lattice domains as GW address. This can represent incorrect value in some cases (e.g. cross-account)
 	// TODO: support multiple endpoint addresses across services.
 	if len(httpRouteList.Items) > 0 {
-		domain := ""
+
+		gw.Status.Addresses = []gateway_api.GatewayAddress{}
+
+		addressType := gateway_api.HostnameAddressType
 		for _, route := range httpRouteList.Items {
 			if route.DeletionTimestamp.IsZero() && len(route.Annotations) > 0 {
-				exists := false
-				if domain, exists = route.Annotations[LatticeAssignedDomainName]; exists {
-					break
+				if domain, exists := route.Annotations[LatticeAssignedDomainName]; exists {
+					gw.Status.Addresses = append(gw.Status.Addresses, gateway_api.GatewayAddress{
+						Type:  &addressType,
+						Value: domain,
+					})
 				}
-			}
-		}
-		if domain == "" {
-			gw.Status.Addresses = []gateway_api.GatewayAddress{}
-		} else {
-			addressType := gateway_api.HostnameAddressType
-			gw.Status.Addresses = []gateway_api.GatewayAddress{
-				{
-					Type:  &addressType,
-					Value: domain,
-				},
 			}
 		}
 	}

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -397,6 +397,31 @@ func UpdateGWListenerStatus(ctx context.Context, k8sclient client.Client, gw *ga
 
 	k8sclient.List(context.TODO(), httpRouteList)
 
+	// Add one of lattice domains as GW address. This can represent incorrect value in some cases (e.g. cross-account)
+	// TODO: support multiple endpoint addresses across services.
+	if len(httpRouteList.Items) > 0 {
+		domain := ""
+		for _, route := range httpRouteList.Items {
+			if route.DeletionTimestamp.IsZero() && len(route.Annotations) > 0 {
+				exists := false
+				if domain, exists = route.Annotations[LatticeAssignedDomainName]; exists {
+					break
+				}
+			}
+		}
+		if domain == "" {
+			gw.Status.Addresses = []gateway_api.GatewayAddress{}
+		} else {
+			addressType := gateway_api.HostnameAddressType
+			gw.Status.Addresses = []gateway_api.GatewayAddress{
+				{
+					Type:  &addressType,
+					Value: domain,
+				},
+			}
+		}
+	}
+
 	if len(gw.Spec.Listeners) == 0 {
 		glog.V(2).Infof("Failed to find gateway listener for gw %v ", gw)
 		return errors.New("no gateway listner found")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug/feature

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Add GatewayAddress to status, and fix some bugs related to namespace on controller.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

**Testing done on this change**:
* `make e2etest`
* GW conformance test (in the existing way)

Now when we create gateway and add HTTPRoutes successfully, the gateway will look like (for example):
```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  annotations:
    application-networking.k8s.aws/lattice-vpc-association: "true"
  creationTimestamp: "2023-06-01T17:04:36Z"
  finalizers:
  - gateway.k8s.aws/resources
  generation: 1
  labels:
    testing.kubernetes.io: "true"
  name: serva-1-wtkdoudhui
  namespace: default
  resourceVersion: "7116440"
  uid: 6e4d714e-a164-4756-b404-8f3b1e12bb04
spec:
  gatewayClassName: amazon-vpc-lattice
  listeners:
  - allowedRoutes:
      namespaces:
        from: Same
    name: http
    port: 80
    protocol: HTTP
  - allowedRoutes:
      namespaces:
        from: Same
    name: https
    port: 443
    protocol: HTTPS
status:
  addresses:
  - type: Hostname
    value: snapp-4-yaw6ondzef-default-064ba98509e399f53.7d67968.vpc-lattice-svcs.us-west-2.on.aws
  conditions:
  - lastTransitionTime: "1970-01-01T00:00:00Z"
    message: application-networking.k8s.aws/gateway-api-controller
    observedGeneration: 1
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2023-06-01T17:06:48Z"
    message: 'aws-gateway-arn: arn:aws:vpc-lattice:us-west-2:219875826667:servicenetwork/sn-0f5470582c4c121fc'
    observedGeneration: 1
    reason: Reconciled
    status: "True"
    type: Programmed
  listeners:
  - attachedRoutes: 1
    conditions:
    - lastTransitionTime: "2023-06-01T17:06:48Z"
      message: ""
      observedGeneration: 1
      reason: Accepted
      status: "True"
      type: Accepted
    name: http
    supportedKinds:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
  - attachedRoutes: 0
    conditions:
    - lastTransitionTime: "2023-06-01T17:06:48Z"
      message: ""
      observedGeneration: 1
      reason: Accepted
      status: "True"
      type: Accepted
    name: https
    supportedKinds:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
```

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.