### PR TITLE
AWS#267 Added support for Port Annotation in ServiceExport Object

### DIFF
--- a/examples/elasticsearch-export.yaml
+++ b/examples/elasticsearch-export.yaml
@@ -1,0 +1,7 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: elasticsearch
+  annotations:
+    multicluster.x-k8s.io/federation: "amazon-vpc-lattice"
+    multicluster.x-k8s.io/port: "9200"

--- a/examples/elasticsearch-import.yaml
+++ b/examples/elasticsearch-import.yaml
@@ -1,0 +1,9 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceImport
+metadata:
+  name: elasticsearch
+spec:
+  type: ClusterSetIP
+  ports:
+  - port: 9200
+    protocol: TCP

--- a/examples/elasticsearch.yaml
+++ b/examples/elasticsearch.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: elasticsearch
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: elasticsearch:7.9.3
+          env:
+            - name: discovery.type
+              value: single-node
+          ports:
+            - name: http
+              containerPort: 9200
+        - name: prometheus-exporter
+          image: justwatch/elasticsearch_exporter:1.1.0
+          args:
+            - '--es.uri=http://localhost:9200'
+          ports:
+            - name: http-prometheus
+              containerPort: 9114
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+spec:
+  selector:
+    app.kubernetes.io/name: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+    - name: http-prometheus
+      port: 9114
+      targetPort: http-prometheus

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -147,7 +147,7 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 					}
 					if portAnnotations == 0 || int64(target.Port) == portAnnotations {
 						targetList = append(targetList, target)
-						fmt.Printf("SESMAILI GOT HERE 1 - portAnnotations:%v, target.Port:%v\n", portAnnotations, target.Port)
+						fmt.Printf("portAnnotations:%v, target.Port:%v\n", portAnnotations, target.Port)
 					} else {
 						glog.V(6).Infof("Found a port match, registering the target - port:%v, containerPort:%v, taerget:%v ***\n", int64(target.Port), portAnnotations, target)
 					}

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	resourceIDLatticeTargets = "LatticeTargets"
+	portAnnotationsKey       = "multicluster.x-k8s.io/port"
 )
 
 type LatticeTargetsBuilder interface {
@@ -115,10 +116,11 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 	if err != nil {
 		glog.V(6).Infof("Failed to find Service export in the DS. Name:%v, Namespace:%v - err:%s\n ", t.tgName, t.tgNamespace, err)
 	} else {
+		// TODO: Change the code to support multiple comma separated ports instead of a single port
 		//portsAnnotations := strings.Split(serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/Ports"], ",")
-		portAnnotations, err = strconv.ParseInt(serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/port"], 10, 64)
+		portAnnotations, err = strconv.ParseInt(serviceExport.ObjectMeta.Annotations[portAnnotationsKey], 10, 64)
 		if err != nil {
-			glog.V(6).Infof("Failed to read Annotaions/Port:%v, err:%s\n ", serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/port"], err)
+			glog.V(6).Infof("Failed to read Annotaions/Port:%v, err:%s\n ", serviceExport.ObjectMeta.Annotations[portAnnotationsKey], err)
 		}
 		glog.V(6).Infof("Build Targets - portAnnotations: %v \n", portAnnotations)
 	}

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -116,7 +116,7 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 		glog.V(6).Infof("Failed to find Service export in the DS. Name:%v, Namespace:%v - err:%s\n ", t.tgName, t.tgNamespace, err)
 	} else {
 		//portsAnnotations := strings.Split(serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/Ports"], ",")
-		portAnnotations, err = strconv.ParseInt(serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/Port"], 10, 64)
+		portAnnotations, err = strconv.ParseInt(serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/port"], 10, 64)
 		if err != nil {
 			glog.V(6).Infof("Failed to read Annotaions/Port:%v, err:%s\n ", serviceExport.ObjectMeta.Annotations["multicluster.x-k8s.io/port"], err)
 		}
@@ -145,6 +145,7 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 					}
 					if portAnnotations == 0 || int64(target.Port) == portAnnotations {
 						targetList = append(targetList, target)
+						fmt.Printf("SESMAILI GOT HERE 1 - portAnnotations:%v, target.Port:%v\n", portAnnotations, target.Port)
 					} else {
 						glog.V(6).Infof("Found a port match, registering the target - port:%v, containerPort:%v, taerget:%v ***\n", int64(target.Port), portAnnotations, target)
 					}

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -23,6 +23,7 @@ import (
 const (
 	resourceIDLatticeTargets = "LatticeTargets"
 	portAnnotationsKey       = "multicluster.x-k8s.io/port"
+	undefinedPort            = int64(0)
 )
 
 type LatticeTargetsBuilder interface {
@@ -110,7 +111,7 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 		return errors.New(errmsg)
 	}
 
-	portAnnotations := int64(0)
+	portAnnotations := undefinedPort
 	serviceExport := &mcs_api.ServiceExport{}
 	err = t.Client.Get(ctx, namespacedName, serviceExport)
 	if err != nil {
@@ -145,9 +146,9 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 						TargetIP: address.IP,
 						Port:     int64(port.Port),
 					}
-					if portAnnotations == 0 || int64(target.Port) == portAnnotations {
+					if portAnnotations == undefinedPort || int64(target.Port) == portAnnotations {
 						targetList = append(targetList, target)
-						fmt.Printf("portAnnotations:%v, target.Port:%v\n", portAnnotations, target.Port)
+						glog.V(6).Infof("portAnnotations:%v, target.Port:%v\n", portAnnotations, target.Port)
 					} else {
 						glog.V(6).Infof("Found a port match, registering the target - port:%v, containerPort:%v, taerget:%v ***\n", int64(target.Port), portAnnotations, target)
 					}

--- a/test/pkg/test/elasticsearch.go
+++ b/test/pkg/test/elasticsearch.go
@@ -1,0 +1,151 @@
+package test
+
+import (
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type ElasticSearchOptions struct {
+	Name                string
+	Namespace           string // the object will be created in this namespace
+	Port                int
+	Port2               int
+	TargetPort          int
+	MergeFromDeployment []*appsv1.Deployment
+	MergeFromService    []*v1.Service
+}
+
+func (env *Framework) NewElasticeApp(options ElasticSearchOptions) (*appsv1.Deployment, *v1.Service) {
+	if options.Port == 0 {
+		options.Port = 80
+	}
+	if options.Port2 == 0 {
+		options.Port2 = 9114
+	}
+	if options.TargetPort == 0 {
+		options.TargetPort = 80
+	}
+	deployment := New(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: lo.ToPtr(int32(2)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": options.Name,
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: options.Namespace,
+					Labels: map[string]string{
+						"app":          options.Name,
+						DiscoveryLabel: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  options.Name,
+							Image: "nginx",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          options.Name,
+									ContainerPort: int32(80),
+									Protocol:      "TCP",
+								},
+							},
+							Env: []v1.EnvVar{{
+								Name:  "PodName",
+								Value: options.Name + " handler pod",
+							}},
+						},
+						{
+							Name:  "prometheus-exporter",
+							Image: "justwatch/elasticsearch_exporter:1.1.0",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "http-prometheus",
+									ContainerPort: int32(9114),
+									Protocol:      "TCP",
+								},
+							},
+							Env: []v1.EnvVar{{
+								Name:  "PodName",
+								Value: options.Name + " handler pod",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}, options.MergeFromDeployment...)
+
+	service := New(&v1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"app": options.Name,
+			},
+			Ports: []v1.ServicePort{
+				{
+					Name:     options.Name,
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(options.Port),
+				},
+				{
+					Name:     "http-prometheus",
+					Protocol: v1.ProtocolTCP,
+					Port:     int32(options.Port2),
+				}},
+		},
+	}, options.MergeFromService...)
+	env.TestCasesCreatedTargetGroupNames[latticestore.TargetGroupName(service.Name, service.Namespace)] = true
+	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, service, deployment)
+	return deployment, service
+
+}
+
+func (env *Framework) NewHttpRoute(parentRefsGateway *v1beta1.Gateway, service *v1.Service) *v1beta1.HTTPRoute {
+	var rules []v1beta1.HTTPRouteRule
+	rule := v1beta1.HTTPRouteRule{
+		BackendRefs: []v1beta1.HTTPBackendRef{{
+			BackendRef: v1beta1.BackendRef{
+				BackendObjectReference: v1beta1.BackendObjectReference{
+					Name:      v1beta1.ObjectName(service.Name),
+					Namespace: (*v1beta1.Namespace)(&service.Namespace),
+					Kind:      lo.ToPtr(v1beta1.Kind("ServiceImport")),
+					Port:      (*v1beta1.PortNumber)(&service.Spec.Ports[0].Port),
+				},
+			},
+		}},
+	}
+	rules = append(rules, rule)
+	httpRoute := New(&v1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: service.Namespace,
+		},
+		Spec: v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: v1beta1.CommonRouteSpec{
+				ParentRefs: []v1beta1.ParentReference{{
+					Name: v1beta1.ObjectName(parentRefsGateway.Name),
+					//SectionName: lo.ToPtr(v1beta1.SectionName("http")),
+				}},
+			},
+			Rules: rules,
+		},
+	})
+	env.TestCasesCreatedServiceNames[latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)] = true
+	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, httpRoute)
+	return httpRoute
+}

