### PR TITLE
Fix target group leaking issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export KUBEBUILDER_ASSETS ?= ${HOME}/.kubebuilder/bin
 export CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
 export CLUSTER_VPC_ID ?= $(shell aws eks describe-cluster --name $(CLUSTER_NAME) | jq -r ".cluster.resourcesVpcConfig.vpcId")
 export AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text)
-
+export REGION ?= $(shell aws configure get region)
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 VERSION ?= $(shell git tag --sort=committerdate | tail -1)

--- a/pkg/deploy/lattice/service_synthesizer.go
+++ b/pkg/deploy/lattice/service_synthesizer.go
@@ -29,7 +29,6 @@ func (s *serviceSynthesizer) SynthesizeCreation(ctx context.Context) error {
 	s.stack.ListResources(&resServices)
 	glog.V(6).Infof("Service-synthesize start: %v \n", resServices)
 
-	// TODO
 	for _, resService := range resServices {
 
 		glog.V(6).Infof("SynthesizeCreation Service/HTTPRoute: %v\n", resService)

--- a/pkg/deploy/lattice/service_synthesizer.go
+++ b/pkg/deploy/lattice/service_synthesizer.go
@@ -64,7 +64,8 @@ func (s *serviceSynthesizer) PostSynthesize(ctx context.Context) error {
 
 	for _, resService := range resServices {
 		if resService.Spec.IsDeleted {
-			// handle service delete
+			// In serviceSynthesizer.PostSynthesize(), we only handle the deletion request,
+			// ignore the creation request which is handled in Synthesize()
 			if err := s.serviceManager.Delete(ctx, resService); err == nil {
 				glog.V(6).Infof("service  PostSynthesize: finish deleting service %v\n", *resService)
 				s.latticeDataStore.DelLatticeService(resService.Spec.Name, resService.Spec.Namespace)

--- a/pkg/deploy/lattice/service_synthesizer.go
+++ b/pkg/deploy/lattice/service_synthesizer.go
@@ -23,7 +23,7 @@ type serviceSynthesizer struct {
 	latticeDataStore *latticestore.LatticeDataStore
 }
 
-func (s *serviceSynthesizer) Synthesize(ctx context.Context) error {
+func (s *serviceSynthesizer) SynthesizeCreation(ctx context.Context) error {
 	var resServices []*latticemodel.Service
 
 	s.stack.ListResources(&resServices)
@@ -32,9 +32,9 @@ func (s *serviceSynthesizer) Synthesize(ctx context.Context) error {
 	// TODO
 	for _, resService := range resServices {
 
-		glog.V(6).Infof("Synthesize Service/HTTPRoute: %v\n", resService)
+		glog.V(6).Infof("SynthesizeCreation Service/HTTPRoute: %v\n", resService)
 		if resService.Spec.IsDeleted {
-			// handle latticeService creation request in Synthesize() only, will handle the deletion request in PostSynthesize()
+			// handle latticeService creation request in SynthesizeCreation() only, will handle the deletion request in SynthesizeDeletion()
 			continue
 		}
 
@@ -56,18 +56,18 @@ func (s *serviceSynthesizer) Synthesize(ctx context.Context) error {
 	return nil
 }
 
-func (s *serviceSynthesizer) PostSynthesize(ctx context.Context) error {
+func (s *serviceSynthesizer) SynthesizeDeletion(ctx context.Context) error {
 	var resServices []*latticemodel.Service
 
 	s.stack.ListResources(&resServices)
-	glog.V(6).Infof("Service PostSynthesize(Deletion) start: %v \n", resServices)
+	glog.V(6).Infof("Service SynthesizeDeletion(Deletion) start: %v \n", resServices)
 
 	for _, resService := range resServices {
 		if resService.Spec.IsDeleted {
-			// In serviceSynthesizer.PostSynthesize(), we only handle the deletion request,
-			// ignore the creation request which is handled in Synthesize()
+			// In serviceSynthesizer.SynthesizeDeletion(), we only handle the deletion request,
+			// ignore the creation request which is handled in SynthesizeCreation()
 			if err := s.serviceManager.Delete(ctx, resService); err == nil {
-				glog.V(6).Infof("service  PostSynthesize: finish deleting service %v\n", *resService)
+				glog.V(6).Infof("service  SynthesizeDeletion: finish deleting service %v\n", *resService)
 				s.latticeDataStore.DelLatticeService(resService.Spec.Name, resService.Spec.Namespace)
 			} else {
 				return err

--- a/pkg/deploy/lattice/service_synthesizer_test.go
+++ b/pkg/deploy/lattice/service_synthesizer_test.go
@@ -162,8 +162,12 @@ func Test_SynthesizeService(t *testing.T) {
 		}
 
 		synthesizer := NewServiceSynthesizer(mockSvcManager, stack, ds)
-
-		err := synthesizer.Synthesize(ctx)
+		var err error
+		if tt.httpRoute.DeletionTimestamp.IsZero() {
+			err = synthesizer.Synthesize(ctx)
+		} else {
+			err = synthesizer.PostSynthesize(ctx)
+		}
 
 		if tt.wantErrIsNil {
 			assert.Nil(t, err)

--- a/pkg/deploy/lattice/service_synthesizer_test.go
+++ b/pkg/deploy/lattice/service_synthesizer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -30,8 +31,7 @@ func Test_SynthesizeService(t *testing.T) {
 		wantIsDeleted bool
 	}{
 		{
-			name: "Add LatticeService",
-
+			name: "HttpRoute Creation trigger LatticeService Creation",
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
@@ -53,7 +53,30 @@ func Test_SynthesizeService(t *testing.T) {
 			wantErrIsNil:  true,
 		},
 		{
-			name: "Delete LatticeService",
+			name: "Add LatticeService, if serviceManager return error, then Synthesize() should return error",
+
+			httpRoute: &gateway_api.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "service3",
+				},
+				Spec: gateway_api.HTTPRouteSpec{
+					CommonRouteSpec: gateway_api.CommonRouteSpec{
+						ParentRefs: []gateway_api.ParentReference{
+							{
+								Name: "gateway1",
+							},
+						},
+					},
+				},
+			},
+			serviceARN:    "arn1234",
+			serviceID:     "56789",
+			mgrErr:        errors.New("Need-to-Retry"),
+			wantIsDeleted: false,
+			wantErrIsNil:  false,
+		},
+		{
+			name: "serviceSynthesizer.Synthesize() should ignore LatticeService deletion request",
 
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -77,57 +100,10 @@ func Test_SynthesizeService(t *testing.T) {
 			wantIsDeleted: true,
 			wantErrIsNil:  true,
 		},
-		{
-			name: "Add LatticeService, return error need to retry",
-
-			httpRoute: &gateway_api.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "service3",
-				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
-							{
-								Name: "gateway1",
-							},
-						},
-					},
-				},
-			},
-			serviceARN:    "arn1234",
-			serviceID:     "56789",
-			mgrErr:        errors.New("Need-to-Retry"),
-			wantIsDeleted: false,
-			wantErrIsNil:  false,
-		},
-		{
-			name: "Delete LatticeService, but need retry",
-
-			httpRoute: &gateway_api.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "service4",
-					Finalizers:        []string{"gateway.k8s.aws/resources"},
-					DeletionTimestamp: &now,
-				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
-							{
-								Name: "gateway2",
-							},
-						},
-					},
-				},
-			},
-			serviceARN:    "arn1234",
-			serviceID:     "56789",
-			mgrErr:        errors.New("need-to-retry-delete"),
-			wantIsDeleted: true,
-			wantErrIsNil:  false,
-		},
 	}
 
 	for _, tt := range tests {
+		log.Println("test case: ", tt.name)
 		c := gomock.NewController(t)
 		defer c.Finish()
 		ctx := context.TODO()
@@ -157,17 +133,11 @@ func Test_SynthesizeService(t *testing.T) {
 
 		if tt.httpRoute.DeletionTimestamp.IsZero() {
 			mockSvcManager.EXPECT().Create(ctx, latticeService).Return(latticemodel.ServiceStatus{ServiceARN: tt.serviceARN, ServiceID: tt.serviceID}, tt.mgrErr)
-		} else {
-			mockSvcManager.EXPECT().Delete(ctx, latticeService).Return(tt.mgrErr)
 		}
 
 		synthesizer := NewServiceSynthesizer(mockSvcManager, stack, ds)
-		var err error
-		if tt.httpRoute.DeletionTimestamp.IsZero() {
-			err = synthesizer.Synthesize(ctx)
-		} else {
-			err = synthesizer.PostSynthesize(ctx)
-		}
+
+		err := synthesizer.Synthesize(ctx)
 
 		if tt.wantErrIsNil {
 			assert.Nil(t, err)
@@ -181,5 +151,155 @@ func Test_SynthesizeService(t *testing.T) {
 			assert.NotNil(t, err)
 		}
 
+	}
+}
+
+func Test_PostSynthesizeService(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name          string
+		httpRoute     *gateway_api.HTTPRoute
+		serviceARN    string
+		serviceID     string
+		mgrErr        error
+		wantErrIsNil  bool
+		wantIsDeleted bool
+	}{
+		{
+			name: "serviceSynthesizer.PostSynthesize() should ignore any LatticeService creation request",
+			httpRoute: &gateway_api.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "service1",
+				},
+				Spec: gateway_api.HTTPRouteSpec{
+					CommonRouteSpec: gateway_api.CommonRouteSpec{
+						ParentRefs: []gateway_api.ParentReference{
+							{
+								Name: "gateway1",
+							},
+						},
+					},
+				},
+			},
+			serviceARN:    "arn1234",
+			serviceID:     "56789",
+			mgrErr:        nil,
+			wantIsDeleted: false,
+			wantErrIsNil:  true,
+		},
+		{
+			name: "LatticeService deletion triggered by HttpRoute deletion, ok case",
+
+			httpRoute: &gateway_api.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "service2",
+					Finalizers:        []string{"gateway.k8s.aws/resources"},
+					DeletionTimestamp: &now,
+				},
+				Spec: gateway_api.HTTPRouteSpec{
+					CommonRouteSpec: gateway_api.CommonRouteSpec{
+						ParentRefs: []gateway_api.ParentReference{
+							{
+								Name: "gateway2",
+							},
+						},
+					},
+				},
+			},
+			serviceARN:    "arn1234",
+			serviceID:     "56789",
+			mgrErr:        nil,
+			wantIsDeleted: true,
+			wantErrIsNil:  true,
+		},
+
+		{
+			name: "LatticeService deletion return err since serviceManager returns error",
+
+			httpRoute: &gateway_api.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "service4",
+					Finalizers:        []string{"gateway.k8s.aws/resources"},
+					DeletionTimestamp: &now,
+				},
+				Spec: gateway_api.HTTPRouteSpec{
+					CommonRouteSpec: gateway_api.CommonRouteSpec{
+						ParentRefs: []gateway_api.ParentReference{
+							{
+								Name: "gateway2",
+							},
+						},
+					},
+				},
+			},
+			serviceARN:    "arn1234",
+			serviceID:     "56789",
+			mgrErr:        errors.New("need-to-retry-delete"),
+			wantIsDeleted: true,
+			wantErrIsNil:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		log.Println("test case: ", tt.name)
+		c := gomock.NewController(t)
+		defer c.Finish()
+		ctx := context.TODO()
+
+		ds := latticestore.NewLatticeDataStore()
+
+		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.httpRoute)))
+
+		mockSvcManager := NewMockServiceManager(c)
+
+		pro := "HTTP"
+		protocols := []*string{&pro}
+		spec := latticemodel.ServiceSpec{
+			Name:      tt.httpRoute.Name,
+			Namespace: tt.httpRoute.Namespace,
+			Protocols: protocols,
+		}
+
+		if tt.httpRoute.DeletionTimestamp.IsZero() {
+			spec.IsDeleted = false
+		} else {
+			spec.IsDeleted = true
+		}
+
+		latticeService := latticemodel.NewLatticeService(stack, "", spec)
+		fmt.Printf("latticeService :%v\n", latticeService)
+
+		if tt.wantIsDeleted {
+			mockSvcManager.EXPECT().Delete(ctx, latticeService).Return(tt.mgrErr)
+			ds.AddLatticeService(spec.Name, spec.Namespace, tt.serviceARN, tt.serviceID, "mytest.com")
+		}
+
+		synthesizer := NewServiceSynthesizer(mockSvcManager, stack, ds)
+		var err error
+
+		err = synthesizer.PostSynthesize(ctx)
+
+		if tt.wantErrIsNil {
+			assert.Nil(t, err)
+		} else {
+			assert.NotNil(t, err)
+		}
+
+		if tt.wantIsDeleted {
+			if tt.mgrErr == nil {
+				// serviceManager delete latticeService successfully,
+				//the entry in the dataStore should be deleted as well
+				_, err := ds.GetLatticeService(spec.Name, spec.Namespace)
+				assert.Equal(t, err, errors.New(latticestore.DATASTORE_SERVICE_NOT_EXIST))
+
+			} else {
+				//serviceManager returns error, delete failed,
+				//latticeService should still exist in the dataStore
+				serviceFromDS, err := ds.GetLatticeService(spec.Name, spec.Namespace)
+				assert.Nil(t, err)
+				assert.Equal(t, tt.serviceARN, serviceFromDS.ARN)
+				assert.Equal(t, tt.serviceID, serviceFromDS.ID)
+			}
+		}
 	}
 }

