### PR TITLE
Fix Httproute deletion  leaking Target Group issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export KUBEBUILDER_ASSETS ?= ${HOME}/.kubebuilder/bin
 export CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
 export CLUSTER_VPC_ID ?= $(shell aws eks describe-cluster --name $(CLUSTER_NAME) | jq -r ".cluster.resourcesVpcConfig.vpcId")
 export AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text)
-
+export REGION ?= $(shell aws configure get region)
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 VERSION ?= $(shell git tag --sort=committerdate | tail -1)

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -76,13 +76,6 @@ func (t *latticeServiceModelBuildTask) buildModel(ctx context.Context) error {
 		return err
 	}
 
-	if !t.httpRoute.DeletionTimestamp.IsZero() {
-		// in case of deleting HTTPRoute, we will let reconcile logic to delete
-		// stated target group(s) at next reconcile interval
-		glog.V(2).Infof("latticeServiceModuleBuildTask: for HTTPRouteDelete, reconcile tagetgroups/targets at reconcile interval")
-		return nil
-	}
-
 	_, err = t.buildTargetGroup(ctx, t.Client)
 
 	if err != nil {

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -132,7 +132,7 @@ func (t *targetGroupModelBuildTask) BuildTargets(ctx context.Context) error {
 	return nil
 }
 
-// Triggered from httproute/service/targetgrou
+// Triggered from httproute/service/targetgroup
 func (t *latticeServiceModelBuildTask) buildTargets(ctx context.Context) error {
 	for _, httpRule := range t.httpRoute.Spec.Rules {
 		for _, httpBackendRef := range httpRule.BackendRefs {
@@ -248,15 +248,19 @@ func (t *latticeServiceModelBuildTask) buildTargetGroup(ctx context.Context, cli
 			if *httpBackendRef.Kind == "Service" {
 				t.Datastore.AddTargetGroup(tgName, "", "", "", tgSpec.Config.IsServiceImport, t.httpRoute.Name)
 			} else {
+				// for serviceimport, the httproutename is ""
 				t.Datastore.AddTargetGroup(tgName, "", "", "", tgSpec.Config.IsServiceImport, "")
 			}
 
 			if t.httpRoute.DeletionTimestamp.IsZero() {
 				// to add
-				t.Datastore.SetTargetGroupByBackendRef(tgName, t.httpRoute.Name, false, true)
+				t.Datastore.SetTargetGroupByBackendRef(tgName, t.httpRoute.Name, tgSpec.Config.IsServiceImport, true)
 			} else {
 				// to delete
-				t.Datastore.SetTargetGroupByBackendRef(tgName, t.httpRoute.Name, false, false)
+				t.Datastore.SetTargetGroupByBackendRef(tgName, t.httpRoute.Name, tgSpec.Config.IsServiceImport, false)
+				dsTG, _ := t.Datastore.GetTargetGroup(tgName, t.httpRoute.Name, tgSpec.Config.IsServiceImport)
+				tgSpec.IsDeleted = true
+				tgSpec.LatticeID = dsTG.ID
 			}
 
 			tg := latticemodel.NewTargetGroup(t.stack, tgName, tgSpec)
@@ -271,6 +275,7 @@ func (t *latticeServiceModelBuildTask) buildTargetGroup(ctx context.Context, cli
 
 }
 
+// Now, Only k8sService and serviceImport creation deletion use this function to build TargetGroupSpec, serviceExport does not use this function to create TargetGroupSpec
 func (t *latticeServiceModelBuildTask) buildHTTPTargetGroupSpec(ctx context.Context, client client.Client, httpBackendRef *gateway_api.HTTPBackendRef) (latticemodel.TargetGroupSpec, error) {
 	var namespace string
 
@@ -286,8 +291,15 @@ func (t *latticeServiceModelBuildTask) buildHTTPTargetGroupSpec(ctx context.Cont
 	var vpc = config.VpcID
 	var ekscluster = ""
 	var isServiceImport bool
+	var isDeleted bool
 
+	if t.httpRoute.DeletionTimestamp.IsZero() {
+		isDeleted = false
+	} else {
+		isDeleted = true
+	}
 	if backendKind == "ServiceImport" {
+		isServiceImport = true
 		namespaceName := types.NamespacedName{
 			Namespace: namespace,
 			Name:      string(httpBackendRef.Name),
@@ -298,11 +310,15 @@ func (t *latticeServiceModelBuildTask) buildHTTPTargetGroupSpec(ctx context.Cont
 			glog.V(6).Infof("buildHTTPTargetGroupSpec, using service Import %v\n", namespaceName)
 			vpc = serviceImport.Annotations["multicluster.x-k8s.io/aws-vpc"]
 			ekscluster = serviceImport.Annotations["multicluster.x-k8s.io/aws-eks-cluster-name"]
-			isServiceImport = true
 
 		} else {
 			glog.V(6).Infof("buildHTTPTargetGroupSpec, using service Import %v, err :%v\n", namespaceName, err)
-			return latticemodel.TargetGroupSpec{}, err
+			if !isDeleted {
+				//Return error for creation request only.
+				//For ServiceImport deletion request, we should go ahead to build TargetGroupSpec model,
+				//although the targetGroupSynthesizer could skip TargetGroup deletion triggered by ServiceImport deletion
+				return latticemodel.TargetGroupSpec{}, err
+			}
 		}
 
 	} else {
@@ -320,19 +336,15 @@ func (t *latticeServiceModelBuildTask) buildHTTPTargetGroupSpec(ctx context.Cont
 		svc := &corev1.Service{}
 		if err := t.Client.Get(ctx, serviceNamespaceName, svc); err != nil {
 			glog.V(6).Infof("Error finding backend service %v error :%v \n", serviceNamespaceName, err)
-			return latticemodel.TargetGroupSpec{}, err
+			if !isDeleted {
+				//Return error for creation request only,
+				//For k8sService deletion request, we should go ahead to build TargetGroupSpec model
+				return latticemodel.TargetGroupSpec{}, err
+			}
 		}
 	}
 
 	tgName := latticestore.TargetGroupName(string(httpBackendRef.Name), namespace)
-
-	var isDeleted bool
-
-	if t.httpRoute.DeletionTimestamp.IsZero() {
-		isDeleted = false
-	} else {
-		isDeleted = true
-	}
 
 	return latticemodel.TargetGroupSpec{
 		Name: tgName,

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,7 +77,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 			wantIsDeleted: false,
 		},
 		{
-			name: "Deleting ServieExport where service object does NOT exist",
+			name: "Deleting ServiceExport where service object does NOT exist",
 			svcExport: &mcs_api.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "export3",
@@ -277,9 +276,8 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 			name: "Create LatticeService where backend K8S service does NOT exist",
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "service3",
-					Finalizers:        []string{"gateway.k8s.aws/resources"},
-					DeletionTimestamp: &now,
+					Name:       "service3",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 				Spec: gateway_api.HTTPRouteSpec{
 					CommonRouteSpec: gateway_api.CommonRouteSpec{
@@ -316,9 +314,8 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 			name: "Create LatticeService where backend mcs serviceimport does NOT exist",
 			httpRoute: &gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "service4",
-					Finalizers:        []string{"gateway.k8s.aws/resources"},
-					DeletionTimestamp: &now,
+					Name:       "service4",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 				Spec: gateway_api.HTTPRouteSpec{
 					CommonRouteSpec: gateway_api.CommonRouteSpec{

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("HTTPRoute header matches", func() {
 	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
-		gateway := testFramework.NewGateway("","")
+		gateway := testFramework.NewGateway("", "")
 
 		deployment3, service3 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3"})
 		headerMatchHttpRoute := testFramework.NewHeaderMatchHttpRoute(gateway, []*v1.Service{service3})

--- a/test/suites/integration/httproute_mutation_do_not_leak_target_group_test.go
+++ b/test/suites/integration/httproute_mutation_do_not_leak_target_group_test.go
@@ -1,0 +1,139 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"time"
+)
+
+var _ = Describe("HTTPRoute Mutation", func() {
+	var (
+		gateway            *v1beta1.Gateway   = nil
+		pathMatchHttpRoute *v1beta1.HTTPRoute = nil
+		deployment1        *appsv1.Deployment = nil
+		service1           *corev1.Service    = nil
+		deployment2        *appsv1.Deployment = nil
+		service2           *corev1.Service    = nil
+		deployment3        *appsv1.Deployment = nil
+		service3           *corev1.Service    = nil
+	)
+
+	It("Create a HTTPRoute that backendref to service1 and service2 first, tg1 and tg2 should be created, tg3 should not be created. "+
+		"Then, update the HTTPRoute to backendref to service1 and service3, tg1 should still exist, tg2 should be deleted, tg3 should be created", func() {
+		gateway = testFramework.NewGateway("", "default")
+		deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: "default"})
+		deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: "default"})
+		deployment3, service3 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3", Namespace: "default"})
+
+		pathMatchHttpRoute = testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http",
+			"", "default")
+
+		// Create Kubernetes Resources
+		testFramework.ExpectCreated(ctx,
+			gateway,
+			pathMatchHttpRoute,
+			service1,
+			deployment1,
+			service2,
+			deployment2,
+			service3,
+			deployment3,
+		)
+
+		fmt.Println("service1.Name: ", service1.Name)
+		fmt.Println("service2.Name: ", service2.Name)
+		fmt.Println("service3.Name: ", service3.Name)
+		time.Sleep(30 * time.Second)
+
+		Eventually(func(g Gomega) {
+			service1TgFound := false
+			service2TgFound := false
+			service3TgFound := false
+
+			targetGroups, err := testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			g.Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				fmt.Println("targetGroup.Name: ", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service3.Name, service3.Namespace) {
+					service3TgFound = true
+				}
+			}
+			g.Expect(service1TgFound).To(BeTrue())
+			g.Expect(service2TgFound).To(BeTrue())
+			g.Expect(service3TgFound).To(BeFalse())
+		}).Should(Succeed())
+
+		testFramework.Get(ctx, types.NamespacedName{Name: pathMatchHttpRoute.Name, Namespace: pathMatchHttpRoute.Namespace}, pathMatchHttpRoute)
+
+		fmt.Println("Will update the pathMatchHttpRoute to backendRefs to service1 and service3")
+		pathMatchHttpRoute.Spec.Rules[1].BackendRefs[0].BackendObjectReference.Name = v1beta1.ObjectName(service3.Name)
+		testFramework.Update(ctx, pathMatchHttpRoute)
+		time.Sleep(30 * time.Second)
+
+		// Verify the targetGroup that corresponds to the service2 is deleted
+		// And the targetGroup that corresponds to the service3 is created
+		Eventually(func(g Gomega) {
+			service1TgFound := false
+			service2TgFound := false
+			service3TgFound := false
+			targetGroups, err := testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			fmt.Println("Retrieved targetGroups len: ", len(targetGroups))
+			g.Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				fmt.Println("targetGroup.Name: ", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service3.Name, service3.Namespace) {
+					service3TgFound = true
+				}
+			}
+			g.Expect(service1TgFound).To(BeTrue())
+			g.Expect(service2TgFound).To(BeFalse())
+			g.Expect(service3TgFound).To(BeTrue())
+		}).Should(Succeed())
+
+	})
+
+	AfterEach(func() {
+		testFramework.ExpectDeleted(ctx,
+			gateway,
+			pathMatchHttpRoute,
+			deployment1,
+			service1,
+			deployment2,
+			service2,
+			deployment3,
+			service3)
+		testFramework.EventuallyExpectNotFound(ctx,
+			gateway,
+			pathMatchHttpRoute,
+			deployment1,
+			service1,
+			deployment2,
+			service2,
+			deployment3,
+			service3)
+	})
+})


### PR DESCRIPTION
Trying to solve this Target Groups Leaked  issue: https://github.com/aws/aws-application-networking-k8s/issues/119

Modified version of this PR: https://github.com/aws/aws-application-networking-k8s/pull/268

## Changes:

- Changed model_build_targetgroup and model_build_service, make sure target group deletion request `model` triggered by httproute deletion could pass to target_group_synthesizer correctly

- Changed lattice resource creation and deletion order for httproute. Before both creation and deletion follow the same order: first TargetGroup then LatticeService. Now, the creation order keep the first TargetGroup then LatticeService, while the the deletion order change to first  LatticeService then TargetGroup
     - The reason to do this change is vpc lattice don't support to delete a still-in-use targetGroup (has LatticeServce's listener rules that route to this TargetGroup), we need to delete the service fist to make this targetGroup status change to not-in-use.


## Test:
Add e2etest could pass: (5 existing tests and 1 newly added one)
full log: https://gist.github.com/zijun726911/9d774d3829373ff6e21608bd975fda15
```
------------------------------

Ran 6 of 6 Specs in 2088.666 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2089.14s)
PASS
ok  	github.com/aws/aws-application-networking-k8s/test/suites/integration	2089.682s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.