### PR TITLE
Added e2e tests for target deregistration upon Service or Deployment …

### DIFF
--- a/test/suites/integration/deregister_targets_test.go
+++ b/test/suites/integration/deregister_targets_test.go
@@ -1,0 +1,96 @@
+package integration
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"log"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"time"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+)
+
+var _ = Describe("Deregister Targets", func() {
+	var (
+		gateway            *v1beta1.Gateway
+		deployment         *appsv1.Deployment
+		service            *v1.Service
+		pathMatchHttpRoute *v1beta1.HTTPRoute
+		vpcLatticeService  *vpclattice.ServiceSummary
+		targetGroup        *vpclattice.TargetGroupSummary
+	)
+
+	BeforeEach(func() {
+		gateway = testFramework.NewGateway("", k8snamespace)
+		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:      "target-deregistration-test",
+			Namespace: k8snamespace,
+		})
+		pathMatchHttpRoute = testFramework.NewPathMatchHttpRoute(
+			gateway, []client.Object{service}, "http", "", k8snamespace)
+		testFramework.ExpectCreated(
+			ctx,
+			gateway,
+			pathMatchHttpRoute,
+			service,
+			deployment,
+		)
+		time.Sleep(3 * time.Minute) // Wait for creation of VPCLattice resources
+
+		// Verify VPC Lattice Service exists
+		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, pathMatchHttpRoute)
+		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(
+			latticestore.AWSServiceName(pathMatchHttpRoute.Name, pathMatchHttpRoute.Namespace)))
+
+		// Verify VPC Lattice Target Group exists
+		targetGroup = testFramework.GetTargetGroup(ctx, service)
+		Expect(*targetGroup.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
+		Expect(*targetGroup.Protocol).To(Equal("HTTP"))
+
+		// Verify VPC Lattice Targets exist
+		targets := testFramework.GetTargets(ctx, targetGroup, deployment)
+		Expect(*targetGroup.Port).To(BeEquivalentTo(80))
+		for _, target := range targets {
+			Expect(*target.Port).To(BeEquivalentTo(service.Spec.Ports[0].TargetPort.IntVal))
+			Expect(*target.Status).To(Or(
+				Equal(vpclattice.TargetStatusInitial),
+				Equal(vpclattice.TargetStatusHealthy),
+			))
+		}
+	})
+
+	AfterEach(func() {
+		testFramework.CleanTestEnvironment(ctx)
+		testFramework.EventuallyExpectNotFound(
+			ctx,
+			gateway,
+			pathMatchHttpRoute,
+			service,
+			deployment,
+		)
+	})
+
+	It("Kubernetes Service deletion deregisters targets", func() {
+		testFramework.ExpectDeleted(ctx, service)
+		Eventually(func(g Gomega) {
+			log.Println("Verifying VPC lattice Targets deregistered")
+			targets := testFramework.GetTargets(ctx, targetGroup, deployment)
+			Expect(len(targets) == 0)
+		}).WithTimeout(5*time.Minute + 10*time.Second)
+	})
+
+	It("Kubernetes Deployment deletion deregisters targets", func() {
+		testFramework.ExpectDeleted(ctx, deployment)
+		Eventually(func(g Gomega) {
+			log.Println("Verifying VPC lattice Targets deregistered")
+			targets := testFramework.GetTargets(ctx, targetGroup, deployment)
+			Expect(len(targets) == 0)
+		}).WithTimeout(5*time.Minute + 10*time.Second)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Added missing tests
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/aws/aws-application-networking-k8s/issues/257

**What does this PR do / Why do we need it**:
Adds e2e tests for Kubernetes Service and Deployment deletion to verify that VPC Lattice Targets corresponding to the Service and Deployment are deregistered from their Target Group.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
N/A

**Testing done on this change**:
Ran all e2e tests to verify the new ones work and previous ones are unaffected.
```
• [260.678 seconds]
------------------------------

Ran 5 of 5 Specs in 1742.740 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (1743.65s)
PASS
```

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No. Yes.

**Does this PR introduce any user-facing change?**:
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.