### PR TITLE
Update resource naming and conformance

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -449,7 +449,6 @@ func UpdateGWListenerStatus(ctx context.Context, k8sclient client.Client, gw *ga
 		} else {
 
 			hasValidListener = true
-			attachedRoutes := 0
 
 			condition := metav1.Condition{
 				Type:               "Accepted",
@@ -474,7 +473,6 @@ func UpdateGWListenerStatus(ctx context.Context, k8sclient client.Client, gw *ga
 						*parentRef.Namespace != gateway_api.Namespace(gw.Namespace) {
 						continue
 					}
-					attachedRoutes++
 
 					var httpSectionName string
 					if parentRef.SectionName == nil {
@@ -487,8 +485,10 @@ func UpdateGWListenerStatus(ctx context.Context, k8sclient client.Client, gw *ga
 					if httpSectionName != string(listener.Name) {
 						continue
 					}
+					if parentRef.Port != nil && *parentRef.Port != listener.Port {
+						continue
+					}
 					listenerStatus.AttachedRoutes++
-					attachedRoutes++
 
 				}
 			}

--- a/docs/conformance-test.md
+++ b/docs/conformance-test.md
@@ -18,23 +18,23 @@
 | | | | |
 | HTTPRoute | [HTTPRouteCrossNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-cross-namespace.go) | ok |
 | | [HTTPExactPathMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-exact-path-matching.go) | ok |
-| | [HTTPRouteHeaderMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-header-matching.go) | ok |
+| | [HTTPRouteHeaderMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-header-matching.go) | fail | Test data exceeds Lattice limit |
 | | [HTTPRouteSimpleSameNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-simple-same-namespace.go) | ok |
-| | [HTTPRouteListenerHostnameMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-listener-hostname-matching.go) | ok |
-| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | ok |
-| | [HTTPRouteMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching.go) | ok |
+| | [HTTPRouteListenerHostnameMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-listener-hostname-matching.go) | NA | Listener hostname not supported |
+| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | NA | Custom domain name conflict not supported |
+| | [HTTPRouteMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching.go) | fail | Route precedence |
 | | [HTTPRouteObservedGenerationBump](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-observed-generation-bump.go) | ok |
-| | [HTTPRoutePathMatchOrder](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-path-match-order.go) | ok |
-| | [HTTPRouteReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-reference-grant.go) | ok |
-| | [HTTPRouteDisallowedKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-disallowed-kind.go) | ok |
-| | [HTTPRouteInvalidNonExistentBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-nonexistent.go) | ok |
-| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | ok |
-| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | ok |
-| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | ok |
-| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | ok |
-| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | ok |
+| | [HTTPRoutePathMatchOrder](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-path-match-order.go) | fail | Test data exceeds Lattice limit |
+| | [HTTPRouteReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-reference-grant.go) | fail |
+| | [HTTPRouteDisallowedKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-disallowed-kind.go) | fail |
+| | [HTTPRouteInvalidNonExistentBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-nonexistent.go) | fail |
+| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | fail |
+| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | fail |
+| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | fail |
+| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | fail |
+| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | fail |
 | | | | |
-| | [HTTPRouteMethodMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.go) | nok | not support in controller yet. [#123](https://github.com/aws/aws-application-networking-k8s/issues/123) |
+| | [HTTPRouteMethodMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.go) | fail | not support in controller yet. [#123](https://github.com/aws/aws-application-networking-k8s/issues/123) |
 | | | | |
 | | [HTTPRouteHostnameIntersection](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-hostname-intersection.go) | NA | VPC lattice only support one hostname for BYOC
 | | HTTPRouteQueryParamMatching | NA | Not supported by lattice |
@@ -63,13 +63,11 @@ make run
 
 ### Run individual conformance test
 
+Conformance tests directly send traffic, so they should run inside the VPC that the cluster is operating on.
+
 ```
-# 
-# go test ./conformance/... --run TestConformance/<ShortName>
-
-
- go test ./conformance/... --run TestConformance/HTTPRouteInvalidParentRefNotMatchingSectionName \
- -args -gateway-class=amazon-vpc-lattice
+go test ./conformance/ --run "TestConformance/HTTPRouteCrossNamespace$" -v -args -gateway-class amazon-vpc-lattice \
+-supported-features Gateway,HTTPRoute,GatewayClassObservedGenerationBump
 
 ```
 

--- a/docs/conformance-test.md
+++ b/docs/conformance-test.md
@@ -12,40 +12,40 @@
 | | [GatewayWithAttachedRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-with-attached-routes.go) | ok |
 | | | | |
 | | [GatewaySecretInvalidReferenceGrants](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-invalid-reference-grant.go) | N/A | VPC Lattice supports ACM certs |
-| | [GatewaySecretMissingReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-missing-reference-grant.go) | N/A | same as above
-| | [GatewaySecretReferenceGrantAllInNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go) | N/A | same as above
-| | [GatewaySecretReferenceGrantSpecific](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-specific.go) | N/A | same as above
+| | [GatewaySecretMissingReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-missing-reference-grant.go) | N/A | VPC Lattice supports ACM certs |
+| | [GatewaySecretReferenceGrantAllInNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go) | N/A | VPC Lattice supports ACM Certs |
+| | [GatewaySecretReferenceGrantSpecific](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-specific.go) | N/A | VPC Lattice supports ACM certs |
 | | | | |
 | HTTPRoute | [HTTPRouteCrossNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-cross-namespace.go) | ok |
 | | [HTTPExactPathMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-exact-path-matching.go) | ok |
 | | [HTTPRouteHeaderMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-header-matching.go) | fail | Test data exceeds Lattice limit on # of rules |
 | | [HTTPRouteSimpleSameNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-simple-same-namespace.go) | ok |
 | | [HTTPRouteListenerHostnameMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-listener-hostname-matching.go) | N/A | Listener hostname not supported |
-| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | N/A | Custom domain name conflict not supported |
+| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | N/A | Custom domain name conflict not allowed |
 | | [HTTPRouteMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching.go) | fail | Route precedence |
 | | [HTTPRouteObservedGenerationBump](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-observed-generation-bump.go) | ok |
 | | [HTTPRoutePathMatchOrder](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-path-match-order.go) | fail | Test data exceeds Lattice limit on # of rules |
 | | [HTTPRouteReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-reference-grant.go) | N/A |
 | | [HTTPRouteDisallowedKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-disallowed-kind.go) | N/A | Only HTTPRoute is supported |
 | | [HTTPRouteInvalidNonExistentBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-nonexistent.go) | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
-| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | fail | same as above |
-| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | fail | same as above |
-| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | fail | same as above |
-| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | fail | same as above |
-| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | fail | same as above |
+| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
+| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
+| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
+| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
+| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
 | | | | |
 | | [HTTPRouteMethodMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.go) | fail | not supported in controller yet. [#123](https://github.com/aws/aws-application-networking-k8s/issues/123) |
 | | | | |
-| | [HTTPRouteHostnameIntersection](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-hostname-intersection.go) | N/A | VPC lattice only supports one custom domain
+| | [HTTPRouteHostnameIntersection](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-hostname-intersection.go) | N/A | VPC lattice only supports one custom domain |
 | | HTTPRouteQueryParamMatching | N/A | Not supported by lattice |
-| | HTTPRouteRedirectHostAndStatus | N/A | same as above |
-| | HTTPRouteRedirectPath | N/A | same as above |
-| | HTTPRouteRedirectPort | N/A | same as above | 
-| | HTTPRouteRedirectScheme | N/A | same as above |
-| | HTTPRouteRequestHeaderModifier | N/A | same as above |
-| | HTTPRouteResponseHeaderModifier | N/A | same as above |
-| | HTTPRouteRewriteHost | N/A | same as above |
-| | HTTPRouteRewritePath | N/A | same as above |
+| | HTTPRouteRedirectHostAndStatus | N/A | Not supported by lattice |
+| | HTTPRouteRedirectPath | N/A | Not supported by lattice |
+| | HTTPRouteRedirectPort | N/A | Not supported by lattice | 
+| | HTTPRouteRedirectScheme | N/A | Not supported by lattice |
+| | HTTPRouteRequestHeaderModifier | N/A | Not supported by lattice |
+| | HTTPRouteResponseHeaderModifier | N/A | Not supported by lattice |
+| | HTTPRouteRewriteHost | N/A | Not supported by lattice |
+| | HTTPRouteRewritePath | N/A | Not supported by lattice |
 
 ## Running Gateway API Conformance
 

--- a/docs/conformance-test.md
+++ b/docs/conformance-test.md
@@ -11,41 +11,41 @@
 | | [GatewayInvalidRouteKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-invalid-route-kind.go) | ok |
 | | [GatewayWithAttachedRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-with-attached-routes.go) | ok |
 | | | | |
-| | [GatewaySecretInvalidReferenceGrants](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-invalid-reference-grant.go) | NA | VPC Lattice supports ACM certs |
-| | [GatewaySecretMissingReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-missing-reference-grant.go) | NA | same as above
-| | [GatewaySecretReferenceGrantAllInNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go) | NA | same as above
-| | [GatewaySecretReferenceGrantSpecific](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-specific.go) | NA | same as above
+| | [GatewaySecretInvalidReferenceGrants](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-invalid-reference-grant.go) | N/A | VPC Lattice supports ACM certs |
+| | [GatewaySecretMissingReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-missing-reference-grant.go) | N/A | same as above
+| | [GatewaySecretReferenceGrantAllInNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-all-in-namespace.go) | N/A | same as above
+| | [GatewaySecretReferenceGrantSpecific](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/gateway-secret-reference-grant-specific.go) | N/A | same as above
 | | | | |
 | HTTPRoute | [HTTPRouteCrossNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-cross-namespace.go) | ok |
 | | [HTTPExactPathMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-exact-path-matching.go) | ok |
-| | [HTTPRouteHeaderMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-header-matching.go) | fail | Test data exceeds Lattice limit |
+| | [HTTPRouteHeaderMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-header-matching.go) | fail | Test data exceeds Lattice limit on # of rules |
 | | [HTTPRouteSimpleSameNamespace](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-simple-same-namespace.go) | ok |
-| | [HTTPRouteListenerHostnameMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-listener-hostname-matching.go) | NA | Listener hostname not supported |
-| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | NA | Custom domain name conflict not supported |
+| | [HTTPRouteListenerHostnameMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-listener-hostname-matching.go) | N/A | Listener hostname not supported |
+| | [HTTPRouteMatchingAcrossRoutes](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching-across-routes.go) | N/A | Custom domain name conflict not supported |
 | | [HTTPRouteMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-matching.go) | fail | Route precedence |
 | | [HTTPRouteObservedGenerationBump](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-observed-generation-bump.go) | ok |
-| | [HTTPRoutePathMatchOrder](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-path-match-order.go) | fail | Test data exceeds Lattice limit |
-| | [HTTPRouteReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-reference-grant.go) | fail |
-| | [HTTPRouteDisallowedKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-disallowed-kind.go) | fail |
-| | [HTTPRouteInvalidNonExistentBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-nonexistent.go) | fail |
-| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | fail |
-| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | fail |
-| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | fail |
-| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | fail |
-| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | fail |
+| | [HTTPRoutePathMatchOrder](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-path-match-order.go) | fail | Test data exceeds Lattice limit on # of rules |
+| | [HTTPRouteReferenceGrant](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-reference-grant.go) | N/A |
+| | [HTTPRouteDisallowedKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-disallowed-kind.go) | N/A | Only HTTPRoute is supported |
+| | [HTTPRouteInvalidNonExistentBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-nonexistent.go) | fail | [#277](https://github.com/aws/aws-application-networking-k8s/issues/277) |
+| | [HTTPRouteInvalidBackendRefUnknownKind](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-backendref-unknown-kind.go) | fail | same as above |
+| | [HTTPRouteInvalidCrossNamespaceBackendRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-backend-ref.go) | fail | same as above |
+| | [HTTPRouteInvalidCrossNamespaceParentRef](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go)  | fail | same as above |
+| | [HTTPRouteInvalidParentRefNotMatchingListenerPort](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go) | fail | same as above |
+| | [HTTPRouteInvalidParentRefNotMatchingSectionName](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-invalid-parentref-not-matching-section-name.go) | fail | same as above |
 | | | | |
-| | [HTTPRouteMethodMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.go) | fail | not support in controller yet. [#123](https://github.com/aws/aws-application-networking-k8s/issues/123) |
+| | [HTTPRouteMethodMatching](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-method-matching.go) | fail | not supported in controller yet. [#123](https://github.com/aws/aws-application-networking-k8s/issues/123) |
 | | | | |
-| | [HTTPRouteHostnameIntersection](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-hostname-intersection.go) | NA | VPC lattice only support one hostname for BYOC
-| | HTTPRouteQueryParamMatching | NA | Not supported by lattice |
-| | HTTPRouteRedirectHostAndStatus | NA | same as above |
-| | HTTPRouteRedirectPath | NA | same as above |
-| | HTTPRouteRedirectPort | NA | same as above | 
-| | HTTPRouteRedirectScheme | NA | same as above |
-| | HTTPRouteRequestHeaderModifier | NA | same as above |
-| | HTTPRouteResponseHeaderModifier | NA | same as above |
-| | HTTPRouteRewriteHost | NA | same as above |
-| | HTTPRouteRewritePath | NA | same as above |
+| | [HTTPRouteHostnameIntersection](https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/httproute-hostname-intersection.go) | N/A | VPC lattice only supports one custom domain
+| | HTTPRouteQueryParamMatching | N/A | Not supported by lattice |
+| | HTTPRouteRedirectHostAndStatus | N/A | same as above |
+| | HTTPRouteRedirectPath | N/A | same as above |
+| | HTTPRouteRedirectPort | N/A | same as above | 
+| | HTTPRouteRedirectScheme | N/A | same as above |
+| | HTTPRouteRequestHeaderModifier | N/A | same as above |
+| | HTTPRouteResponseHeaderModifier | N/A | same as above |
+| | HTTPRouteRewriteHost | N/A | same as above |
+| | HTTPRouteRewritePath | N/A | same as above |
 
 ## Running Gateway API Conformance
 
@@ -53,7 +53,7 @@
 
 ```
 # create a gateway first in the cluster
-kubectl apply -f example my-hotel-gateway.yaml
+kubectl apply -f examples/my-hotel-gateway.yaml
 
 # run controller in following mode
 

--- a/pkg/deploy/lattice/listener_manager.go
+++ b/pkg/deploy/lattice/listener_manager.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
 
+	"github.com/golang/glog"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 
@@ -107,7 +109,7 @@ func k8s2LatticeName(name string, namespace string) string {
 }
 
 func k8sLatticeListenerName(name string, namespace string, port int, protocol string) string {
-	listenerName := fmt.Sprintf("%s-%s-%d-%s", name, namespace, port, strings.ToLower(protocol))
+	listenerName := fmt.Sprintf("%s-%s-%d-%s", utils.Truncate(name, 20), utils.Truncate(namespace, 18), port, strings.ToLower(protocol))
 
 	return listenerName
 }

--- a/pkg/deploy/lattice/service_manager.go
+++ b/pkg/deploy/lattice/service_manager.go
@@ -3,6 +3,7 @@ package lattice
 import (
 	"context"
 	"errors"
+
 	"github.com/golang/glog"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,7 +52,7 @@ func NewServiceManager(cloud lattice_aws.Cloud, latticeDataStore *latticestore.L
 func (s *defaultServiceManager) Create(ctx context.Context, service *latticemodel.Service) (latticemodel.ServiceStatus, error) {
 
 	// check if exists
-	svcName := latticestore.AWSServiceName(service.Spec.Name, service.Spec.Namespace)
+	svcName := latticestore.LatticeServiceName(service.Spec.Name, service.Spec.Namespace)
 	serviceSummary, err := s.findServiceByName(ctx, svcName)
 	if err != nil {
 		return latticemodel.ServiceStatus{ServiceARN: "", ServiceID: ""}, err
@@ -194,7 +195,7 @@ func (s *defaultServiceManager) Delete(ctx context.Context, service *latticemode
 
 	latticeSess := s.cloud.Lattice()
 
-	svcName := latticestore.AWSServiceName(service.Spec.Name, service.Spec.Namespace)
+	svcName := latticestore.LatticeServiceName(service.Spec.Name, service.Spec.Namespace)
 	serviceSummary, err := s.findServiceByName(ctx, svcName)
 	if err != nil || serviceSummary == nil {
 		glog.V(6).Infof("defaultServiceManager: Deleting unknown service %v\n", service.Spec.Name)

--- a/pkg/deploy/lattice/service_manager_test.go
+++ b/pkg/deploy/lattice/service_manager_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/vpclattice"
+	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/service/vpclattice"
 
 	mocks_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
@@ -59,7 +61,7 @@ func Test_Create_ValidateService(t *testing.T) {
 		latticeDataStore.AddServiceNetwork(tt.meshName, config.AccountID, tt.meshArn, tt.meshId, latticestore.DATASTORE_SERVICE_NETWORK_CREATED)
 		mockCloud := mocks_aws.NewMockCloud(c)
 
-		SVCName := latticestore.AWSServiceName(tt.wantServiceName, "default")
+		SVCName := latticestore.LatticeServiceName(tt.wantServiceName, "default")
 		createServiceOutput := &vpclattice.CreateServiceOutput{
 			Arn:    &tt.wantServiceArn,
 			Id:     &tt.wantServiceId,
@@ -360,7 +362,7 @@ func Test_Create_MeshServiceAssociation(t *testing.T) {
 			},
 			Status: &latticemodel.ServiceStatus{ServiceARN: "", ServiceID: ""},
 		}
-		SVCName := latticestore.AWSServiceName(tt.wantServiceName, "default")
+		SVCName := latticestore.LatticeServiceName(tt.wantServiceName, "default")
 		tt.wantListServiceOutput = append(tt.wantListServiceOutput, &vpclattice.ServiceSummary{
 			Arn:  &tt.wantServiceArn,
 			Id:   &tt.wantServiceId,
@@ -443,7 +445,7 @@ func Test_Create_Check(t *testing.T) {
 			},
 			Status: &latticemodel.ServiceStatus{ServiceARN: "", ServiceID: ""},
 		}
-		SVCName := latticestore.AWSServiceName(tt.wantServiceName, "default")
+		SVCName := latticestore.LatticeServiceName(tt.wantServiceName, "default")
 		tt.wantListServiceOutput = append(tt.wantListServiceOutput, &vpclattice.ServiceSummary{
 			Arn:  &tt.wantServiceArn,
 			Id:   &tt.wantServiceId,
@@ -509,7 +511,7 @@ func Test_Delete_ValidateInput(t *testing.T) {
 		latticeDataStore.AddServiceNetwork(tt.meshName, config.AccountID, tt.meshArn, tt.meshId, latticestore.DATASTORE_SERVICE_NETWORK_CREATED)
 		mockCloud := mocks_aws.NewMockCloud(c)
 
-		SVCName := latticestore.AWSServiceName(tt.wantServiceName, "default")
+		SVCName := latticestore.LatticeServiceName(tt.wantServiceName, "default")
 		tt.wantListServiceOutput = append(tt.wantListServiceOutput, &vpclattice.ServiceSummary{
 			Arn:  &tt.wantServiceArn,
 			Id:   &tt.wantServiceId,
@@ -624,7 +626,7 @@ func Test_Delete_Disassociation_DeleteService(t *testing.T) {
 		latticeDataStore.AddServiceNetwork(tt.meshName, config.AccountID, tt.meshArn, tt.meshId, latticestore.DATASTORE_SERVICE_NETWORK_CREATED)
 		mockCloud := mocks_aws.NewMockCloud(c)
 
-		SVCName := latticestore.AWSServiceName(tt.wantServiceName, "default")
+		SVCName := latticestore.LatticeServiceName(tt.wantServiceName, "default")
 		tt.wantListServiceOutput = append(tt.wantListServiceOutput, &vpclattice.ServiceSummary{
 			Arn:  &tt.wantServiceArn,
 			Id:   &tt.wantServiceId,

--- a/pkg/latticestore/latticestore.go
+++ b/pkg/latticestore/latticestore.go
@@ -3,8 +3,11 @@ package latticestore
 import (
 	"errors"
 	"fmt"
-	"github.com/golang/glog"
 	"sync"
+
+	"github.com/golang/glog"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 )
 
 // ERROR CODE
@@ -293,18 +296,15 @@ func (ds *LatticeDataStore) GetLatticeService(name string, namespace string) (La
 
 // the max tg name length is 127
 func TargetGroupName(name string, namespace string) string {
-	return fmt.Sprintf("k8s-%0.20s-%0.20s", name, namespace)
+	return fmt.Sprintf("k8s-%s-%s", utils.Truncate(name, 20), utils.Truncate(namespace, 20))
 }
 
 func TargetGroupLongName(k8sName string, routeName string, vpcid string) string {
-	return fmt.Sprintf("k8s-%0.40s-%0.20s-%0.20s", k8sName, routeName, vpcid)
+	return fmt.Sprintf("%s-%s-%s", k8sName, utils.Truncate(routeName, 20), utils.Truncate(vpcid, 20))
 }
 
-// TODO , find out a good name
-// AWSserviceName,  or VSNServiceName or LatticeServiceName
-// the max name length is 40
-func AWSServiceName(name string, namespace string) string {
-	return fmt.Sprintf("%0.20s-%0.18s", name, namespace)
+func LatticeServiceName(name string, namespace string) string {
+	return fmt.Sprintf("%s-%s", utils.Truncate(name, 20), utils.Truncate(namespace, 18))
 }
 
 func (ds *LatticeDataStore) AddTargetGroup(name string, vpc string, arn string, tgID string,

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -1,9 +1,18 @@
 package utils
 
+import "strings"
+
 // TODO: should be check by API call (Mingxi)
 func ArntoId(arn string) string {
 	if len(arn) == 0 {
 		return ""
 	}
 	return arn[len(arn)-22:]
+}
+
+func Truncate(name string, length int) string {
+	if len(name) > length {
+		name = name[:length]
+	}
+	return strings.Trim(name, "-")
 }

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -2,23 +2,21 @@ package test
 
 import (
 	"context"
-	"github.com/aws/aws-application-networking-k8s/controllers"
-	"github.com/aws/aws-application-networking-k8s/pkg/config"
-	"github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	"log"
 	"os"
 	"reflect"
 	"time"
 
-	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+
+	"github.com/aws/aws-application-networking-k8s/controllers"
+	"github.com/aws/aws-application-networking-k8s/pkg/config"
+	"github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -33,6 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
 func init() {
@@ -237,7 +240,7 @@ func (env *Framework) GetVpcLatticeService(ctx context.Context, httpRoute *v1bet
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(listServicesOutput.Items).ToNot(BeEmpty())
 		for _, service := range listServicesOutput.Items {
-			if lo.FromPtr(service.Name) == latticestore.AWSServiceName(httpRoute.Name, httpRoute.Namespace) {
+			if lo.FromPtr(service.Name) == latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace) {
 				found = service
 			}
 		}

--- a/test/pkg/test/header_match_httproute.go
+++ b/test/pkg/test/header_match_httproute.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 )
 
 func (env *Framework) NewHeaderMatchHttpRoute(parentRefsGateway *v1beta1.Gateway, services []*v1.Service) *v1beta1.HTTPRoute {
@@ -50,7 +51,7 @@ func (env *Framework) NewHeaderMatchHttpRoute(parentRefsGateway *v1beta1.Gateway
 		},
 	})
 
-	env.TestCasesCreatedServiceNames[latticestore.AWSServiceName(httpRoute.Name, httpRoute.Namespace)] = true
+	env.TestCasesCreatedServiceNames[latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)] = true
 	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, httpRoute)
 	return httpRoute
 }

--- a/test/pkg/test/path_match_httproute.go
+++ b/test/pkg/test/path_match_httproute.go
@@ -1,16 +1,18 @@
 package test
 
 import (
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"strconv"
+
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-	"strconv"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 )
 
 func (env *Framework) NewPathMatchHttpRoute(parentRefsGateway *v1beta1.Gateway, backendRefObjects []client.Object,
-	gwListenerSectionName string,name string, namespace string) *v1beta1.HTTPRoute {
+	gwListenerSectionName string, name string, namespace string) *v1beta1.HTTPRoute {
 	var rules []v1beta1.HTTPRouteRule
 	var httpns *string
 	if namespace == "" {
@@ -24,9 +26,9 @@ func (env *Framework) NewPathMatchHttpRoute(parentRefsGateway *v1beta1.Gateway, 
 			BackendRefs: []v1beta1.HTTPBackendRef{{
 				BackendRef: v1beta1.BackendRef{
 					BackendObjectReference: v1beta1.BackendObjectReference{
-						Name: v1beta1.ObjectName(object.GetName()),
+						Name:      v1beta1.ObjectName(object.GetName()),
 						Namespace: (*v1beta1.Namespace)(httpns),
-						Kind: lo.ToPtr(v1beta1.Kind(object.GetObjectKind().GroupVersionKind().Kind)),
+						Kind:      lo.ToPtr(v1beta1.Kind(object.GetObjectKind().GroupVersionKind().Kind)),
 					},
 				},
 			}},
@@ -41,25 +43,24 @@ func (env *Framework) NewPathMatchHttpRoute(parentRefsGateway *v1beta1.Gateway, 
 		}
 		rules = append(rules, rule)
 	}
-	
+
 	httpRoute := New(&v1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
 			Namespace: namespace,
-
 		},
 		Spec: v1beta1.HTTPRouteSpec{
 			CommonRouteSpec: v1beta1.CommonRouteSpec{
 				ParentRefs: []v1beta1.ParentReference{{
 					Name:        v1beta1.ObjectName(parentRefsGateway.Name),
-					Namespace:(*v1beta1.Namespace)(httpns),
+					Namespace:   (*v1beta1.Namespace)(httpns),
 					SectionName: lo.ToPtr(v1beta1.SectionName(gwListenerSectionName)),
 				}},
 			},
 			Rules: rules,
 		},
 	})
-	env.TestCasesCreatedServiceNames[latticestore.AWSServiceName(httpRoute.Name, httpRoute.Namespace)] = true
+	env.TestCasesCreatedServiceNames[latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)] = true
 	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, httpRoute)
 	return httpRoute
 }

--- a/test/pkg/test/weighted_routing_httproute.go
+++ b/test/pkg/test/weighted_routing_httproute.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 )
 
 type ObjectAndWeight struct {
@@ -46,7 +47,7 @@ func (env *Framework) NewWeightedRoutingHttpRoute(parentRefsGateway *v1beta1.Gat
 			},
 		},
 	})
-	env.TestCasesCreatedServiceNames[latticestore.AWSServiceName(httpRoute.Name, httpRoute.Namespace)] = true
+	env.TestCasesCreatedServiceNames[latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)] = true
 	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, httpRoute)
 	return httpRoute
 }

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -2,22 +2,24 @@ package integration
 
 import (
 	"fmt"
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
-	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
+	"log"
+	"regexp"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"log"
-	"regexp"
-	"time"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
 var _ = Describe("HTTPRoute header matches", func() {
 	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
-		gateway := testFramework.NewGateway("","")
+		gateway := testFramework.NewGateway("", "")
 
 		deployment3, service3 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3"})
 		headerMatchHttpRoute := testFramework.NewHeaderMatchHttpRoute(gateway, []*v1.Service{service3})
@@ -30,7 +32,7 @@ var _ = Describe("HTTPRoute header matches", func() {
 
 		time.Sleep(3 * time.Minute)
 		vpcLatticeService := testFramework.GetVpcLatticeService(ctx, headerMatchHttpRoute)
-		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.AWSServiceName(headerMatchHttpRoute.Name, headerMatchHttpRoute.Namespace)))
+		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(headerMatchHttpRoute.Name, headerMatchHttpRoute.Namespace)))
 		Eventually(func(g Gomega) {
 			log.Println("Verifying VPC lattice service listeners and rules")
 			listListenerResp, err := testFramework.LatticeClient.ListListenersWithContext(ctx, &vpclattice.ListListenersInput{

--- a/test/suites/integration/httproute_path_match_test.go
+++ b/test/suites/integration/httproute_path_match_test.go
@@ -42,7 +42,7 @@ var _ = Describe("HTTPRoute path matches", func() {
 
 		// Verify VPC Lattice Resource
 		vpcLatticeService := testFramework.GetVpcLatticeService(ctx, pathMatchHttpRoute)
-		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.AWSServiceName(pathMatchHttpRoute.Name, pathMatchHttpRoute.Namespace)))
+		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(pathMatchHttpRoute.Name, pathMatchHttpRoute.Namespace)))
 
 		targetGroupV1 := testFramework.GetTargetGroup(ctx, service1)
 		Expect(*targetGroupV1.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))

--- a/test/suites/integration/https_listener_weighted_rule_with_service_export_import_test.go
+++ b/test/suites/integration/https_listener_weighted_rule_with_service_export_import_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Test 2 listeners gateway with weighted httproute rules and ser
 
 			time.Sleep(3 * time.Minute)
 			vpcLatticeService := testFramework.GetVpcLatticeService(ctx, httpRoute)
-			Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.AWSServiceName(httpRoute.Name, httpRoute.Namespace)))
+			Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
 			log.Println("Verifying Target Groups")
 			retrievedTg0 := testFramework.GetTargetGroup(ctx, service0)
 			retrievedTg1 := testFramework.GetTargetGroup(ctx, service1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

* #260 - TG and service long names are not what we intended, fixing to a correct name
* Setting route status, only support plain Accepted status, other statuses should be covered by #277 
* Do not attach route to gateway if port does not match

**What does this PR do / Why do we need it**:
Fixes multiple bugs for testing

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
```
make e2etest
```
Conformance test results also updated.

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.