### PR TITLE
fix: clean up resources after test run

### DIFF
--- a/test/suites/integration/https_listener_weighted_rule_with_service_export_import_test.go
+++ b/test/suites/integration/https_listener_weighted_rule_with_service_export_import_test.go
@@ -18,6 +18,12 @@ import (
 )
 
 var _ = Describe("Test 2 listeners gateway with weighted httproute rules and service export import", func() {
+	// Clean up resources in case an assertion failed before cleaning up
+	// at the end
+	AfterEach(func() {
+		testFramework.CleanTestEnvironment(ctx)
+	})
+
 	It("Create a gateway with 2 listeners(http and https), create a weightedRoutingHttpRoute that parentRef to both http and https listeners,"+
 		" and this httpRoute BackendRef to one service and one serviceImport, weighted traffic should work for both http and https listeners",
 		func() {
@@ -134,7 +140,7 @@ var _ = Describe("Test 2 listeners gateway with weighted httproute rules and ser
 					} else if strings.Contains(stdout, "service-import-export-test1 handler pod") {
 						hitTg1++
 					} else {
-						Fail("Unexpected response")
+						Fail(fmt.Sprintf("Unexpected response: %s", stdout))
 					}
 				}
 				log.Printf("Send traffic to %s listener: \n", protocol)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: bug


**What does this PR do / Why do we need it**:  this PR fix clean up issue for test `Test 2 listeners gateway with weighted httproute rules and service export import`


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**: N/A


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
`make e2etest` output:

```
Ran 7 of 7 Specs in 2926.795 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2927.51s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   2927.541s
```

**Automation added to e2e**: N/A
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: N/A

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.