### PR TITLE
Added .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ go.work*
 
 # envFile from load_env_variables.sh
 **/envFile
+
+# IDE files/directories
+.idea/


### PR DESCRIPTION
This pull request adds .idea/ to the .gitignore file. This change ensures that JetBrains IDE settings and configurations are not tracked by Git.

By ignoring the .idea/ directory (used by JetBrains IDEs like IntelliJ IDEA, PyCharm, WebStorm, etc.), we allow each developer to have their own local settings without interfering with the project's source code.

This change is purely related to the project's development environment and has no impact on the actual codebase or functionality.