### PR TITLE
Added HTTPRoute Creation/Update E2E Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ e2etest:
 	cd test && go test \
 		-p 1 \
 		-count 1 \
-		-timeout 60m \
+		-timeout 90m \
 		-v \
 		./suites/... \
 		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.timeout=60m \
+		--ginkgo.timeout=90m \
 		--ginkgo.v

--- a/test/suites/integration/httproute_creation_test.go
+++ b/test/suites/integration/httproute_creation_test.go
@@ -1,0 +1,102 @@
+package integration
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+)
+
+var resourceCreationWaitTime = 3 * time.Minute
+
+var _ = Describe("HTTPRoute Creation", func() {
+
+	var (
+		gateway           *v1beta1.Gateway
+		deployment        *appsv1.Deployment
+		service           *v1.Service
+		serviceExport     *v1alpha1.ServiceExport
+		serviceImport     *v1alpha1.ServiceImport
+		httpRoute         *v1beta1.HTTPRoute
+		vpcLatticeService *vpclattice.ServiceSummary
+		targetGroup       *vpclattice.TargetGroupSummary
+	)
+
+	BeforeEach(func() {
+		gateway = testFramework.NewGateway("test-gateway", k8snamespace)
+		deployment, service = testFramework.NewElasticApp(test.ElasticSearchOptions{
+			Name:      "port-test",
+			Namespace: k8snamespace,
+		})
+		serviceExport = testFramework.CreateServiceExport(service)
+		serviceImport = testFramework.CreateServiceImport(service)
+		httpRoute = testFramework.NewHttpRoute(gateway, service)
+
+		testFramework.ExpectCreated(ctx, gateway)
+	})
+
+	Context("Order #1: serviceImport, httpRoute, serviceExport, & service", func() {
+		It("creates successfully", func() {
+			testFramework.ExpectCreated(ctx, serviceImport)
+			testFramework.ExpectCreated(ctx, httpRoute)
+			testFramework.ExpectCreated(ctx, serviceExport)
+			testFramework.ExpectCreated(ctx, service, deployment)
+
+			verifyResourceCreation(vpcLatticeService, httpRoute, targetGroup, service)
+		})
+	})
+
+	Context("Order #2: httpRoute, serviceImport, service, & serviceExport", func() {
+		It("creates successfully", func() {
+			testFramework.ExpectCreated(ctx, httpRoute)
+			testFramework.ExpectCreated(ctx, serviceImport)
+			testFramework.ExpectCreated(ctx, service, deployment)
+			testFramework.ExpectCreated(ctx, serviceExport)
+
+			verifyResourceCreation(vpcLatticeService, httpRoute, targetGroup, service)
+		})
+	})
+
+	Context("Order #3: serviceExport, httpRoute, serviceImport, & service", func() {
+		It("creates successfully", func() {
+			testFramework.ExpectCreated(ctx, serviceExport)
+			testFramework.ExpectCreated(ctx, httpRoute)
+			testFramework.ExpectCreated(ctx, serviceImport)
+			testFramework.ExpectCreated(ctx, service, deployment)
+
+			verifyResourceCreation(vpcLatticeService, httpRoute, targetGroup, service)
+		})
+	})
+
+	AfterEach(func() {
+		testFramework.CleanTestEnvironment(ctx)
+	})
+})
+
+func verifyResourceCreation(
+	vpcLatticeService *vpclattice.ServiceSummary,
+	httpRoute *v1beta1.HTTPRoute,
+	targetGroup *vpclattice.TargetGroupSummary,
+	service *v1.Service,
+) {
+	log.Println(fmt.Sprintf("Waiting %s for Amazon VPC Lattice resource creation.", resourceCreationWaitTime))
+	time.Sleep(resourceCreationWaitTime)
+
+	vpcLatticeService = testFramework.GetVpcLatticeService(ctx, httpRoute)
+	Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
+
+	targetGroup = testFramework.GetTargetGroup(ctx, service)
+	Expect(*targetGroup.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
+	Expect(*targetGroup.Protocol).To(Equal("HTTP"))
+}

--- a/test/suites/integration/httproute_update_test.go
+++ b/test/suites/integration/httproute_update_test.go
@@ -1,0 +1,144 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/types"
+	"log"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+)
+
+var _ = Describe("HTTPRoute Update", func() {
+
+	var (
+		gateway               *v1beta1.Gateway   = nil
+		pathMatchHttpRouteOne *v1beta1.HTTPRoute = nil
+		pathMatchHttpRouteTwo *v1beta1.HTTPRoute = nil
+		deployment1           *appsv1.Deployment = nil
+		service1              *corev1.Service    = nil
+		deployment2           *appsv1.Deployment = nil
+		service2              *corev1.Service    = nil
+	)
+
+	var resourceCreationWaitTime = 30 * time.Second
+
+	Context("Create a HTTPRoute with backendref to service1, then update the HTTPRoute with backendref to service1 "+
+		"and service2, then update the HTTPRoute with backendref to just service2", func() {
+		It("Updates rules correctly with corresponding target groups after each update", func() {
+			gateway = testFramework.NewGateway("", "default")
+			deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: "default"})
+			deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: "default"})
+
+			pathMatchHttpRouteOne = testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1}, "http",
+				"", "default")
+			pathMatchHttpRouteTwo = testFramework.NewPathMatchHttpRoute(gateway, []client.Object{service1, service2}, "http",
+				"", "default")
+
+			// Create Kubernetes Resources
+			testFramework.ExpectCreated(ctx,
+				gateway,
+				pathMatchHttpRouteOne,
+				service1,
+				deployment1,
+				service2,
+				deployment2,
+			)
+
+			log.Println("service1.Name: ", service1.Name)
+			log.Println("service2.Name: ", service2.Name)
+			log.Println(fmt.Sprintf("Waiting %s for Amazon VPC Lattice resource creation.", resourceCreationWaitTime))
+			time.Sleep(resourceCreationWaitTime)
+
+			service1TgFound := false
+			service2TgFound := false
+
+			targetGroups, err := testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				log.Println("targetGroup.Name: ", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+			}
+			Expect(service1TgFound).To(BeTrue())
+			Expect(service2TgFound).To(BeFalse())
+
+			testFramework.ExpectCreated(ctx,
+				pathMatchHttpRouteTwo,
+			)
+			testFramework.Get(ctx, types.NamespacedName{Name: pathMatchHttpRouteTwo.Name, Namespace: pathMatchHttpRouteTwo.Namespace}, pathMatchHttpRouteTwo)
+
+			log.Println("Will update the pathMatchHttpRoute to backendRefs to service1 and service2")
+			testFramework.Update(ctx, pathMatchHttpRouteTwo)
+			time.Sleep(30 * time.Second)
+
+			service1TgFound = false
+			service2TgFound = false
+			targetGroups, err = testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			log.Println("Retrieved target groups:", len(targetGroups))
+			Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				log.Println("targetGroup.Name:", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+			}
+			Expect(service1TgFound).To(BeTrue())
+			Expect(service2TgFound).To(BeTrue())
+
+			testFramework.Get(ctx, types.NamespacedName{Name: pathMatchHttpRouteOne.Name, Namespace: pathMatchHttpRouteOne.Namespace}, pathMatchHttpRouteOne)
+
+			log.Println("Will update the pathMatchHttpRoute to backendRefs to just service2")
+
+			// Remove pathMatchHttpRouteTwo for service2 so service is free to use again
+			testFramework.Update(ctx, pathMatchHttpRouteOne)
+			testFramework.ExpectDeleted(ctx, pathMatchHttpRouteTwo)
+			testFramework.EventuallyExpectNotFound(ctx, pathMatchHttpRouteTwo)
+
+			pathMatchHttpRouteOne.Spec.Rules[0].BackendRefs[0].BackendObjectReference.Name = v1beta1.ObjectName(service2.Name)
+			testFramework.Update(ctx, pathMatchHttpRouteOne)
+			time.Sleep(30 * time.Second)
+
+			service1TgFound = false
+			service2TgFound = false
+			targetGroups, err = testFramework.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+			log.Println("Retrieved target groups:", len(targetGroups))
+			Expect(err).To(BeNil())
+			for _, targetGroup := range targetGroups {
+				log.Println("targetGroup.Name: ", *targetGroup.Name)
+
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service1.Name, service1.Namespace) {
+					service1TgFound = true
+				}
+				if lo.FromPtr(targetGroup.Name) == latticestore.TargetGroupName(service2.Name, service2.Namespace) {
+					service2TgFound = true
+				}
+			}
+			Expect(service1TgFound).To(BeFalse())
+			Expect(service2TgFound).To(BeTrue())
+		})
+	})
+
+	AfterEach(func() {
+		testFramework.CleanTestEnvironment(ctx)
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**
Feature, additional HTTPRoute E2E Tests

**Which issue does this PR fix**:
#273

**What does this PR do / Why do we need it**:
Adds HTTPRoute creation/update E2E tests to improve test coverage

**Testing done on this change**:
```
FOCUS="" make e2etest

...

------------------------------

Ran 11 of 11 Specs in 4656.643 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (4656.81s)
PASS
```

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
This will not break upgrades or downgrades. These changes were tested on the latest v0.0.15 release.

**Does this PR introduce any user-facing change?**:
No, only additional E2E tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.