### PR TITLE
Improved assertions & resource clean-up for E2E tests

### DIFF
--- a/pkg/aws/services/vpclattice.go
+++ b/pkg/aws/services/vpclattice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/golang/glog"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -35,7 +36,7 @@ func NewDefaultLattice(sess *session.Session, region string) *defaultLattice {
 		endpoint = latticeEndpoint
 	}
 
-	latticeSess = vpclattice.New(sess, aws.NewConfig().WithRegion(region).WithEndpoint(endpoint))
+	latticeSess = vpclattice.New(sess, aws.NewConfig().WithRegion(region).WithEndpoint(endpoint).WithMaxRetries(20).WithSleepDelay(func(t time.Duration) { time.Sleep(time.Millisecond * 500) }))
 
 	glog.V(2).Infoln("Lattice Service EndPoint:", endpoint)
 

--- a/test/pkg/test/elasticsearch.go
+++ b/test/pkg/test/elasticsearch.go
@@ -19,7 +19,7 @@ type ElasticSearchOptions struct {
 	MergeFromService    []*v1.Service
 }
 
-func (env *Framework) NewElasticeApp(options ElasticSearchOptions) (*appsv1.Deployment, *v1.Service) {
+func (env *Framework) NewElasticApp(options ElasticSearchOptions) (*appsv1.Deployment, *v1.Service) {
 	if options.Port == 0 {
 		options.Port = 80
 	}

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -144,8 +144,9 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 
 		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
 		for _, tg := range retrievedTargetGroups {
-			Logger(ctx).Infof("Found TargetGroup: %v, checking it whether it's created by current EKS Cluster", tg)
+			Logger(ctx).Infof("Found TargetGroup: %s, checking it whether it's created by current EKS Cluster", *tg.Id)
 			if currentClusterVpcId != *tg.VpcIdentifier {
+				Logger(ctx).Infof("Target group VPC Id: %s, does not match current EKS Cluster VPC Id: %s", *tg.VpcIdentifier, currentClusterVpcId)
 				//This tg is not created by current EKS Cluster, skip it
 				continue
 			}
@@ -156,6 +157,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 				Logger(ctx).Infof("Found Tags for tg %v tags: %v", *tg.Name, retrievedTags)
 				tagValue, ok := retrievedTags.Tags[lattice.K8SParentRefTypeKey]
 				if ok && *tagValue == lattice.K8SServiceExportType {
+					Logger(ctx).Infof("TargetGroup: %s was created by k8s controller, by a ServiceExport", *tg.Id)
 					//This tg is created by k8s controller, by a ServiceExport,
 					//ServiceExport still have a known targetGroup leaking issue,
 					//so we temporarily skip to verify whether ServiceExport created TargetGroup is deleted or not
@@ -220,9 +222,9 @@ func (env *Framework) EventuallyExpectNotFound(ctx context.Context, objects ...c
 			Logger(ctx).Infof("Checking whether %s %s %s is not found", reflect.TypeOf(object), object.GetNamespace(), object.GetName())
 			g.Expect(errors.IsNotFound(env.Get(ctx, client.ObjectKeyFromObject(object), object))).To(BeTrue())
 		}
-		// Wait for 6 minutes at maximum just in case the k8sService deletion triggered targets draining time
+		// Wait for 7 minutes at maximum just in case the k8sService deletion triggered targets draining time
 		// and httproute deletion need to wait for that targets draining time finish then it can return
-	}).WithTimeout(6 * time.Minute).WithOffset(1).Should(Succeed())
+	}).WithTimeout(7 * time.Minute).WithOffset(1).Should(Succeed())
 }
 
 func (env *Framework) EventuallyExpectNoneFound(ctx context.Context, objectList client.ObjectList) {
@@ -459,7 +461,9 @@ func (env *Framework) DeleteAllFrameworkTracedVpcLatticeServices(ctx aws.Context
 		_, err := env.LatticeClient.DeleteServiceNetworkServiceAssociationWithContext(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
 			ServiceNetworkServiceAssociationIdentifier: snsaId,
 		})
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			Expect(err.(awserr.Error).Code()).To(Equal(vpclattice.ErrCodeResourceNotFoundException))
+		}
 	}
 
 	Eventually(func(g Gomega) {
@@ -493,6 +497,9 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 	tgIds := lo.Map(filteredTgs, func(targetGroup *vpclattice.TargetGroupSummary, _ int) *string {
 		return targetGroup.Id
 	})
+
+	log.Println("Number of traced target groups to delete is:", len(tgIds))
+
 	for _, tgId := range tgIds {
 		targetSummaries, err := env.LatticeClient.ListTargetsAsList(ctx, &vpclattice.ListTargetsInput{
 			TargetGroupIdentifier: tgId,
@@ -510,6 +517,18 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 				TargetGroupIdentifier: tgId,
 				Targets:               targets,
 			})
+		} else {
+			Logger(ctx).Infof("Target group %s no longer has targets registered. Deleting now.", *tgId)
+			Eventually(func() bool {
+				_, err := env.LatticeClient.DeleteTargetGroup(&vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: tgId,
+				})
+				if err != nil {
+					// Allow time for related service to be deleted prior
+					return err.(awserr.Error).Code() == vpclattice.ErrCodeResourceNotFoundException
+				}
+				return true
+			}).WithPolling(15 * time.Second).WithTimeout(2 * time.Minute).Should(BeTrue())
 		}
 	}
 
@@ -518,7 +537,7 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 		//After initiating the DeregisterTargets call, the Targets will be in `draining` status for the next 5 minutes,
 		//And VPC lattice backend will run a background job to completely delete the targets within 6 minutes at maximum in total.
 		Eventually(func(g Gomega) {
-			log.Println("Trying to clear Target group", tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted, " need to wait for draining targets to be deregistered")
+			log.Println("Trying to clear Target group", tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted, "need to wait for draining targets to be deregistered")
 
 			for _, tgId := range tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted {
 				_, err := env.LatticeClient.DeleteTargetGroupWithContext(ctx, &vpclattice.DeleteTargetGroupInput{
@@ -528,7 +547,7 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 					g.Expect(err.(awserr.Error).Code()).To(Equal(vpclattice.ErrCodeResourceNotFoundException))
 				}
 			}
-		}).WithTimeout(360 * time.Second).Should(Succeed())
+		}).WithPolling(time.Minute).WithTimeout(7 * time.Minute).Should(Succeed())
 
 	}
 	env.TestCasesCreatedServiceNames = make(map[string]bool)


### PR DESCRIPTION
**What type of PR is this?**
Bug

**Which issue does this PR fix**:
This addresses E2E reliability by improving assertions and clean-up of resources that may leak during E2E test executions. It also addresses Amazon VPC Lattice throttling exceptions by introducing a retry strategy for the VPC Lattice client.

**What does this PR do / Why do we need it**:
This improves the reliability of existing E2E tests.

**Testing done on this change**:
```
FOCUS="" make e2etest

...

------------------------------

Ran 11 of 11 Specs in 4656.643 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (4656.81s)
PASS
```

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades. These changes were tested on the latest `v0.0.15` release.

**Does this PR introduce any user-facing change?**:
No.

```release-note
This addresses E2E reliability by improving assertions, adding a VPC Lattice client retry strategy, and enhanced clean-up of resources that may leak during E2E test executions.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.