--- a/test/pkg/test/service_export_import.go
+++ b/test/pkg/test/service_export_import.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"strconv"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -39,4 +41,47 @@ func (env *Framework) CreateServiceExportAndServiceImportByService(service *v1.S
 	})
 	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, serviceExport, serviceImport)
 	return serviceExport, serviceImport
+}
+
+func (env *Framework) CreateServiceExport(service *v1.Service) *v1alpha1.ServiceExport {
+	serviceExport := New(&v1alpha1.ServiceExport{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "multicluster.x-k8s.io/v1alpha1",
+			Kind:       "ServiceExport",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+			Annotations: map[string]string{
+				"multicluster.x-k8s.io/federation": "amazon-vpc-lattice",
+				"multicluster.x-k8s.io/port":       strconv.FormatInt(int64(service.Spec.Ports[0].Port), 10),
+			},
+		},
+	})
+	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, serviceExport)
+	return serviceExport
+}
+
+func (env *Framework) CreateServiceImport(service *v1.Service) *v1alpha1.ServiceImport {
+	serviceImport := New(&v1alpha1.ServiceImport{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "multicluster.x-k8s.io/v1alpha1",
+			Kind:       "ServiceImport",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+		},
+		Spec: v1alpha1.ServiceImportSpec{
+			Type: v1alpha1.ClusterSetIP,
+			Ports: []v1alpha1.ServicePort{
+				{
+					Port:     service.Spec.Ports[0].Port,
+					Protocol: service.Spec.Ports[0].Protocol,
+				},
+			},
+		},
+	})
+	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, serviceImport)
+	return serviceImport
 }

