### PR TITLE
Init Config for test framework

### DIFF
--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -71,6 +71,7 @@ func NewFramework(ctx context.Context) *Framework {
 	var scheme = scheme.Scheme
 	lo.Must0(v1beta1.Install(scheme))
 	lo.Must0(v1alpha1.Install(scheme))
+	config.ConfigInit()
 	controllerRuntimeConfig := controllerruntime.GetConfigOrDie()
 	framework := &Framework{
 		Client:                              lo.Must(client.New(controllerRuntimeConfig, client.Options{Scheme: scheme})),


### PR DESCRIPTION
As we recently changed the method to read Config file in 
https://github.com/aws/aws-application-networking-k8s/pull/264

We need to explicitly do config.ConfigInit() when create the test framework


## Test
- Did the 	fmt.Println("config.Region: ", config.Region), it could read the correct `config.Region`
- `make e2etest` all can pass
```
• [253.448 seconds]
------------------------------

Ran 3 of 3 Specs in 769.177 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (769.41s)
PASS
ok  	github.com/aws/aws-application-networking-k8s/test/suites/integration	770.031s
``` 
