### PR TITLE
Fix small issue with getting started doc

### DIFF
--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -108,8 +108,8 @@ This example creates a single cluster in a single VPC, then configures two route
 
 
    ```bash
-   ratesdns=$(kubectl get httproute rates -o json | jq -r .status.parents[].conditions[].message)
-   inventorydns=$(kubectl get httproute inventory -o json | jq -r .status.parents[].conditions[].message)
+   ratesdns=$(kubectl get httproute rates -o json | jq -r '.status.parents[].conditions[0].message')
+   inventorydns=$(kubectl get httproute inventory -o json | jq -r '.status.parents[].conditions[0].message')
    ```
    
    remove preceding extra text:
@@ -126,6 +126,10 @@ confirm that the URLs are stored correctly:
 
 ```bash
 echo $ratesFQDN $inventoryFQDN
+```
+
+```
+rates-default-034e0056410499722.7d67968.vpc-lattice-svcs.us-west-2.on.aws inventory-default-0c54a5e5a426f92c2.7d67968.vpc-lattice-svcs.us-west-2.on.aws
 ```
 
 **Check service connectivity**


### PR DESCRIPTION
This CR fixes a small syntax error in the latest getting started docs.

**What type of PR is this?**
documentation

**Which issue does this PR fix**:
N/a

**What does this PR do / Why do we need it**:
Fixes syntax error when running getting started docs. When running the docs in ZSH or running them a second time there could be additional httpRoute entries and we need to specify the first one.

**Testing done on this change**:
Running through getting started with a clean environment

**Automation added to e2e**:
N/a

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
testing in running cluster

**Does this PR introduce any user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.