--- a/pkg/deploy/lattice/service_synthesizer_test.go
+++ b/pkg/deploy/lattice/service_synthesizer_test.go
@@ -53,7 +53,7 @@ func Test_SynthesizeService(t *testing.T) {
 			wantErrIsNil:  true,
 		},
 		{
-			name: "Add LatticeService, if serviceManager return error, then Synthesize() should return error",
+			name: "Add LatticeService, if serviceManager return error, then SynthesizeCreation() should return error",
 
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -76,7 +76,7 @@ func Test_SynthesizeService(t *testing.T) {
 			wantErrIsNil:  false,
 		},
 		{
-			name: "serviceSynthesizer.Synthesize() should ignore LatticeService deletion request",
+			name: "serviceSynthesizer.SynthesizeCreation() should ignore LatticeService deletion request",
 
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -137,7 +137,7 @@ func Test_SynthesizeService(t *testing.T) {
 
 		synthesizer := NewServiceSynthesizer(mockSvcManager, stack, ds)
 
-		err := synthesizer.Synthesize(ctx)
+		err := synthesizer.SynthesizeCreation(ctx)
 
 		if tt.wantErrIsNil {
 			assert.Nil(t, err)
@@ -166,7 +166,7 @@ func Test_PostSynthesizeService(t *testing.T) {
 		wantIsDeleted bool
 	}{
 		{
-			name: "serviceSynthesizer.PostSynthesize() should ignore any LatticeService creation request",
+			name: "serviceSynthesizer.SynthesizeDeletion() should ignore any LatticeService creation request",
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
@@ -277,7 +277,7 @@ func Test_PostSynthesizeService(t *testing.T) {
 		synthesizer := NewServiceSynthesizer(mockSvcManager, stack, ds)
 		var err error
 
-		err = synthesizer.PostSynthesize(ctx)
+		err = synthesizer.SynthesizeDeletion(ctx)
 
 		if tt.wantErrIsNil {
 			assert.Nil(t, err)

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -160,13 +160,30 @@ func (s *defaultTargetGroupManager) Delete(ctx context.Context, targetGroup *lat
 	}
 	glog.V(6).Infof("TG manager list, listReq %v\n", listTargetsInput)
 	listResp, err := vpcLatticeSess.ListTargetsAsList(ctx, &listTargetsInput)
-	glog.V(6).Infof("manager delete,  listResp %v, err: %v \n", listResp, err)
+	glog.V(6).Infof("TG manager delete,  listResp %v, err: %v \n", listResp, err)
 	if err != nil {
 		return err
 	}
 
 	var targets []*vpclattice.Target
 	for _, t := range listResp {
+		if t.Status != nil && *t.Status != vpclattice.TargetStatusUnused {
+			// When delete a target group, and it has non-notInUsed status target(e.g, healthy, unhealthy, initial status),
+			// it means this target group is still in use (referenced by latticeService's listeners and rules).
+
+			//The caller path of defaultTargetGroupManager.Delete() can be following 2 cases only:
+			// 1. delete a HttpRoute trigger the delete of target group (httproute_controller -> model_build_targetgroup -> target_group_synthesizer -> target_group_manager code path)
+			// 2. delete the serviceExport trigger the delete of target group (serviceexport_controller -> model_build_targetgroup -> target_group_synthesizer -> target_group_manager code path)
+			//In both 2 above cases, listeners and rules that related to this tg should be deleted prior to hitting the defaultTargetGroupManager.Delete().
+			//(FYI: if the serivceImport of this serviceExport still in used by a httproute, the controller will forbid delete the serviceExport)
+			//In that case, if this tg still has non-notInUsed status targets, it means the listenerRules-to-target_group disassociation still need some time to take effect.
+			//We could do a LATTICE_RETRY to wait 20 sec to make the target group (targets) status changed to Unused.
+
+			//FYI: delete k8sService request (service_controller -> model_build_targets -> targets_synthesizer -> targets_manager code path) can still deregister targets for a still-in-use target group,
+			//which could cause draining status targets. In that case, HttpRoute deletion request need to retry (5min at maximum) until the draining targets to be removed from the target group by vpc lattice backend, then the controller could delete the target group.
+
+			return errors.New(LATTICE_RETRY)
+		}
 		targets = append(targets, &vpclattice.Target{
 			Id:   t.Id,
 			Port: t.Port,

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -143,7 +143,11 @@ func Test_SynthesizeTriggeredServiceExport(t *testing.T) {
 				}
 			}
 
-			err = synthersizer.SynthesizeTriggeredTargetGroup(ctx)
+			if tg.Spec.IsDeleted {
+				err = synthersizer.SynthesizeTriggeredDeleteTargetGroups(ctx)
+			} else {
+				err = synthersizer.SynthesizeTriggeredCreateTargetGroups(ctx)
+			}
 
 			if !tt.wantErrIsNil {
 				assert.NotNil(t, err)
@@ -277,7 +281,13 @@ func Test_SynthersizeTriggeredByServiceImport(t *testing.T) {
 			}
 		}
 		synthesizer := NewTargetGroupSynthesizer(nil, nil, mockTGManager, stack, ds)
-		err := synthesizer.SynthesizeTriggeredTargetGroup(ctx)
+		var err error
+		if !tt.isDeleted {
+			err = synthesizer.SynthesizeTriggeredCreateTargetGroups(ctx)
+		} else {
+			err = synthesizer.SynthesizeTriggeredDeleteTargetGroups(ctx)
+		}
+
 		fmt.Printf("err:%v \n", err)
 
 		if tt.wantErrIsNil {
@@ -721,7 +731,12 @@ func Test_SynthesizeTriggeredService(t *testing.T) {
 		}
 
 		synthesizer := NewTargetGroupSynthesizer(nil, nil, mockTGManager, stack, ds)
-		err := synthesizer.SynthesizeTriggeredTargetGroup(ctx)
+		var err error
+		if !tt.isDeleted {
+			err = synthesizer.SynthesizeTriggeredCreateTargetGroups(ctx)
+		} else {
+			err = synthesizer.SynthesizeTriggeredDeleteTargetGroups(ctx)
+		}
 		fmt.Printf("err:%v \n", err)
 
 		if tt.wantErrIsNil {

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -290,7 +290,7 @@ func Test_SynthesizeTriggeredTargetGroupsDeletion_TriggeredByServiceImport(t *te
 	}{
 
 		{
-			name: " ignore all target group deletion triggered by service import",
+			name: "Ignore all target group deletion request triggered by httproute deletion with backendref service import",
 			svcImportList: []svcImportDef{
 				{
 					name:    "service-import31",
@@ -794,7 +794,7 @@ func Test_SynthesizeTriggeredTargetGroupsDeletion_TriggeredByK8sService(t *testi
 		wantErrIsNil bool
 	}{
 		{
-			name: "k8sService triggered target group deletion, ok case",
+			name: "httproute with backendref k8sService deletion request triggering target group deletion, ok case",
 			svcList: []svcDef{
 				{
 					name:   "service11",
@@ -813,7 +813,7 @@ func Test_SynthesizeTriggeredTargetGroupsDeletion_TriggeredByK8sService(t *testi
 			wantErrIsNil: true,
 		},
 		{
-			name: "k8sService triggered target group deletion, mgrErr",
+			name: "httproute with backendref k8sService deletion request triggering target group deletion, mgrErr",
 			svcList: []svcDef{
 				{
 					name:   "service21",

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -95,8 +95,8 @@ func NewLatticeServiceStackDeploy(cloud aws.Cloud, k8sClient client.Client, latt
 func (d *latticeServiceStackDeployer) Deploy(ctx context.Context, stack core.Stack) error {
 	synthesizers := []ResourceSynthesizer{
 		lattice.NewTargetGroupSynthesizer(d.cloud, d.k8sclient, d.targetGroupManager, stack, d.latticeDataStore),
-		lattice.NewServiceSynthesizer(d.latticeServiceManager, stack, d.latticeDataStore),
 		lattice.NewTargetsSynthesizer(d.cloud, lattice.NewTargetsManager(d.cloud, d.latticeDataStore), stack, d.latticeDataStore),
+		lattice.NewServiceSynthesizer(d.latticeServiceManager, stack, d.latticeDataStore),
 		lattice.NewListenerSynthesizer(d.listenerManager, stack, d.latticeDataStore),
 		lattice.NewRuleSynthesizer(d.ruleManager, stack, d.latticeDataStore),
 	}

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -76,13 +76,6 @@ func (t *latticeServiceModelBuildTask) buildModel(ctx context.Context) error {
 		return err
 	}
 
-	if !t.httpRoute.DeletionTimestamp.IsZero() {
-		// in case of deleting HTTPRoute, we will let reconcile logic to delete
-		// stated target group(s) at next reconcile interval
-		glog.V(2).Infof("latticeServiceModuleBuildTask: for HTTPRouteDelete, reconcile tagetgroups/targets at reconcile interval")
-		return nil
-	}
-
 	_, err = t.buildTargetGroup(ctx, t.Client)
 
 	if err != nil {

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -315,7 +315,8 @@ func (t *latticeServiceModelBuildTask) buildHTTPTargetGroupSpec(ctx context.Cont
 			glog.V(6).Infof("buildHTTPTargetGroupSpec, using service Import %v, err :%v\n", namespaceName, err)
 			if !isDeleted {
 				//Return error for creation request only.
-				//For ServiceImport deletion request, we should go ahead to build TargetGroupSpec model
+				//For ServiceImport deletion request, we should go ahead to build TargetGroupSpec model,
+				//although the targetGroupSynthesizer could skip TargetGroup deletion triggered by ServiceImport deletion
 				return latticemodel.TargetGroupSpec{}, err
 			}
 		}

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +77,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 			wantIsDeleted: false,
 		},
 		{
-			name: "Deleting ServieExport where service object does NOT exist",
+			name: "Deleting ServiceExport where service object does NOT exist",
 			svcExport: &mcs_api.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "export3",
@@ -277,9 +276,8 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 			name: "Create LatticeService where backend K8S service does NOT exist",
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "service3",
-					Finalizers:        []string{"gateway.k8s.aws/resources"},
-					DeletionTimestamp: &now,
+					Name:       "service3",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 				Spec: gateway_api.HTTPRouteSpec{
 					CommonRouteSpec: gateway_api.CommonRouteSpec{
@@ -316,9 +314,8 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 			name: "Create LatticeService where backend mcs serviceimport does NOT exist",
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "service4",
-					Finalizers:        []string{"gateway.k8s.aws/resources"},
-					DeletionTimestamp: &now,
+					Name:       "service4",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 				Spec: gateway_api.HTTPRouteSpec{
 					CommonRouteSpec: gateway_api.CommonRouteSpec{

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -138,17 +138,30 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 				}
 			}
 		}
+
+		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+		for _, tg := range retrievedTargetGroups {
+			Logger(ctx).Infof("Found TargetGroup: %v, checking it whether it's created by current EKS Cluster", tg)
+			if currentClusterVpcId != *tg.VpcIdentifier {
+				//This tg is not created by current EKS Cluster, skip it
+				continue
+			}
+			retrievedTags, err := env.LatticeClient.ListTagsForResourceWithContext(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: tg.Arn,
+			})
+			if err == nil {
+				Logger(ctx).Infof("Found Tags for tg %v tags: %v", *tg.Name, retrievedTags)
+				tagValue, ok := retrievedTags.Tags[lattice.K8SParentRefTypeKey]
+				if ok && *tagValue == lattice.K8SServiceExportType {
+					//This tg is created by k8s controller, by a ServiceExport,
+					//ServiceExport still have a known targetGroup leaking issue,
+					//so we temporarily skip to verify whether ServiceExport created TargetGroup is deleted or not
+					continue
+				}
+				Expect(*tg.Name).To(Not(ContainElements(BeKeyOf(env.TestCasesCreatedServiceNames))))
+			}
+		}
 	}).Should(Succeed())
-
-	//Currently, We have a know issue that the controller will not clear the TargetGroup when it cleans the k8s service
-	//Also, TargetGroup don't have an appropriate tag to identify whether this tg is created by current EKS Cluster or not.
-	//So, we temporarily don't check whether the TargetGroup have been cleaned.
-
-	//retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
-	//for _, tg := range retrievedTargetGroups {
-	//	Logger(ctx).Infof("Found TargetGroup: %v, checking it whether it's created by current EKS Cluster", tg)
-	//	g.Expect(*tg.Name).To(Not(ContainElements(BeKeyOf(env.TestCasesCreatedServiceNames))))
-	//}
 }
 
 func (env *Framework) CleanTestEnvironment(ctx context.Context) {

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -217,7 +217,9 @@ func (env *Framework) EventuallyExpectNotFound(ctx context.Context, objects ...c
 			Logger(ctx).Infof("Checking whether %s %s %s is not found", reflect.TypeOf(object), object.GetNamespace(), object.GetName())
 			g.Expect(errors.IsNotFound(env.Get(ctx, client.ObjectKeyFromObject(object), object))).To(BeTrue())
 		}
-	}).WithTimeout(5 * time.Minute).WithOffset(1).Should(Succeed())
+		// Wait for 6 minutes at maximum just in case the k8sService deletion triggered targets draining time
+		// and httproute deletion need to wait for that targets draining time finish then it can return
+	}).WithTimeout(6 * time.Minute).WithOffset(1).Should(Succeed())
 }
 
 func (env *Framework) EventuallyExpectNoneFound(ctx context.Context, objectList client.ObjectList) {

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -217,7 +217,7 @@ func (env *Framework) EventuallyExpectNotFound(ctx context.Context, objects ...c
 			Logger(ctx).Infof("Checking whether %s %s %s is not found", reflect.TypeOf(object), object.GetNamespace(), object.GetName())
 			g.Expect(errors.IsNotFound(env.Get(ctx, client.ObjectKeyFromObject(object), object))).To(BeTrue())
 		}
-	}).WithOffset(1).Should(Succeed())
+	}).WithTimeout(5 * time.Minute).WithOffset(1).Should(Succeed())
 }
 
 func (env *Framework) EventuallyExpectNoneFound(ctx context.Context, objectList client.ObjectList) {

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -15,9 +15,9 @@ import (
 	"time"
 )
 
-var _ = Describe("HTTPRoute header matches", func() {
+var _ = Describe("HTTPRoute header matches", Focus, func() {
 	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
-		gateway := testFramework.NewGateway("","")
+		gateway := testFramework.NewGateway("", "")
 
 		deployment3, service3 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3"})
 		headerMatchHttpRoute := testFramework.NewHeaderMatchHttpRoute(gateway, []*v1.Service{service3})

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-var _ = Describe("HTTPRoute header matches", Focus, func() {
+var _ = Describe("HTTPRoute header matches", func() {
 	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
 		gateway := testFramework.NewGateway("", "")
 

--- a/test/suites/integration/httproute_mutation_do_not_leak_target_group_test.go
+++ b/test/suites/integration/httproute_mutation_do_not_leak_target_group_test.go
@@ -1,0 +1,139 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"time"
+)
+
+var _ = Describe("HTTPRoute Mutation", func() {
+	var (
+		gateway            *v1beta1.Gateway   = nil
+		pathMatchHttpRoute *v1beta1.HTTPRoute = nil
+		deployment1        *appsv1.Deployment = nil
+		service1           *corev1.Service    = nil
+		deployment2        *appsv1.Deployment = nil
+		service2           *corev1.Service    = nil
+		deployment3        *appsv1.Deployment = nil
+		service3           *corev1.Service    = nil
+	)
+
+	It("Create a HTTPRoute that backendref to service1 and service2 first, tg1 and tg2 should be created, tg3 should not be created. "+
+		"Then, update the HTTPRoute to backendref to service1 and service3, tg1 should still exist, tg2 should be deleted, tg3 should be created", func() {
+		gateway = testFramework.NewGateway("", "default")
+		deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: "default"})
+		deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: "default"})
+		deployment3, service3 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3", Namespace: "default"})
+
+		pathMatchHttpRoute = testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http",
+			"", "default")
+
+		// Create Kubernetes Resources
+		testFramework.ExpectCreated(ctx,
+			gateway,
+			pathMatchHttpRoute,
+			service1,
+			deployment1,
+			service2,
+			deployment2,
+			service3,
+			deployment3,
+		)
+
+		fmt.Println("service1.Name: ", service1.Name)
+		fmt.Println("service2.Name: ", service2.Name)
+		fmt.Println("service3.Name: ", service3.Name)
+		time.Sleep(30 * time.Second)
+
+		Eventually(func(g Gomega) {
+			service1TgFound := false
+			service2TgFound := false
+			service3TgFound := false
+
+			targetGroups, err := testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			g.Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				fmt.Println("targetGroup.Name: ", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service3.Name, service3.Namespace) {
+					service3TgFound = true
+				}
+			}
+			g.Expect(service1TgFound).To(BeTrue())
+			g.Expect(service2TgFound).To(BeTrue())
+			g.Expect(service3TgFound).To(BeFalse())
+		}).Should(Succeed())
+
+		testFramework.Get(ctx, types.NamespacedName{Name: pathMatchHttpRoute.Name, Namespace: pathMatchHttpRoute.Namespace}, pathMatchHttpRoute)
+
+		fmt.Println("Will update the pathMatchHttpRoute to backendRefs to service1 and service3")
+		pathMatchHttpRoute.Spec.Rules[1].BackendRefs[0].BackendObjectReference.Name = v1beta1.ObjectName(service3.Name)
+		testFramework.Update(ctx, pathMatchHttpRoute)
+		time.Sleep(30 * time.Second)
+
+		// Verify the targetGroup that corresponds to the service2 is deleted
+		// And the targetGroup that corresponds to the service3 is created
+		Eventually(func(g Gomega) {
+			service1TgFound := false
+			service2TgFound := false
+			service3TgFound := false
+			targetGroups, err := testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			fmt.Println("Retrieved targetGroups len: ", len(targetGroups))
+			g.Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				fmt.Println("targetGroup.Name: ", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service3.Name, service3.Namespace) {
+					service3TgFound = true
+				}
+			}
+			g.Expect(service1TgFound).To(BeTrue())
+			g.Expect(service2TgFound).To(BeFalse())
+			g.Expect(service3TgFound).To(BeTrue())
+		}).Should(Succeed())
+
+	})
+
+	AfterEach(func() {
+		testFramework.ExpectDeleted(ctx,
+			gateway,
+			pathMatchHttpRoute,
+			deployment1,
+			service1,
+			deployment2,
+			service2,
+			deployment3,
+			service3)
+		testFramework.EventuallyExpectNotFound(ctx,
+			gateway,
+			pathMatchHttpRoute,
+			deployment1,
+			service1,
+			deployment2,
+			service2,
+			deployment3,
+			service3)
+	})
+})


### PR DESCRIPTION
Trying to solve this Target Groups Leaked  issue: https://github.com/aws/aws-application-networking-k8s/issues/119


## Changes:

- Changed model_build_targetgroup and model_build_service, make sure target group deletion request `model` triggered by httproute deletion could pass to target_group_synthesizer


- Changed lattice resource creation and deletion order. move delete latticeSerivce and delete Targetgroup logic in the in the corresponding PostSynthesize()
    - __New LatticeResource creation order when receive httproute creation request:__ TargetGroup -> Targets -> LatticeService -> Listener -> Rule
   
    - __New LatticeResource deletion order when receive httproute deletion request:__ LatticeService (vpc lattice backend will asynchronous delete its listeners and rules ) ->  TargetGroup(target_group_manager.go layer would check and deregister targets for this target group)
    
- Split the SynthesizeTriggeredTargetGroup into two functions: SynthesizeTriggeredTargetGroupCreation (invoked in Synthesize() ) , SynthesizeTriggeredTargetGroupDeletion (invoked in PostSynthesize() )
-  Add target group clean up verification logic in the e2etest framework ToBeClean()
- Add a new HttpRoute mutation e2etest case
-  Add some code comments either related to my code change or general comments to improve readability

---

## Test:
- `make e2etest` pass, all 4 tests could pass. Full log : https://gist.github.com/zijun726911/abcf41ba1aa1fdadab364128db2e2796

- gateway related all previsous passed conformance test could pass
-  Per #119 , do `kubectl apply -f myapp.yaml` and then do  the `kubectl delete -f myapp.yaml`, all lattice resource could be deleted, no any lattice resource leaking, where myappl.yaml contains:
     - Gateway
     - HTTPRoute
     - Service
     - Deployment
- do `kubectl apply -f myapp.yaml`  and then do the `kubectl delete httproute myhttproute`, all lattice resource could be deleted, no any lattice resource leaking


---


## New LatticeResource creation and deletion order from the `latticeServiceStackDeployer` perspective


From the `latticeServiceStackDeployer` perspective, when receive a httproute creation request, the LatticeResource creation order is :

1. TargetGroupSynthesizer.Synthesize()  (handle tg creation request, create tg )
2. TargetsSynthesizer.Synthesize()  (handle targets 'reconcile' request, (reconcile means invoke vpc lattice apis to create or delete Targets to make it change to the _desigired_ num of targets ) )
3. ServiceSynthesizer.Synthesize()  (handle service creation request, create latticeService)
4.  ListenerSynthesizer.Synthesize()  (handle listener creation request, create listener )
5.  RuleSynthesizer.Synthesize()  (handle rules creation request, create rules )
6. ServiceSynthesizer.PostSynthesize() (skip service creation request)
7. TargetGroupSynthesizer.PostSynthesize()  (skip tg cretion request )



From the `latticeServiceStackDeployer` perspective, when receive a httproute deletion request,  the LatticeResource deletion order is :

1. TargetGroupSynthesizer.Synthesize()  (skip tg deletion request)
2. TargetsSynthesizer.Synthesize()  ([do nothing, as  model_build_lattice_service layer didn't build targets model](https://github.com/aws/aws-application-networking-k8s/blob/1af736bd18b6f8ea7eea6602ecd5f1c60377c2ed/pkg/gateway/model_build_lattice_service.go#L88))
3. ServiceSynthesizer.Synthesize()  (skip service deletion request)
4.  ListenerSynthesizer.Synthesize()  ([do nothing as  model_build_lattice_service layer didn't build listener model ](https://github.com/aws/aws-application-networking-k8s/blob/1af736bd18b6f8ea7eea6602ecd5f1c60377c2ed/pkg/gateway/model_build_lattice_service.go#L88))
5.  RuleSynthesizer.Synthesize()  ([do nothing as  model_build_lattice_service layer didn't build rule model](https://github.com/aws/aws-application-networking-k8s/blob/1af736bd18b6f8ea7eea6602ecd5f1c60377c2ed/pkg/gateway/model_build_lattice_service.go#L88))
6. ServiceSynthesizer.PostSynthesize() (__handle LatticeService deletion request, delete the LatticeService, and then, the VPC Lattice backend it will asynchronous delete the listener and rules and disassociate service-targetgroup relation__)
7. TargetGroupSynthesizer.PostSynthesize()  (__handle tg deletion request, check if the tg have still unused status targets, if yes, deregister them, if the tg have still have other status targets, return a retry, if all targets clear, delete the targetgroup__)
