### PR TITLE
test: add unit tests for `stack_deployer.go`

### DIFF
--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"context"
+
 	"github.com/aws/aws-application-networking-k8s/pkg/aws"
 	"github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
@@ -74,6 +75,7 @@ type latticeServiceStackDeployer struct {
 	k8sclient             client.Client
 	latticeServiceManager lattice.ServiceManager
 	targetGroupManager    lattice.TargetGroupManager
+	targetsManager        lattice.TargetsManager
 	listenerManager       lattice.ListenerManager
 	ruleManager           lattice.RuleManager
 	latticeDataStore      *latticestore.LatticeDataStore
@@ -85,6 +87,7 @@ func NewLatticeServiceStackDeploy(cloud aws.Cloud, k8sClient client.Client, latt
 		k8sclient:             k8sClient,
 		latticeServiceManager: lattice.NewServiceManager(cloud, latticeDataStore),
 		targetGroupManager:    lattice.NewTargetGroupManager(cloud),
+		targetsManager:        lattice.NewTargetsManager(cloud, latticeDataStore),
 		listenerManager:       lattice.NewListenerManager(cloud, latticeDataStore),
 		ruleManager:           lattice.NewRuleManager(cloud, latticeDataStore),
 		latticeDataStore:      latticeDataStore,
@@ -93,7 +96,7 @@ func NewLatticeServiceStackDeploy(cloud aws.Cloud, k8sClient client.Client, latt
 
 func (d *latticeServiceStackDeployer) Deploy(ctx context.Context, stack core.Stack) error {
 	targetGroupSynthesizer := lattice.NewTargetGroupSynthesizer(d.cloud, d.k8sclient, d.targetGroupManager, stack, d.latticeDataStore)
-	targetsSynthesizer := lattice.NewTargetsSynthesizer(d.cloud, lattice.NewTargetsManager(d.cloud, d.latticeDataStore), stack, d.latticeDataStore)
+	targetsSynthesizer := lattice.NewTargetsSynthesizer(d.cloud, d.targetsManager, stack, d.latticeDataStore)
 	serviceSynthesizer := lattice.NewServiceSynthesizer(d.latticeServiceManager, stack, d.latticeDataStore)
 	listenerSynthesizer := lattice.NewListenerSynthesizer(d.listenerManager, stack, d.latticeDataStore)
 	ruleSynthesizer := lattice.NewRuleSynthesizer(d.ruleManager, stack, d.latticeDataStore)

--- a/pkg/deploy/stack_deployer_test.go
+++ b/pkg/deploy/stack_deployer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
@@ -65,7 +66,9 @@ func Test_latticeServiceStackDeployer_createAllResources(t *testing.T) {
 		latticeDataStore:      mockLatticeDataStore,
 	}
 
-	deployer.Deploy(ctx, s)
+	err := deployer.Deploy(ctx, s)
+
+	assert.Nil(t, err)
 }
 
 func Test_latticeServiceStackDeployer_CreateJustService(t *testing.T) {
@@ -110,7 +113,9 @@ func Test_latticeServiceStackDeployer_CreateJustService(t *testing.T) {
 		latticeDataStore:      mockLatticeDataStore,
 	}
 
-	deployer.Deploy(ctx, s)
+	err := deployer.Deploy(ctx, s)
+
+	assert.Nil(t, err)
 }
 
 func Test_latticeServiceStackDeployer_DeleteService(t *testing.T) {
@@ -157,7 +162,9 @@ func Test_latticeServiceStackDeployer_DeleteService(t *testing.T) {
 		latticeDataStore:      mockLatticeDataStore,
 	}
 
-	deployer.Deploy(ctx, s)
+	err := deployer.Deploy(ctx, s)
+
+	assert.Nil(t, err)
 }
 
 func Test_latticeServiceStackDeployer_DeleteAllResources(t *testing.T) {
@@ -208,5 +215,7 @@ func Test_latticeServiceStackDeployer_DeleteAllResources(t *testing.T) {
 		latticeDataStore:      mockLatticeDataStore,
 	}
 
-	deployer.Deploy(ctx, s)
+	err := deployer.Deploy(ctx, s)
+
+	assert.Nil(t, err)
 }

--- a/pkg/deploy/stack_deployer_test.go
+++ b/pkg/deploy/stack_deployer_test.go
@@ -1,0 +1,212 @@
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	mocks_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	"github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/golang/mock/gomock"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+)
+
+func Test_latticeServiceStackDeployer_createAllResources(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	mockClient := mock_client.NewMockClient(c)
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+
+	mockServiceManager := lattice.NewMockServiceManager(c)
+
+	mockTargetGroupManager := lattice.NewMockTargetGroupManager(c)
+
+	mockListenerManager := lattice.NewMockListenerManager(c)
+
+	mockRuleManager := lattice.NewMockRuleManager(c)
+
+	mockTargetsManager := lattice.NewMockTargetsManager(c)
+
+	mockLatticeDataStore := latticestore.NewLatticeDataStore()
+
+	ctx := context.TODO()
+
+	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
+
+	latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{})
+	latticemodel.NewTargetGroup(s, "fake-targetGroup", latticemodel.TargetGroupSpec{})
+	latticemodel.NewTargets(s, "fake-target", latticemodel.TargetsSpec{})
+	latticemodel.NewListener(s, "fake-listener", 8080, "HTTP", "service1", "default", latticemodel.DefaultAction{})
+	latticemodel.NewRule(s, "fake-rule", "fake-rule", "default", 80, "HTTP", latticemodel.RuleAction{}, latticemodel.RuleSpec{})
+
+	mockTargetGroupManager.EXPECT().List(gomock.Any()).AnyTimes()
+	mockListenerManager.EXPECT().List(gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockServiceManager.EXPECT().Create(gomock.Any(), gomock.Any())
+	mockTargetGroupManager.EXPECT().Create(gomock.Any(), gomock.Any()).AnyTimes()
+	mockTargetsManager.EXPECT().Create(gomock.Any(), gomock.Any())
+	mockListenerManager.EXPECT().Create(gomock.Any(), gomock.Any())
+	mockRuleManager.EXPECT().Create(gomock.Any(), gomock.Any())
+
+	deployer := &latticeServiceStackDeployer{
+		cloud:                 mockCloud,
+		k8sclient:             mockClient,
+		latticeServiceManager: mockServiceManager,
+		targetGroupManager:    mockTargetGroupManager,
+		listenerManager:       mockListenerManager,
+		ruleManager:           mockRuleManager,
+		targetsManager:        mockTargetsManager,
+		latticeDataStore:      mockLatticeDataStore,
+	}
+
+	deployer.Deploy(ctx, s)
+}
+
+func Test_latticeServiceStackDeployer_CreateJustService(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	mockClient := mock_client.NewMockClient(c)
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+
+	mockServiceManager := lattice.NewMockServiceManager(c)
+
+	mockTargetGroupManager := lattice.NewMockTargetGroupManager(c)
+
+	mockTargetsManager := lattice.NewMockTargetsManager(c)
+
+	mockListenerManager := lattice.NewMockListenerManager(c)
+
+	mockRuleManager := lattice.NewMockRuleManager(c)
+
+	mockLatticeDataStore := latticestore.NewLatticeDataStore()
+
+	ctx := context.TODO()
+
+	mockTargetGroupManager.EXPECT().List(gomock.Any())
+	mockListenerManager.EXPECT().List(gomock.Any(), gomock.Any())
+
+	mockServiceManager.EXPECT().Create(gomock.Any(), gomock.Any())
+
+	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
+
+	latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{})
+
+	deployer := &latticeServiceStackDeployer{
+		cloud:                 mockCloud,
+		k8sclient:             mockClient,
+		latticeServiceManager: mockServiceManager,
+		targetGroupManager:    mockTargetGroupManager,
+		targetsManager:        mockTargetsManager,
+		listenerManager:       mockListenerManager,
+		ruleManager:           mockRuleManager,
+		latticeDataStore:      mockLatticeDataStore,
+	}
+
+	deployer.Deploy(ctx, s)
+}
+
+func Test_latticeServiceStackDeployer_DeleteService(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	mockClient := mock_client.NewMockClient(c)
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+
+	mockServiceManager := lattice.NewMockServiceManager(c)
+
+	mockTargetGroupManager := lattice.NewMockTargetGroupManager(c)
+
+	mockListenerManager := lattice.NewMockListenerManager(c)
+
+	mockRuleManager := lattice.NewMockRuleManager(c)
+
+	mockTargetsManager := lattice.NewMockTargetsManager(c)
+
+	mockLatticeDataStore := latticestore.NewLatticeDataStore()
+
+	ctx := context.TODO()
+
+	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
+
+	latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{
+		IsDeleted: true,
+	})
+
+	mockTargetGroupManager.EXPECT().List(gomock.Any()).AnyTimes()
+	mockListenerManager.EXPECT().List(gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockServiceManager.EXPECT().Delete(gomock.Any(), gomock.Any())
+
+	deployer := &latticeServiceStackDeployer{
+		cloud:                 mockCloud,
+		k8sclient:             mockClient,
+		latticeServiceManager: mockServiceManager,
+		targetGroupManager:    mockTargetGroupManager,
+		listenerManager:       mockListenerManager,
+		ruleManager:           mockRuleManager,
+		targetsManager:        mockTargetsManager,
+		latticeDataStore:      mockLatticeDataStore,
+	}
+
+	deployer.Deploy(ctx, s)
+}
+
+func Test_latticeServiceStackDeployer_DeleteAllResources(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	mockClient := mock_client.NewMockClient(c)
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+
+	mockServiceManager := lattice.NewMockServiceManager(c)
+
+	mockTargetGroupManager := lattice.NewMockTargetGroupManager(c)
+
+	mockListenerManager := lattice.NewMockListenerManager(c)
+
+	mockRuleManager := lattice.NewMockRuleManager(c)
+
+	mockTargetsManager := lattice.NewMockTargetsManager(c)
+
+	mockLatticeDataStore := latticestore.NewLatticeDataStore()
+
+	ctx := context.TODO()
+
+	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
+
+	latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{
+		IsDeleted: true,
+	})
+	latticemodel.NewTargetGroup(s, "fake-targetGroup", latticemodel.TargetGroupSpec{
+		IsDeleted: true,
+	})
+
+	mockTargetGroupManager.EXPECT().List(gomock.Any()).AnyTimes()
+	mockListenerManager.EXPECT().List(gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockServiceManager.EXPECT().Delete(gomock.Any(), gomock.Any())
+	mockTargetGroupManager.EXPECT().Delete(gomock.Any(), gomock.Any())
+
+	deployer := &latticeServiceStackDeployer{
+		cloud:                 mockCloud,
+		k8sclient:             mockClient,
+		latticeServiceManager: mockServiceManager,
+		targetGroupManager:    mockTargetGroupManager,
+		listenerManager:       mockListenerManager,
+		ruleManager:           mockRuleManager,
+		targetsManager:        mockTargetsManager,
+		latticeDataStore:      mockLatticeDataStore,
+	}
+
+	deployer.Deploy(ctx, s)
+}

--- a/test/suites/integration/deregister_targets_test.go
+++ b/test/suites/integration/deregister_targets_test.go
@@ -1,15 +1,16 @@
 package integration
 
 import (
+	"log"
+	"os"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"log"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
-	"time"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
@@ -45,8 +46,9 @@ var _ = Describe("Deregister Targets", func() {
 
 		// Verify VPC Lattice Service exists
 		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, pathMatchHttpRoute)
+
 		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(
-			latticestore.AWSServiceName(pathMatchHttpRoute.Name, pathMatchHttpRoute.Namespace)))
+			latticestore.LatticeServiceName(pathMatchHttpRoute.Name, pathMatchHttpRoute.Namespace)))
 
 		// Verify VPC Lattice Target Group exists
 		targetGroup = testFramework.GetTargetGroup(ctx, service)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
- Add unit tests for `stack_deployer.go`
- Fix e2e test build failure

**What does this PR do / Why do we need it**:

This PR add unit tests for `stack_deployer.go` and fix e2e test build failure

#274 

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

`make e2etest`

```
• [271.541 seconds]
------------------------------

Ran 6 of 6 Specs in 2329.978 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2330.79s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   2330.817s
```

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
N/A

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

No

```release-note
fix: fix build error for e2e test
test: add unit tests for stack_deployer.Deploy
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.