--- a/test/suites/integration/srvexport_port_annotation_targets_test.go
+++ b/test/suites/integration/srvexport_port_annotation_targets_test.go
@@ -1,0 +1,96 @@
+package integration
+
+import (
+	"log"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+)
+
+var _ = Describe("Port Annotations Targets", func() {
+	var (
+		gateway           *v1beta1.Gateway
+		deployment        *appsv1.Deployment
+		service           *v1.Service
+		serviceExport     *v1alpha1.ServiceExport
+		serviceImport     *v1alpha1.ServiceImport
+		httpRoute         *v1beta1.HTTPRoute
+		vpcLatticeService *vpclattice.ServiceSummary
+		targetGroup       *vpclattice.TargetGroupSummary
+	)
+
+	BeforeEach(func() {
+		gateway = testFramework.NewGateway("test-gateway", k8snamespace)
+		deployment, service = testFramework.NewElasticeApp(test.ElasticSearchOptions{
+			Name:      "port-test",
+			Namespace: k8snamespace,
+		})
+		serviceExport = testFramework.CreateServiceExport(service)
+		serviceImport = testFramework.CreateServiceImport(service)
+		httpRoute = testFramework.NewHttpRoute(gateway, service)
+		testFramework.ExpectCreated(
+			ctx,
+			gateway,
+			serviceExport,
+			serviceImport,
+			service,
+			deployment,
+			httpRoute,
+		)
+		time.Sleep(3 * time.Minute) // Wait for creation of VPCLattice resources
+
+		// Verify VPC Lattice Service exists
+		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, httpRoute)
+		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
+
+		// Verify VPC Lattice Target Group exists
+		targetGroup = testFramework.GetTargetGroup(ctx, service)
+		Expect(*targetGroup.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
+		Expect(*targetGroup.Protocol).To(Equal("HTTP"))
+	})
+
+	AfterEach(func() {
+		testFramework.CleanTestEnvironment(ctx)
+		testFramework.EventuallyExpectNotFound(
+			ctx,
+			gateway,
+			serviceExport,
+			serviceImport,
+			service,
+			deployment,
+			httpRoute,
+		)
+	})
+
+	It("Port Annotaion on Service Export", func() {
+
+		targets := testFramework.GetTargets(ctx, targetGroup, deployment)
+		Expect(*targetGroup.Port).To(BeEquivalentTo(80))
+		log.Println("Verifying Targets are only craeted for the port defined in Port Annotaion in ServiceExport")
+		for _, target := range targets {
+			Expect(*target.Port).To(BeEquivalentTo(service.Spec.Ports[0].Port))
+			Expect(*target.Status).To(Or(
+				Equal(vpclattice.TargetStatusInitial),
+				Equal(vpclattice.TargetStatusHealthy),
+			))
+			log.Println("Target:", target)
+		}
+
+		testFramework.ExpectDeleted(ctx, service)
+		Eventually(func(g Gomega) {
+			log.Println("Verifying Targets are only craeted for the port defined in Port Annotaion in ServiceExport")
+			targets := testFramework.GetTargets(ctx, targetGroup, deployment)
+			Expect(len(targets) == 0)
+		}).WithTimeout(5*time.Minute + 30*time.Second)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** Feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: AWS#267


**What does this PR do / Why do we need it**: This PR enables users to define which port/container to be exported vi ServiceExport object.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**: Yes
make presubmit output:
```go
?       github.com/aws/aws-application-networking-k8s/pkg/aws   [no test files]
?       github.com/aws/aws-application-networking-k8s/pkg/deploy        [no test files]
ok      github.com/aws/aws-application-networking-k8s/pkg/aws/services  0.017s  coverage: 2.9% of statements
ok      github.com/aws/aws-application-networking-k8s/pkg/config        0.011s  coverage: 77.4% of statements
?       github.com/aws/aws-application-networking-k8s/pkg/k8s   [no test files]
?       github.com/aws/aws-application-networking-k8s/pkg/model/lattice [no test files]
?       github.com/aws/aws-application-networking-k8s/pkg/runtime       [no test files]
?       github.com/aws/aws-application-networking-k8s/pkg/utils [no test files]
?       github.com/aws/aws-application-networking-k8s/pkg/utils/retry   [no test files]
?       github.com/aws/aws-application-networking-k8s/pkg/utils/ttime   [no test files]
ok      github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice        0.042s  coverage: 86.1% of statements
**ok      github.com/aws/aws-application-networking-k8s/pkg/gateway       0.054s  coverage: 77.8% of statements**
ok      github.com/aws/aws-application-networking-k8s/pkg/latticestore  0.004s  coverage: 73.3% of statements
ok      github.com/aws/aws-application-networking-k8s/pkg/model/core    0.004s  coverage: 40.9% of statements
ok      github.com/aws/aws-application-networking-k8s/pkg/model/core/graph      0.003s  coverage: 17.2% of statements
ok      github.com/aws/aws-application-networking-k8s/pkg/utils/log     0.002s  coverage: 0.0% of statements [no tests to run]
```
E2E Tests output:
```go
Ran 7 of 7 Specs in 3104.031 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (3104.19s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   3104.210s
```
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**: No
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: Yes

**Does this PR introduce any user-facing change?**: Yes.
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Users will be able to define which ports/containers to expose through ServiceExport by adding an annotation to ServiceExport objects.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.