### PR TITLE
Abstract Routes to Support Multiple Route Types

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -309,7 +309,7 @@ func (r *GatewayReconciler) updateGatewayAcceptStatus(ctx context.Context, gw *g
 	return nil
 }
 
-func UpdateHTTPRouteListenerStatus(ctx context.Context, k8sclient client.Client, httproute *gateway_api.HTTPRoute) error {
+func UpdateHTTPRouteListenerStatus(ctx context.Context, k8sclient client.Client, httproute core.HTTPRoute) error {
 	gw := &gateway_api.Gateway{}
 
 	gwNamespace := httproute.Namespace

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -309,7 +309,7 @@ func (r *GatewayReconciler) updateGatewayAcceptStatus(ctx context.Context, gw *g
 	return nil
 }
 
-func UpdateHTTPRouteListenerStatus(ctx context.Context, k8sclient client.Client, httproute core.HTTPRoute) error {
+func UpdateHTTPRouteListenerStatus(ctx context.Context, k8sclient client.Client, httproute *core.HTTPRoute) error {
 	gw := &gateway_api.Gateway{}
 
 	gwNamespace := httproute.Namespace

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -312,18 +312,18 @@ func (r *GatewayReconciler) updateGatewayAcceptStatus(ctx context.Context, gw *g
 func UpdateHTTPRouteListenerStatus(ctx context.Context, k8sclient client.Client, httproute *core.HTTPRoute) error {
 	gw := &gateway_api.Gateway{}
 
-	gwNamespace := httproute.Namespace
-	if httproute.Spec.ParentRefs[0].Namespace != nil {
-		gwNamespace = string(*httproute.Spec.ParentRefs[0].Namespace)
+	gwNamespace := httproute.Namespace()
+	if httproute.Spec().ParentRefs()[0].Namespace != nil {
+		gwNamespace = string(*httproute.Spec().ParentRefs()[0].Namespace)
 	}
 	gwName := types.NamespacedName{
 		Namespace: gwNamespace,
 		// TODO assume one parent for now and point to service network
-		Name: string(httproute.Spec.ParentRefs[0].Name),
+		Name: string(httproute.Spec().ParentRefs()[0].Name),
 	}
 
 	if err := k8sclient.Get(ctx, gwName, gw); err != nil {
-		glog.V(2).Infof("Failed to update gateway listener status due to gatewag not found for %v\n", httproute.Spec)
+		glog.V(2).Infof("Failed to update gateway listener status due to gatewag not found for %v\n", httproute.Spec())
 		return errors.New("gateway not found")
 	}
 

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -134,7 +134,7 @@ func (r *HTTPRouteReconciler) reconcile(ctx context.Context, req ctrl.Request) e
 			return err
 		}
 		UpdateHTTPRouteListenerStatus(ctx, r.Client, httpRoute)
-		r.finalizerManager.RemoveFinalizers(ctx, &httpRoute, httpRouteFinalizer)
+		r.finalizerManager.RemoveFinalizers(ctx, &httpRoute.HTTPRoute, httpRouteFinalizer)
 
 		// TODO delete metrics
 		return nil

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -158,7 +158,7 @@ func (r *HTTPRouteReconciler) cleanupHTTPRouteResources(ctx context.Context, htt
 
 func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute *core.HTTPRoute) bool {
 	if len(httpRoute.Spec().ParentRefs()) == 0 {
-		glog.V(2).Infof("Ignore HTTPRoute which has no ParentRefs gateway %v \n ", httpRoute.Spec)
+		glog.V(2).Infof("Ignore HTTPRoute which has no ParentRefs gateway %v \n ", httpRoute.Spec())
 		return false
 	}
 
@@ -175,7 +175,7 @@ func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute
 
 	if err := r.gwReconciler.Client.Get(ctx, gwName, gw); err != nil {
 		glog.V(6).Infof("Could not find gateway %s: %s\n", gwName.String(), err.Error())
-		glog.V(6).Infof("Ignore HTTPRoute whose ParentRef gatway object has NOT defined yet for %v\n", httpRoute.Spec)
+		glog.V(6).Infof("Ignore HTTPRoute whose ParentRef gatway object has NOT defined yet for %v\n", httpRoute.Spec())
 		return false
 	}
 
@@ -187,16 +187,16 @@ func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute
 	}
 
 	if err := r.gwClassReconciler.Client.Get(ctx, gwClassName, gwClass); err != nil {
-		glog.V(6).Infof("Ignore HTTPRoute that NOT controlled by any GatewayClass for %v\n", httpRoute.Spec)
+		glog.V(6).Infof("Ignore HTTPRoute that NOT controlled by any GatewayClass for %v\n", httpRoute.Spec())
 		return false
 	}
 
 	if gwClass.Spec.ControllerName == config.LatticeGatewayControllerName {
-		glog.V(6).Infof("Found aws-vpc-lattice for HTTPRoute for %v\n", httpRoute.Spec)
+		glog.V(6).Infof("Found aws-vpc-lattice for HTTPRoute for %v\n", httpRoute.Spec())
 
 		return true
 	} else {
-		glog.V(6).Infof("Ignore non aws-vpc-lattice HTTPRoute !!! %v\n", httpRoute.Spec)
+		glog.V(6).Infof("Ignore non aws-vpc-lattice HTTPRoute !!! %v\n", httpRoute.Spec())
 		return false
 	}
 }

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -114,9 +114,9 @@ func (r *HTTPRouteReconciler) reconcile(ctx context.Context, req ctrl.Request) e
 	// TODO(user): your logic here
 	httpLog.Info("HTTPRouteReconciler")
 
-	httpRoute := &gateway_api.HTTPRoute{}
+	httpRoute := core.HTTPRoute{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, httpRoute); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, &httpRoute.HTTPRoute); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
@@ -127,20 +127,20 @@ func (r *HTTPRouteReconciler) reconcile(ctx context.Context, req ctrl.Request) e
 
 	if !httpRoute.DeletionTimestamp.IsZero() {
 		httpLog.Info("Deleting")
-		r.eventRecorder.Event(httpRoute, corev1.EventTypeNormal,
+		r.eventRecorder.Event(httpRoute.GetRuntimeObject(), corev1.EventTypeNormal,
 			k8s.HTTPRouteeventReasonReconcile, "Deleting Reconcile")
 		if err := r.cleanupHTTPRouteResources(ctx, httpRoute); err != nil {
 			glog.V(6).Infof("Failed to cleanup HTTPRoute %v err %v\n", httpRoute, err)
 			return err
 		}
 		UpdateHTTPRouteListenerStatus(ctx, r.Client, httpRoute)
-		r.finalizerManager.RemoveFinalizers(ctx, httpRoute, httpRouteFinalizer)
+		r.finalizerManager.RemoveFinalizers(ctx, &httpRoute, httpRouteFinalizer)
 
 		// TODO delete metrics
 		return nil
 	} else {
 		httpLog.Info("Adding/Updating")
-		r.eventRecorder.Event(httpRoute, corev1.EventTypeNormal,
+		r.eventRecorder.Event(httpRoute.GetRuntimeObject(), corev1.EventTypeNormal,
 			k8s.HTTPRouteeventReasonReconcile, "Adding/Updating Reconcile")
 		err := r.reconcileHTTPRouteResource(ctx, httpRoute)
 		// TODO add/update metrics
@@ -149,14 +149,14 @@ func (r *HTTPRouteReconciler) reconcile(ctx context.Context, req ctrl.Request) e
 
 }
 
-func (r *HTTPRouteReconciler) cleanupHTTPRouteResources(ctx context.Context, httpRoute *gateway_api.HTTPRoute) error {
+func (r *HTTPRouteReconciler) cleanupHTTPRouteResources(ctx context.Context, httpRoute core.Route) error {
 
 	_, _, err := r.buildAndDeployModel(ctx, httpRoute)
 
 	return err
 }
 
-func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute *gateway_api.HTTPRoute) bool {
+func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute core.HTTPRoute) bool {
 
 	if len(httpRoute.Spec.ParentRefs) == 0 {
 		glog.V(2).Infof("Ignore HTTPRoute which has no ParentRefs gateway %v \n ", httpRoute.Spec)
@@ -202,16 +202,16 @@ func (r *HTTPRouteReconciler) isHTTPRouteRelevant(ctx context.Context, httpRoute
 	}
 }
 
-func (r *HTTPRouteReconciler) buildAndDeployModel(ctx context.Context, httproute *gateway_api.HTTPRoute) (core.Stack, *latticemodel.Service, error) {
+func (r *HTTPRouteReconciler) buildAndDeployModel(ctx context.Context, route core.Route) (core.Stack, *latticemodel.Service, error) {
 	httpLog := log.FromContext(ctx)
 
-	stack, latticeService, err := r.modelBuilder.Build(ctx, httproute)
+	stack, latticeService, err := r.modelBuilder.Build(ctx, route)
 
 	if err != nil {
 
-		r.eventRecorder.Event(httproute, corev1.EventTypeWarning,
+		r.eventRecorder.Event(route.GetRuntimeObject(), corev1.EventTypeWarning,
 			k8s.HTTPRouteEventReasonFailedBuildModel, fmt.Sprintf("Failed build model due to %v", err))
-		glog.V(6).Infof("buildAndDeployModel, Failed build model for %v due to %v\n", httproute.Name, err)
+		glog.V(6).Infof("buildAndDeployModel, Failed build model for %v due to %v\n", route.GetName(), err)
 
 		// Build failed
 		// TODO continue deploy to trigger reconsile of stale HTTProute and policy
@@ -227,16 +227,16 @@ func (r *HTTPRouteReconciler) buildAndDeployModel(ctx context.Context, httproute
 	httpLog.Info("Successfully built model:", stackJSON, "")
 
 	if err := r.stackDeployer.Deploy(ctx, stack); err != nil {
-		glog.V(6).Infof("HTTPRouteReconciler: Failed deploy %s due to err %v \n", httproute.Name, err)
+		glog.V(6).Infof("HTTPRouteReconciler: Failed deploy %s due to err %v \n", route.GetName(), err)
 
 		var retryErr = errors.New(lattice.LATTICE_RETRY)
 
 		if errors.As(err, &retryErr) {
-			r.eventRecorder.Event(httproute, corev1.EventTypeNormal,
+			r.eventRecorder.Event(route.GetRuntimeObject(), corev1.EventTypeNormal,
 				k8s.HTTPRouteEventReasonRetryReconcile, "retry reconcile...")
 
 		} else {
-			r.eventRecorder.Event(httproute, corev1.EventTypeWarning,
+			r.eventRecorder.Event(route.GetRuntimeObject(), corev1.EventTypeWarning,
 				k8s.HTTPRouteEventReasonFailedDeployModel, fmt.Sprintf("Failed deploy model due to %v", err))
 		}
 		return nil, nil, err
@@ -247,25 +247,25 @@ func (r *HTTPRouteReconciler) buildAndDeployModel(ctx context.Context, httproute
 	return stack, latticeService, err
 }
 
-func (r *HTTPRouteReconciler) reconcileHTTPRouteResource(ctx context.Context, httproute *gateway_api.HTTPRoute) error {
-	glog.V(6).Infof("Beginning -- reconcileHTTPRouteResource, [%v]\n", httproute)
+func (r *HTTPRouteReconciler) reconcileHTTPRouteResource(ctx context.Context, httpRoute core.HTTPRoute) error {
+	glog.V(6).Infof("Beginning -- reconcileHTTPRouteResource, [%v]\n", httpRoute)
 
-	if err := r.finalizerManager.AddFinalizers(ctx, httproute, httpRouteFinalizer); err != nil {
-		r.eventRecorder.Event(httproute, corev1.EventTypeWarning, k8s.HTTPRouteventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
+	if err := r.finalizerManager.AddFinalizers(ctx, &httpRoute.HTTPRoute, httpRouteFinalizer); err != nil {
+		r.eventRecorder.Event(httpRoute.GetRuntimeObject(), corev1.EventTypeWarning, k8s.HTTPRouteventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
 	}
 
-	_, _, err := r.buildAndDeployModel(ctx, httproute)
+	_, _, err := r.buildAndDeployModel(ctx, httpRoute)
 
 	//TODO add metric
 
 	if err == nil {
-		r.eventRecorder.Event(httproute, corev1.EventTypeNormal,
+		r.eventRecorder.Event(httpRoute.GetRuntimeObject(), corev1.EventTypeNormal,
 			k8s.HTTPRouteeventReasonDeploySucceed, "Adding/Updating reconcile Done!")
 
-		serviceStatus, err1 := r.latticeDataStore.GetLatticeService(httproute.Name, httproute.Namespace)
+		serviceStatus, err1 := r.latticeDataStore.GetLatticeService(httpRoute.Name, httpRoute.Namespace)
 
 		if err1 == nil {
-			r.updateHTTPRouteStatus(ctx, serviceStatus.DNS, httproute)
+			r.updateHTTPRouteStatus(ctx, serviceStatus.DNS, httpRoute)
 		}
 	}
 
@@ -273,63 +273,63 @@ func (r *HTTPRouteReconciler) reconcileHTTPRouteResource(ctx context.Context, ht
 
 }
 
-func (r *HTTPRouteReconciler) updateHTTPRouteStatus(ctx context.Context, dns string, httproute *gateway_api.HTTPRoute) error {
-	glog.V(6).Infof("updateHTTPRouteStatus: httproute %v, dns %v\n", httproute, dns)
-	httprouteOld := httproute.DeepCopy()
+func (r *HTTPRouteReconciler) updateHTTPRouteStatus(ctx context.Context, dns string, httpRoute core.HTTPRoute) error {
+	glog.V(6).Infof("updateHTTPRouteStatus: httpRoute %v, dns %v\n", httpRoute, dns)
+	httprouteOld := httpRoute.HTTPRoute.DeepCopy()
 
-	if len(httproute.ObjectMeta.Annotations) == 0 {
-		httproute.ObjectMeta.Annotations = make(map[string]string)
+	if len(httpRoute.ObjectMeta.Annotations) == 0 {
+		httpRoute.ObjectMeta.Annotations = make(map[string]string)
 	}
 
-	httproute.ObjectMeta.Annotations[LatticeAssignedDomainName] = dns
-	if err := r.Client.Patch(ctx, httproute, client.MergeFrom(httprouteOld)); err != nil {
+	httpRoute.ObjectMeta.Annotations[LatticeAssignedDomainName] = dns
+	if err := r.Client.Patch(ctx, &httpRoute.HTTPRoute, client.MergeFrom(httprouteOld)); err != nil {
 		glog.V(2).Infof("updateHTTPRouteStatus: Patch() received err %v \n", err)
-		return errors.Wrapf(err, "failed to update httproute status")
+		return errors.Wrapf(err, "failed to update httpRoute status")
 	}
-	httprouteOld = httproute.DeepCopy()
+	httprouteOld = httpRoute.HTTPRoute.DeepCopy()
 
-	if len(httproute.Status.RouteStatus.Parents) == 0 {
-		httproute.Status.RouteStatus.Parents = make([]gateway_api.RouteParentStatus, 1)
+	if len(httpRoute.Status.RouteStatus.Parents) == 0 {
+		httpRoute.Status.RouteStatus.Parents = make([]gateway_api.RouteParentStatus, 1)
 	}
-	httproute.Status.RouteStatus.Parents[0].ParentRef = httproute.Spec.ParentRefs[0]
-	httproute.Status.RouteStatus.Parents[0].ControllerName = config.LatticeGatewayControllerName
+	httpRoute.Status.RouteStatus.Parents[0].ParentRef = httpRoute.Spec.ParentRefs[0]
+	httpRoute.Status.RouteStatus.Parents[0].ControllerName = config.LatticeGatewayControllerName
 
 	// Update listener Status
-	if err := UpdateHTTPRouteListenerStatus(ctx, r.Client, httproute); err != nil {
-		updateRouteCondition(httproute, metav1.Condition{
+	if err := UpdateHTTPRouteListenerStatus(ctx, r.Client, httpRoute); err != nil {
+		updateRouteCondition(httpRoute, metav1.Condition{
 			Type:               string(gateway_api.RouteConditionAccepted),
 			Status:             metav1.ConditionFalse,
-			ObservedGeneration: httproute.Generation,
+			ObservedGeneration: httpRoute.Generation,
 			Reason:             string(gateway_api.RouteReasonNoMatchingParent),
-			Message:            fmt.Sprintf("Could not match gateway %s: %s", httproute.Spec.ParentRefs[0].Name, err.Error()),
+			Message:            fmt.Sprintf("Could not match gateway %s: %s", httpRoute.Spec.ParentRefs[0].Name, err.Error()),
 		})
 	} else {
-		updateRouteCondition(httproute, metav1.Condition{
+		updateRouteCondition(httpRoute, metav1.Condition{
 			Type:               string(gateway_api.RouteConditionAccepted),
 			Status:             metav1.ConditionTrue,
-			ObservedGeneration: httproute.Generation,
+			ObservedGeneration: httpRoute.Generation,
 			Reason:             string(gateway_api.RouteReasonAccepted),
 			Message:            fmt.Sprintf("DNS Name: %s", dns),
 		})
-		updateRouteCondition(httproute, metav1.Condition{
+		updateRouteCondition(httpRoute, metav1.Condition{
 			Type:               string(gateway_api.RouteConditionResolvedRefs),
 			Status:             metav1.ConditionTrue,
-			ObservedGeneration: httproute.Generation,
+			ObservedGeneration: httpRoute.Generation,
 			Reason:             string(gateway_api.RouteReasonResolvedRefs),
 			Message:            fmt.Sprintf("DNS Name: %s", dns),
 		})
 	}
 
-	if err := r.Client.Status().Patch(ctx, httproute, client.MergeFrom(httprouteOld)); err != nil {
+	if err := r.Client.Status().Patch(ctx, &httpRoute.HTTPRoute, client.MergeFrom(httprouteOld)); err != nil {
 		glog.V(2).Infof("updateHTTPRouteStatus: Patch() received err %v \n", err)
-		return errors.Wrapf(err, "failed to update httproute status")
+		return errors.Wrapf(err, "failed to update httpRoute status")
 	}
 	glog.V(6).Infof("updateHTTPRouteStatus patched dns %v \n", dns)
 
 	return nil
 }
 
-func updateRouteCondition(httproute *gateway_api.HTTPRoute, updated metav1.Condition) {
+func updateRouteCondition(httproute core.HTTPRoute, updated metav1.Condition) {
 	httproute.Status.RouteStatus.Parents[0].Conditions = updateCondition(httproute.Status.RouteStatus.Parents[0].Conditions, updated)
 }
 

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -5,14 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"github.com/golang/glog"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	lattice_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
@@ -23,7 +21,7 @@ const (
 )
 
 type LatticeServiceBuilder interface {
-	Build(ctx context.Context, httpRoute *gateway_api.HTTPRoute) (core.Stack, *latticemodel.Service, error)
+	Build(ctx context.Context, httpRoute core.Route) (core.Stack, *latticemodel.Service, error)
 }
 
 type latticeServiceModelBuilder struct {
@@ -43,11 +41,11 @@ func NewLatticeServiceBuilder(client client.Client, datastore *latticestore.Latt
 }
 
 // TODO  right now everything is around HTTPRoute,  future, this might need to refactor for TLSRoute
-func (b *latticeServiceModelBuilder) Build(ctx context.Context, httpRoute *gateway_api.HTTPRoute) (core.Stack, *latticemodel.Service, error) {
+func (b *latticeServiceModelBuilder) Build(ctx context.Context, httpRoute core.Route) (core.Stack, *latticemodel.Service, error) {
 	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(httpRoute)))
 
 	task := &latticeServiceModelBuildTask{
-		httpRoute: httpRoute,
+		route:     httpRoute,
 		stack:     stack,
 		Client:    b.Client,
 		tgByResID: make(map[string]*latticemodel.TargetGroup),
@@ -83,8 +81,8 @@ func (t *latticeServiceModelBuildTask) buildModel(ctx context.Context) error {
 		return err
 	}
 
-	if !t.httpRoute.DeletionTimestamp.IsZero() {
-		glog.V(2).Infof("latticeServiceModelBuildTask: for delete ignore Targets, policy %v\n", t.httpRoute)
+	if !t.route.GetDeletionTimestamp().IsZero() {
+		glog.V(2).Infof("latticeServiceModelBuildTask: for delete ignore Targets, policy %v\n", t.route)
 		return nil
 	}
 
@@ -115,40 +113,39 @@ func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) 
 	pro := "HTTP"
 	protocols := []*string{&pro}
 	spec := latticemodel.ServiceSpec{
-		Name:      t.httpRoute.Name,
-		Namespace: t.httpRoute.Namespace,
+		Name:      t.route.GetName(),
+		Namespace: t.route.GetNamespace(),
 		Protocols: protocols,
 		//ServiceNetworkNames: string(t.httpRoute.Spec.ParentRefs[0].Name),
 	}
 
-	for _, parentRef := range t.httpRoute.Spec.ParentRefs {
+	for _, parentRef := range t.route.GetSpec().GetParentRefs() {
 		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, string(parentRef.Name))
-
 	}
 	defaultGateway, err := config.GetClusterLocalGateway()
 	if err == nil {
 		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, defaultGateway)
 	}
 
-	if len(t.httpRoute.Spec.Hostnames) > 0 {
+	if len(t.route.GetSpec().GetHostnames()) > 0 {
 		// The 1st hostname will be used as lattice customer-domain-name
-		spec.CustomerDomainName = string(t.httpRoute.Spec.Hostnames[0])
+		spec.CustomerDomainName = string(t.route.GetSpec().GetHostnames()[0])
 
 		glog.V(2).Infof("Setting customer-domain-name: %v for httpRoute %v-%v",
-			spec.CustomerDomainName, t.httpRoute.Name, t.httpRoute.Namespace)
+			spec.CustomerDomainName, t.route.GetName(), t.route.GetNamespace())
 	} else {
 		glog.V(2).Infof("No custom-domain-name for httproute :%v-%v",
-			t.httpRoute.Name, t.httpRoute.Namespace)
+			t.route.GetName(), t.route.GetNamespace())
 		spec.CustomerDomainName = ""
 	}
 
-	if t.httpRoute.DeletionTimestamp.IsZero() {
+	if t.route.GetDeletionTimestamp().IsZero() {
 		spec.IsDeleted = false
 	} else {
 		spec.IsDeleted = true
 	}
 
-	serviceResourceName := fmt.Sprintf("%s-%s", t.httpRoute.Name, t.httpRoute.Namespace)
+	serviceResourceName := fmt.Sprintf("%s-%s", t.route.GetName(), t.route.GetNamespace())
 
 	t.latticeService = latticemodel.NewLatticeService(t.stack, serviceResourceName, spec)
 
@@ -156,7 +153,7 @@ func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) 
 }
 
 type latticeServiceModelBuildTask struct {
-	httpRoute *gateway_api.HTTPRoute
+	route core.Route
 	client.Client
 
 	latticeService  *latticemodel.Service

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -40,12 +40,11 @@ func NewLatticeServiceBuilder(client client.Client, datastore *latticestore.Latt
 	}
 }
 
-// TODO  right now everything is around HTTPRoute,  future, this might need to refactor for TLSRoute
-func (b *latticeServiceModelBuilder) Build(ctx context.Context, httpRoute core.Route) (core.Stack, *latticemodel.Service, error) {
-	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(httpRoute)))
+func (b *latticeServiceModelBuilder) Build(ctx context.Context, route core.Route) (core.Stack, *latticemodel.Service, error) {
+	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(route)))
 
 	task := &latticeServiceModelBuildTask{
-		route:     httpRoute,
+		route:     route,
 		stack:     stack,
 		Client:    b.Client,
 		tgByResID: make(map[string]*latticemodel.TargetGroup),
@@ -116,7 +115,7 @@ func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) 
 		Name:      t.route.GetName(),
 		Namespace: t.route.GetNamespace(),
 		Protocols: protocols,
-		//ServiceNetworkNames: string(t.httpRoute.Spec.ParentRefs[0].Name),
+		//ServiceNetworkNames: string(t.route.GetSpec().GetParentRefs()[0].Name),
 	}
 
 	for _, parentRef := range t.route.GetSpec().GetParentRefs() {

--- a/pkg/gateway/model_build_lattice_service_test.go
+++ b/pkg/gateway/model_build_lattice_service_test.go
@@ -58,7 +58,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService with hostname",
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -75,7 +75,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 						"test2.test.com",
 					},
 				},
-			}},
+			}),
 
 			wantError:     nil,
 			wantName:      "service1",
@@ -84,7 +84,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService",
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -97,7 +97,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 
 			wantError:     nil,
 			wantName:      "service1",
@@ -106,7 +106,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
@@ -134,7 +134,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 
 			wantError:     nil,
 			wantName:      "service2",
@@ -156,7 +156,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			//builder := NewLatticeServiceBuilder(k8sClient, ds, nil)
 
-			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route)))
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
 			task := &latticeServiceModelBuildTask{
 				route:     tt.route,
@@ -183,11 +183,11 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			} else {
 				assert.Equal(t, false, task.latticeService.Spec.IsDeleted)
-				assert.Equal(t, tt.route.GetName(), task.latticeService.Spec.Name)
-				assert.Equal(t, tt.route.GetNamespace(), task.latticeService.Spec.Namespace)
+				assert.Equal(t, tt.route.Name(), task.latticeService.Spec.Name)
+				assert.Equal(t, tt.route.Namespace(), task.latticeService.Spec.Namespace)
 
-				if len(tt.route.GetSpec().GetHostnames()) > 0 {
-					assert.Equal(t, string(tt.route.GetSpec().GetHostnames()[0]), task.latticeService.Spec.CustomerDomainName)
+				if len(tt.route.Spec().Hostnames()) > 0 {
+					assert.Equal(t, string(tt.route.Spec().Hostnames()[0]), task.latticeService.Spec.CustomerDomainName)
 				} else {
 					assert.Equal(t, "", task.latticeService.Spec.CustomerDomainName)
 				}

--- a/pkg/gateway/model_build_lattice_service_test.go
+++ b/pkg/gateway/model_build_lattice_service_test.go
@@ -50,7 +50,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		httpRoute     *gateway_api.HTTPRoute
+		route         core.Route
 		wantError     error
 		wantErrIsNil  bool
 		wantName      string
@@ -58,7 +58,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService with hostname",
-			httpRoute: &gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -75,7 +75,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 						"test2.test.com",
 					},
 				},
-			},
+			}},
 
 			wantError:     nil,
 			wantName:      "service1",
@@ -84,7 +84,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService",
-			httpRoute: &gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -97,7 +97,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 
 			wantError:     nil,
 			wantName:      "service1",
@@ -106,7 +106,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			httpRoute: &gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
@@ -134,7 +134,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 
 			wantError:     nil,
 			wantName:      "service2",
@@ -156,10 +156,10 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			//builder := NewLatticeServiceBuilder(k8sClient, ds, nil)
 
-			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.httpRoute)))
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route)))
 
 			task := &latticeServiceModelBuildTask{
-				httpRoute: tt.httpRoute,
+				route:     tt.route,
 				stack:     stack,
 				Client:    k8sClient,
 				tgByResID: make(map[string]*latticemodel.TargetGroup),
@@ -183,11 +183,11 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			} else {
 				assert.Equal(t, false, task.latticeService.Spec.IsDeleted)
-				assert.Equal(t, tt.httpRoute.Name, task.latticeService.Spec.Name)
-				assert.Equal(t, tt.httpRoute.Namespace, task.latticeService.Spec.Namespace)
+				assert.Equal(t, tt.route.GetName(), task.latticeService.Spec.Name)
+				assert.Equal(t, tt.route.GetNamespace(), task.latticeService.Spec.Namespace)
 
-				if len(tt.httpRoute.Spec.Hostnames) > 0 {
-					assert.Equal(t, string(tt.httpRoute.Spec.Hostnames[0]), task.latticeService.Spec.CustomerDomainName)
+				if len(tt.route.GetSpec().GetHostnames()) > 0 {
+					assert.Equal(t, string(tt.route.GetSpec().GetHostnames()[0]), task.latticeService.Spec.CustomerDomainName)
 				} else {
 					assert.Equal(t, "", task.latticeService.Spec.CustomerDomainName)
 				}

--- a/pkg/gateway/model_build_lattice_service_test.go
+++ b/pkg/gateway/model_build_lattice_service_test.go
@@ -58,7 +58,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService with hostname",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -84,7 +84,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -106,7 +106,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},

--- a/pkg/gateway/model_build_listener.go
+++ b/pkg/gateway/model_build_listener.go
@@ -19,24 +19,24 @@ const (
 	awsCustomCertARN = "application-networking.k8s.aws/certificate-arn"
 )
 
-func (t *latticeServiceModelBuildTask) extractListnerInfo(ctx context.Context, parentRef gateway_api.ParentReference) (int64, string, string, error) {
+func (t *latticeServiceModelBuildTask) extractListenerInfo(ctx context.Context, parentRef gateway_api.ParentReference) (int64, string, string, error) {
 
 	var protocol gateway_api.ProtocolType = gateway_api.HTTPProtocolType
 	if parentRef.SectionName != nil {
 		glog.V(6).Infof("HTTP SectionName %s \n", *parentRef.SectionName)
 	}
 
-	glog.V(6).Infof("Building Listener for HTTPRoute Name %s NameSpace %s\n", t.httpRoute.Name, t.httpRoute.Namespace)
-	var gwNamespace = t.httpRoute.Namespace
-	if t.httpRoute.Spec.ParentRefs[0].Namespace != nil {
-		gwNamespace = string(*t.httpRoute.Spec.ParentRefs[0].Namespace)
+	glog.V(6).Infof("Building Listener for HTTPRoute Name %s NameSpace %s\n", t.route.GetName(), t.route.GetNamespace())
+	var gwNamespace = t.route.GetNamespace()
+	if t.route.GetSpec().GetParentRefs()[0].Namespace != nil {
+		gwNamespace = string(*t.route.GetSpec().GetParentRefs()[0].Namespace)
 	}
-	glog.V(6).Infof("build Listener, Parent Name %s Namespace %s\n", t.httpRoute.Spec.ParentRefs[0].Name, gwNamespace)
+	glog.V(6).Infof("build Listener, Parent Name %s Namespace %s\n", t.route.GetSpec().GetParentRefs()[0].Name, gwNamespace)
 	var listenerPort = 0
 	gw := &gateway_api.Gateway{}
 	gwName := types.NamespacedName{
 		Namespace: gwNamespace,
-		Name:      string(t.httpRoute.Spec.ParentRefs[0].Name),
+		Name:      string(t.route.GetSpec().GetParentRefs()[0].Name),
 	}
 
 	if err := t.Client.Get(ctx, gwName, gw); err != nil {
@@ -93,8 +93,8 @@ func (t *latticeServiceModelBuildTask) extractListnerInfo(ctx context.Context, p
 
 func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error {
 
-	for _, parentRef := range t.httpRoute.Spec.ParentRefs {
-		if parentRef.Name != t.httpRoute.Spec.ParentRefs[0].Name {
+	for _, parentRef := range t.route.GetSpec().GetParentRefs() {
+		if parentRef.Name != t.route.GetSpec().GetParentRefs()[0].Name {
 			// when a service is associate to multiple service network(s), all listener config MUST be same
 			// so here we are only using the 1st gateway
 			glog.V(2).Infof("Ignore parentref of different gateway %v", parentRef.Name)
@@ -102,7 +102,7 @@ func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error 
 			continue
 		}
 
-		port, protocol, certARN, err := t.extractListnerInfo(ctx, parentRef)
+		port, protocol, certARN, err := t.extractListenerInfo(ctx, parentRef)
 
 		if err != nil {
 			glog.V(6).Infof("Error on buildListener %v\n", err)
@@ -114,38 +114,38 @@ func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error 
 
 		glog.V(6).Infof("Building Listener: found matching listner Port %v\n", port)
 
-		if len(t.httpRoute.Spec.Rules) == 0 {
-			glog.V(6).Infof("Error building listener, there is no rules for %v \n", t.httpRoute)
+		if len(t.route.GetSpec().GetRules()) == 0 {
+			glog.V(6).Infof("Error building listener, there is no rules for %v \n", t.route)
 			return errors.New("Error building listener, there are no rules")
 		}
 
-		rule := t.httpRoute.Spec.Rules[0]
+		rule := t.route.GetSpec().GetRules()[0]
 
-		if len(rule.BackendRefs) == 0 {
-			glog.V(6).Infof("Error building listener, there is no backend refs for %v \n", t.httpRoute)
+		if len(rule.GetBackendRefs()) == 0 {
+			glog.V(6).Infof("Error building listener, there is no backend refs for %v \n", t.route)
 			return errors.New("Error building listener, there are no backend refs")
 		}
 
-		httpBackendRef := rule.BackendRefs[0]
+		httpBackendRef := rule.GetBackendRefs()[0]
 
 		var is_import = false
 		var targetgroupName = ""
-		var targetgroupNamespace = t.httpRoute.Namespace
+		var targetgroupNamespace = t.route.GetNamespace()
 
-		if string(*httpBackendRef.Kind) == "Service" {
-			if httpBackendRef.BackendObjectReference.Namespace != nil {
-				targetgroupNamespace = string(*httpBackendRef.BackendObjectReference.Namespace)
+		if string(*httpBackendRef.GetKind()) == "Service" {
+			if httpBackendRef.GetNamespace() != nil {
+				targetgroupNamespace = string(*httpBackendRef.GetNamespace())
 			}
-			targetgroupName = string(httpBackendRef.BackendObjectReference.Name)
+			targetgroupName = string(httpBackendRef.GetName())
 			is_import = false
 		}
 
-		if string(*httpBackendRef.Kind) == "ServiceImport" {
+		if string(*httpBackendRef.GetKind()) == "ServiceImport" {
 			is_import = true
-			if httpBackendRef.BackendObjectReference.Namespace != nil {
-				targetgroupNamespace = string(*httpBackendRef.BackendObjectReference.Namespace)
+			if httpBackendRef.GetNamespace() != nil {
+				targetgroupNamespace = string(*httpBackendRef.GetNamespace())
 			}
-			targetgroupName = string(httpBackendRef.BackendObjectReference.Name)
+			targetgroupName = string(httpBackendRef.GetName())
 		}
 
 		action := latticemodel.DefaultAction{
@@ -154,10 +154,10 @@ func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error 
 			BackendServiceNamespace: targetgroupNamespace,
 		}
 
-		listenerResourceName := fmt.Sprintf("%s-%s-%d-%s", t.httpRoute.Name, t.httpRoute.Namespace, port, protocol)
+		listenerResourceName := fmt.Sprintf("%s-%s-%d-%s", t.route.GetName(), t.route.GetNamespace(), port, protocol)
 		glog.V(6).Infof("listenerResourceName : %v \n", listenerResourceName)
 
-		latticemodel.NewListener(t.stack, listenerResourceName, port, protocol, t.httpRoute.Name, t.httpRoute.Namespace, action)
+		latticemodel.NewListener(t.stack, listenerResourceName, port, protocol, t.route.GetName(), t.route.GetNamespace(), action)
 	}
 
 	return nil

--- a/pkg/gateway/model_build_listener.go
+++ b/pkg/gateway/model_build_listener.go
@@ -26,17 +26,17 @@ func (t *latticeServiceModelBuildTask) extractListenerInfo(ctx context.Context, 
 		glog.V(6).Infof("HTTP SectionName %s \n", *parentRef.SectionName)
 	}
 
-	glog.V(6).Infof("Building Listener for HTTPRoute Name %s NameSpace %s\n", t.route.GetName(), t.route.GetNamespace())
-	var gwNamespace = t.route.GetNamespace()
-	if t.route.GetSpec().GetParentRefs()[0].Namespace != nil {
-		gwNamespace = string(*t.route.GetSpec().GetParentRefs()[0].Namespace)
+	glog.V(6).Infof("Building Listener for HTTPRoute Name %s NameSpace %s\n", t.route.Name(), t.route.Namespace())
+	var gwNamespace = t.route.Namespace()
+	if t.route.Spec().ParentRefs()[0].Namespace != nil {
+		gwNamespace = string(*t.route.Spec().ParentRefs()[0].Namespace)
 	}
-	glog.V(6).Infof("build Listener, Parent Name %s Namespace %s\n", t.route.GetSpec().GetParentRefs()[0].Name, gwNamespace)
+	glog.V(6).Infof("build Listener, Parent Name %s Namespace %s\n", t.route.Spec().ParentRefs()[0].Name, gwNamespace)
 	var listenerPort = 0
 	gw := &gateway_api.Gateway{}
 	gwName := types.NamespacedName{
 		Namespace: gwNamespace,
-		Name:      string(t.route.GetSpec().GetParentRefs()[0].Name),
+		Name:      string(t.route.Spec().ParentRefs()[0].Name),
 	}
 
 	if err := t.Client.Get(ctx, gwName, gw); err != nil {
@@ -93,8 +93,8 @@ func (t *latticeServiceModelBuildTask) extractListenerInfo(ctx context.Context, 
 
 func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error {
 
-	for _, parentRef := range t.route.GetSpec().GetParentRefs() {
-		if parentRef.Name != t.route.GetSpec().GetParentRefs()[0].Name {
+	for _, parentRef := range t.route.Spec().ParentRefs() {
+		if parentRef.Name != t.route.Spec().ParentRefs()[0].Name {
 			// when a service is associate to multiple service network(s), all listener config MUST be same
 			// so here we are only using the 1st gateway
 			glog.V(2).Infof("Ignore parentref of different gateway %v", parentRef.Name)
@@ -114,38 +114,38 @@ func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error 
 
 		glog.V(6).Infof("Building Listener: found matching listner Port %v\n", port)
 
-		if len(t.route.GetSpec().GetRules()) == 0 {
+		if len(t.route.Spec().Rules()) == 0 {
 			glog.V(6).Infof("Error building listener, there is no rules for %v \n", t.route)
 			return errors.New("Error building listener, there are no rules")
 		}
 
-		rule := t.route.GetSpec().GetRules()[0]
+		rule := t.route.Spec().Rules()[0]
 
-		if len(rule.GetBackendRefs()) == 0 {
+		if len(rule.BackendRefs()) == 0 {
 			glog.V(6).Infof("Error building listener, there is no backend refs for %v \n", t.route)
 			return errors.New("Error building listener, there are no backend refs")
 		}
 
-		httpBackendRef := rule.GetBackendRefs()[0]
+		httpBackendRef := rule.BackendRefs()[0]
 
 		var is_import = false
 		var targetgroupName = ""
-		var targetgroupNamespace = t.route.GetNamespace()
+		var targetgroupNamespace = t.route.Namespace()
 
-		if string(*httpBackendRef.GetKind()) == "Service" {
-			if httpBackendRef.GetNamespace() != nil {
-				targetgroupNamespace = string(*httpBackendRef.GetNamespace())
+		if string(*httpBackendRef.Kind()) == "Service" {
+			if httpBackendRef.Namespace() != nil {
+				targetgroupNamespace = string(*httpBackendRef.Namespace())
 			}
-			targetgroupName = string(httpBackendRef.GetName())
+			targetgroupName = string(httpBackendRef.Name())
 			is_import = false
 		}
 
-		if string(*httpBackendRef.GetKind()) == "ServiceImport" {
+		if string(*httpBackendRef.Kind()) == "ServiceImport" {
 			is_import = true
-			if httpBackendRef.GetNamespace() != nil {
-				targetgroupNamespace = string(*httpBackendRef.GetNamespace())
+			if httpBackendRef.Namespace() != nil {
+				targetgroupNamespace = string(*httpBackendRef.Namespace())
 			}
-			targetgroupName = string(httpBackendRef.GetName())
+			targetgroupName = string(httpBackendRef.Name())
 		}
 
 		action := latticemodel.DefaultAction{
@@ -154,10 +154,10 @@ func (t *latticeServiceModelBuildTask) buildListener(ctx context.Context) error 
 			BackendServiceNamespace: targetgroupNamespace,
 		}
 
-		listenerResourceName := fmt.Sprintf("%s-%s-%d-%s", t.route.GetName(), t.route.GetNamespace(), port, protocol)
+		listenerResourceName := fmt.Sprintf("%s-%s-%d-%s", t.route.Name(), t.route.Namespace(), port, protocol)
 		glog.V(6).Infof("listenerResourceName : %v \n", listenerResourceName)
 
-		latticemodel.NewListener(t.stack, listenerResourceName, port, protocol, t.route.GetName(), t.route.GetNamespace(), action)
+		latticemodel.NewListener(t.stack, listenerResourceName, port, protocol, t.route.Name(), t.route.Namespace(), action)
 	}
 
 	return nil

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -66,7 +66,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -90,7 +90,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "listener, tls with cert arn",
@@ -100,7 +100,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       true,
 			certARN:            "test-cert-ARN",
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -124,7 +124,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "listener, tls mode is not terminate",
@@ -134,7 +134,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       false,
 			certARN:            "test-cert-ARN",
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -158,7 +158,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "listener, with wrong annotation",
@@ -168,7 +168,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       false,
 			certARN:            "test-cert-ARN",
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -192,7 +192,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "listener, default serviceimport action",
@@ -200,7 +200,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -224,14 +224,14 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:              "no parentref ",
 			gwListenerPort:    *PortNumberPtr(80),
 			wantErrIsNil:      false,
 			k8sGetGatewayCall: false,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -250,7 +250,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "No k8sgateway object",
@@ -258,7 +258,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: false,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -282,7 +282,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "no section name ",
@@ -290,7 +290,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -314,7 +314,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 	}
 
@@ -335,7 +335,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 						listener := gateway_api.Listener{
 							Port:     tt.gwListenerPort,
 							Protocol: "HTTP",
-							Name:     *tt.route.GetSpec().GetParentRefs()[0].SectionName,
+							Name:     *tt.route.Spec().ParentRefs()[0].SectionName,
 						}
 
 						if tt.tlsTerminate {
@@ -375,7 +375,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 
 		ds := latticestore.NewLatticeDataStore()
 
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route)))
+		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
 		task := &latticeServiceModelBuildTask{
 			route:           tt.route,
@@ -410,19 +410,19 @@ func Test_ListenerModelBuild(t *testing.T) {
 
 		fmt.Printf("resListener :%v \n", resListener)
 		assert.Equal(t, resListener[0].Spec.Port, int64(tt.gwListenerPort))
-		assert.Equal(t, resListener[0].Spec.Name, tt.route.GetName())
-		assert.Equal(t, resListener[0].Spec.Namespace, tt.route.GetNamespace())
+		assert.Equal(t, resListener[0].Spec.Name, tt.route.Name())
+		assert.Equal(t, resListener[0].Spec.Namespace, tt.route.Namespace())
 		assert.Equal(t, resListener[0].Spec.Protocol, "HTTP")
 
 		assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceName,
-			string(tt.route.GetSpec().GetRules()[0].GetBackendRefs()[0].GetName()))
-		if ns := tt.route.GetSpec().GetRules()[0].GetBackendRefs()[0].GetNamespace(); ns != nil {
+			string(tt.route.Spec().Rules()[0].BackendRefs()[0].Name()))
+		if ns := tt.route.Spec().Rules()[0].BackendRefs()[0].Namespace(); ns != nil {
 			assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, *ns)
 		} else {
-			assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, tt.route.GetNamespace())
+			assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, tt.route.Namespace())
 		}
 
-		if *tt.route.GetSpec().GetRules()[0].GetBackendRefs()[0].GetKind() == "Service" {
+		if *tt.route.Spec().Rules()[0].BackendRefs()[0].Kind() == "Service" {
 			assert.Equal(t, resListener[0].Spec.DefaultAction.Is_Import, false)
 		} else {
 			assert.Equal(t, resListener[0].Spec.DefaultAction.Is_Import, true)

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -66,7 +66,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -100,7 +100,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       true,
 			certARN:            "test-cert-ARN",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -134,7 +134,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       false,
 			certARN:            "test-cert-ARN",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -168,7 +168,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       false,
 			certARN:            "test-cert-ARN",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -200,7 +200,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -231,7 +231,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			gwListenerPort:    *PortNumberPtr(80),
 			wantErrIsNil:      false,
 			k8sGetGatewayCall: false,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -258,7 +258,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: false,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -290,7 +290,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",

--- a/pkg/gateway/model_build_rule.go
+++ b/pkg/gateway/model_build_rule.go
@@ -25,8 +25,6 @@ const (
 
 	LATTICE_UNSUPPORTED_MATCH_TYPE = "LATTICE_UNSUPPORTED_MATCH_TYPE"
 
-	LATTICE_UNSUPPORTED_ROUTE_MATCH_TYPE = "LATTICE_UNSUPPORTED_ROUTE_MATCH_TYPE"
-
 	LATTICE_UNSUPPORTED_HEADER_MATCH_TYPE = "LATTICE_UNSUPPORTED_HEADER_MATCH_TYPE"
 
 	LATTICE_UNSUPPORTED_PATH_MATCH_TYPE = "LATTICE_UNSUPPORTED_PATH_MATCH_TYPE"
@@ -37,8 +35,8 @@ const (
 func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 
 	var ruleID = 1
-	for _, parentRef := range t.route.GetSpec().GetParentRefs() {
-		if parentRef.Name != t.route.GetSpec().GetParentRefs()[0].Name {
+	for _, parentRef := range t.route.Spec().ParentRefs() {
+		if parentRef.Name != t.route.Spec().ParentRefs()[0].Name {
 			// when a service is associate to multiple service network(s), all listener config MUST be same
 			// so here we are only using the 1st gateway
 			glog.V(2).Infof("Ignore parentref of different gateway %v", parentRef.Name)
@@ -52,86 +50,86 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 			return err
 		}
 
-		for _, rule := range t.route.GetSpec().GetRules() {
+		for _, rule := range t.route.Spec().Rules() {
 			glog.V(6).Infof("Parsing http rule spec: %v\n", rule)
 			var ruleSpec latticemodel.RuleSpec
 
-			if len(rule.GetMatches()) > 1 {
+			if len(rule.Matches()) > 1 {
 				// only support 1 match today
-				glog.V(2).Infof("Do not support multiple matches: matches == %v ", len(rule.GetMatches()))
+				glog.V(2).Infof("Do not support multiple matches: matches == %v ", len(rule.Matches()))
 				return errors.New(LATTICE_NO_SUPPORT_FOR_MULTIPLE_MATCHES)
 			}
 
-			if len(rule.GetMatches()) == 0 {
+			if len(rule.Matches()) == 0 {
 				glog.V(6).Infof("Continue next rule, no matches specified in current rule")
 				continue
 			}
 
 			// only support 1 match today
-			match := rule.GetMatches()[0]
+			match := rule.Matches()[0]
 
 			switch httpMatch := match.(type) {
 			case *core.HTTPRouteMatch:
-				if httpMatch.Path != nil && httpMatch.Path.Type != nil {
+				if httpMatch.Path() != nil && httpMatch.Path().Type != nil {
 					glog.V(6).Infof("Examing pathmatch type %v value %v for for httproute %s namespace %s ",
-						*httpMatch.Path.Type, *httpMatch.Path.Value, t.route.GetName(), t.route.GetNamespace())
+						*httpMatch.Path().Type, *httpMatch.Path().Value, t.route.Name(), t.route.Namespace())
 
-					switch *httpMatch.Path.Type {
+					switch *httpMatch.Path().Type {
 					case gateway_api.PathMatchExact:
 						glog.V(6).Infof("Using PathMatchExact for httproute %s namespace %s ",
-							t.route.GetName(), t.route.GetNamespace())
+							t.route.Name(), t.route.Namespace())
 						ruleSpec.PathMatchExact = true
 
 					case gateway_api.PathMatchPathPrefix:
 						glog.V(6).Infof("Using PathMatchPathPrefix for httproute %s namespace %s ",
-							t.route.GetName(), t.route.GetNamespace())
+							t.route.Name(), t.route.Namespace())
 						ruleSpec.PathMatchPrefix = true
 					default:
 						glog.V(2).Infof("Unsupported path match type %v for httproute %s namespace %s",
-							*httpMatch.Path.Type, t.route.GetName(), t.route.GetNamespace())
+							*httpMatch.Path().Type, t.route.Name(), t.route.Namespace())
 						return errors.New(LATTICE_UNSUPPORTED_PATH_MATCH_TYPE)
 					}
-					ruleSpec.PathMatchValue = *httpMatch.Path.Value
+					ruleSpec.PathMatchValue = *httpMatch.Path().Value
 				}
 
 				// controller do not support these match type today
-				if httpMatch.Method != nil || httpMatch.QueryParams != nil {
+				if httpMatch.Method() != nil || httpMatch.QueryParams() != nil {
 					glog.V(2).Infof("Unsupported Match Method %v for httproute %v, namespace %v",
-						httpMatch.Method, t.route.GetName(), t.route.GetNamespace())
+						httpMatch.Method(), t.route.Name(), t.route.Namespace())
 					return errors.New(LATTICE_UNSUPPORTED_MATCH_TYPE)
 				}
 			default:
-				return errors.New(LATTICE_UNSUPPORTED_ROUTE_MATCH_TYPE)
+				return fmt.Errorf("unsupported rule match: %T", httpMatch)
 			}
 
 			// header based match
 			// today, only support EXACT match
-			if match.GetHeaders() != nil {
-				if len(match.GetHeaders()) > LATTICE_MAX_HEADER_MATCHES {
+			if match.Headers() != nil {
+				if len(match.Headers()) > LATTICE_MAX_HEADER_MATCHES {
 					return errors.New(LATTICE_EXCEED_MAX_HEADER_MATCHES)
 				}
 
-				ruleSpec.NumOfHeaderMatches = len(match.GetHeaders())
+				ruleSpec.NumOfHeaderMatches = len(match.Headers())
 
 				glog.V(6).Infof("Examing match.Headers %v for httproute %s namespace %s",
-					match.GetHeaders(), t.route.GetName(), t.route.GetNamespace())
+					match.Headers(), t.route.Name(), t.route.Namespace())
 
-				for i, header := range match.GetHeaders() {
-					glog.V(6).Infof("Examing match.Header: i = %d header.Type %v", i, *header.GetType())
-					if header.GetType() != nil && *header.GetType() != gateway_api.HeaderMatchExact {
+				for i, header := range match.Headers() {
+					glog.V(6).Infof("Examing match.Header: i = %d header.Type %v", i, *header.Type())
+					if header.Type() != nil && *header.Type() != gateway_api.HeaderMatchExact {
 						glog.V(2).Infof("Unsupported header matchtype %v for httproute %v namespace %s",
-							*header.GetType(), t.route.GetName(), t.route.GetNamespace())
+							*header.Type(), t.route.Name(), t.route.Namespace())
 						return errors.New(LATTICE_UNSUPPORTED_HEADER_MATCH_TYPE)
 					}
 
 					glog.V(6).Infof("Found HeaderExactMatch==%v for HTTPRoute %v, namespace %v",
-						header.GetValue(), t.route.GetName(), t.route.GetNamespace())
+						header.Value(), t.route.Name(), t.route.Namespace())
 
 					matchType := vpclattice.HeaderMatchType{
-						Exact: aws.String(header.GetValue()),
+						Exact: aws.String(header.Value()),
 					}
 					ruleSpec.MatchedHeaders[i].Match = &matchType
-					header_name := header.GetName()
+					header_name := header.Name()
 
 					glog.V(6).Infof("Found matching i = %d header_name %v", i, &header_name)
 
@@ -143,51 +141,51 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 
 			tgList := []*latticemodel.RuleTargetGroup{}
 
-			for _, backendRef := range rule.GetBackendRefs() {
+			for _, backendRef := range rule.BackendRefs() {
 				glog.V(6).Infof("buildRoutingPolicy - examining backendRef %v, backendRef kind: %v",
-					backendRef, *backendRef.GetKind())
+					backendRef, *backendRef.Kind())
 
 				ruleTG := latticemodel.RuleTargetGroup{}
 
-				if string(*backendRef.GetKind()) == "Service" {
-					namespace := t.route.GetNamespace()
-					if backendRef.GetNamespace() != nil {
-						namespace = string(*backendRef.GetNamespace())
+				if string(*backendRef.Kind()) == "Service" {
+					namespace := t.route.Namespace()
+					if backendRef.Namespace() != nil {
+						namespace = string(*backendRef.Namespace())
 					}
-					ruleTG.Name = string(backendRef.GetName())
+					ruleTG.Name = string(backendRef.Name())
 					ruleTG.Namespace = namespace
-					ruleTG.RouteName = t.route.GetName()
+					ruleTG.RouteName = t.route.Name()
 					ruleTG.IsServiceImport = false
-					if backendRef.GetWeight() != nil {
-						ruleTG.Weight = int64(*backendRef.GetWeight())
+					if backendRef.Weight() != nil {
+						ruleTG.Weight = int64(*backendRef.Weight())
 					}
 
 				}
 
-				if string(*backendRef.GetKind()) == "ServiceImport" {
+				if string(*backendRef.Kind()) == "ServiceImport" {
 					// TODO
 					glog.V(6).Infof("Handle ServiceImport Routing Policy\n")
 					/* I think this need to be done at policy manager API call
-					tg, err := t.Datastore.GetTargetGroup(string(backendRef.GetName()),
+					tg, err := t.Datastore.GetTargetGroup(string(backendRef.Name()),
 						"default", true) // isServiceImport==true
 					if err != nil {
 						glog.V(6).Infof("ServiceImport %s Not found, continue \n",
-							string(backendRef.GetName()))
+							string(backendRef.Name()))
 						continue
 
 					}
 					*/
-					ruleTG.Name = string(backendRef.GetName())
-					ruleTG.Namespace = t.route.GetNamespace()
-					if backendRef.GetNamespace() != nil {
-						ruleTG.Namespace = string(*backendRef.GetNamespace())
+					ruleTG.Name = string(backendRef.Name())
+					ruleTG.Namespace = t.route.Namespace()
+					if backendRef.Namespace() != nil {
+						ruleTG.Namespace = string(*backendRef.Namespace())
 					}
 					// the routename for serviceimport is always ""
 					ruleTG.RouteName = ""
 					ruleTG.IsServiceImport = true
 
-					if backendRef.GetWeight() != nil {
-						ruleTG.Weight = int64(*backendRef.GetWeight())
+					if backendRef.Weight() != nil {
+						ruleTG.Weight = int64(*backendRef.Weight())
 					}
 
 				}
@@ -199,7 +197,7 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 			ruleAction := latticemodel.RuleAction{
 				TargetGroups: tgList,
 			}
-			latticemodel.NewRule(t.stack, ruleIDName, t.route.GetName(), t.route.GetNamespace(), port,
+			latticemodel.NewRule(t.stack, ruleIDName, t.route.Name(), t.route.Namespace(), port,
 				protocol, ruleAction, ruleSpec)
 			ruleID++
 

--- a/pkg/gateway/model_build_rule.go
+++ b/pkg/gateway/model_build_rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 
 	"github.com/golang/glog"
 
@@ -34,151 +35,154 @@ const (
 func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 
 	var ruleID = 1
-	for _, parentRef := range t.httpRoute.Spec.ParentRefs {
-		if parentRef.Name != t.httpRoute.Spec.ParentRefs[0].Name {
+	for _, parentRef := range t.route.GetSpec().GetParentRefs() {
+		if parentRef.Name != t.route.GetSpec().GetParentRefs()[0].Name {
 			// when a service is associate to multiple service network(s), all listener config MUST be same
 			// so here we are only using the 1st gateway
 			glog.V(2).Infof("Ignore parentref of different gateway %v", parentRef.Name)
 
 			continue
 		}
-		port, protocol, _, err := t.extractListnerInfo(ctx, parentRef)
+		port, protocol, _, err := t.extractListenerInfo(ctx, parentRef)
 
 		if err != nil {
 			glog.V(2).Infof("Error on buildRules %v \n", err)
 			return err
 		}
 
-		for _, httpRule := range t.httpRoute.Spec.Rules {
-			glog.V(6).Infof("Parsing http rule spec: %v\n", httpRule)
+		for _, rule := range t.route.GetSpec().GetRules() {
+			glog.V(6).Infof("Parsing http rule spec: %v\n", rule)
 			var ruleSpec latticemodel.RuleSpec
 
-			if len(httpRule.Matches) > 1 {
+			if len(rule.GetMatches()) > 1 {
 				// only support 1 match today
-				glog.V(2).Infof("Do not support multiple matches: matches == %v ", len(httpRule.Matches))
+				glog.V(2).Infof("Do not support multiple matches: matches == %v ", len(rule.GetMatches()))
 				return errors.New(LATTICE_NO_SUPPORT_FOR_MULTIPLE_MATCHES)
 			}
 
-			if len(httpRule.Matches) == 0 {
+			if len(rule.GetMatches()) == 0 {
 				glog.V(6).Infof("Continue next rule, no matches specified in current rule")
 				continue
 			}
 
 			// only support 1 match today
-			match := httpRule.Matches[0]
+			match := rule.GetMatches()[0]
 
-			if match.Path != nil && match.Path.Type != nil {
-				glog.V(6).Infof("Examing pathmatch type %v value %v for for httproute %s namespace %s ",
-					*match.Path.Type, *match.Path.Value, t.httpRoute.Name, t.httpRoute.Namespace)
+			if httpMatch, ok := match.(core.HTTPRouteMatch); ok {
+				if httpMatch.Path != nil && httpMatch.Path.Type != nil {
+					glog.V(6).Infof("Examing pathmatch type %v value %v for for httproute %s namespace %s ",
+						*httpMatch.Path.Type, *httpMatch.Path.Value, t.route.GetName(), t.route.GetNamespace())
 
-				switch *match.Path.Type {
-				case gateway_api.PathMatchExact:
-					glog.V(6).Infof("Using PathMatchExact for httproute %s namespace %s ",
-						t.httpRoute.Name, t.httpRoute.Namespace)
-					ruleSpec.PathMatchExact = true
+					switch *httpMatch.Path.Type {
+					case gateway_api.PathMatchExact:
+						glog.V(6).Infof("Using PathMatchExact for httproute %s namespace %s ",
+							t.route.GetName(), t.route.GetNamespace())
+						ruleSpec.PathMatchExact = true
 
-				case gateway_api.PathMatchPathPrefix:
-					glog.V(6).Infof("Using PathMatchPathPrefix for httproute %s namespace %s ",
-						t.httpRoute.Name, t.httpRoute.Namespace)
-					ruleSpec.PathMatchPrefix = true
-				default:
-					glog.V(2).Infof("Unsupported path match type %v for httproute %s namespace %s",
-						*match.Path.Type, t.httpRoute.Name, t.httpRoute.Namespace)
-					return errors.New(LATTICE_UNSUPPORTED_PATH_MATCH_TYPE)
+					case gateway_api.PathMatchPathPrefix:
+						glog.V(6).Infof("Using PathMatchPathPrefix for httproute %s namespace %s ",
+							t.route.GetName(), t.route.GetNamespace())
+						ruleSpec.PathMatchPrefix = true
+					default:
+						glog.V(2).Infof("Unsupported path match type %v for httproute %s namespace %s",
+							*httpMatch.Path.Type, t.route.GetName(), t.route.GetNamespace())
+						return errors.New(LATTICE_UNSUPPORTED_PATH_MATCH_TYPE)
+					}
+					ruleSpec.PathMatchValue = *httpMatch.Path.Value
 				}
-				ruleSpec.PathMatchValue = *match.Path.Value
+
+				// controller do not support these match type today
+				if httpMatch.Method != nil || httpMatch.QueryParams != nil {
+					glog.V(2).Infof("Unsupported Match Method %v for httproute %v, namespace %v",
+						httpMatch.Method, t.route.GetName(), t.route.GetNamespace())
+					return errors.New(LATTICE_UNSUPPORTED_MATCH_TYPE)
+				}
 			}
 
 			// header based match
 			// today, only support EXACT match
-			if match.Headers != nil {
-				if len(match.Headers) > LATTICE_MAX_HEADER_MATCHES {
+			if match.GetHeaders() != nil {
+				if len(match.GetHeaders()) > LATTICE_MAX_HEADER_MATCHES {
 					return errors.New(LATTICE_EXCEED_MAX_HEADER_MATCHES)
 				}
 
-				ruleSpec.NumOfHeaderMatches = len(match.Headers)
+				ruleSpec.NumOfHeaderMatches = len(match.GetHeaders())
 
 				glog.V(6).Infof("Examing match.Headers %v for httproute %s namespace %s",
-					match.Headers, t.httpRoute.Name, t.httpRoute.Namespace)
+					match.GetHeaders(), t.route.GetName(), t.route.GetNamespace())
 
-				for i, header := range match.Headers {
-					glog.V(6).Infof("Examing match.Header: i = %d header.Type %v", i, *header.Type)
-					if header.Type != nil && gateway_api.HeaderMatchType(*header.Type) != gateway_api.HeaderMatchExact {
+				for i, header := range match.GetHeaders() {
+					glog.V(6).Infof("Examing match.Header: i = %d header.Type %v", i, *header.GetType())
+					if header.GetType() != nil && *header.GetType() != gateway_api.HeaderMatchExact {
 						glog.V(2).Infof("Unsupported header matchtype %v for httproute %v namespace %s",
-							*header.Type, t.httpRoute.Name, t.httpRoute.Namespace)
+							*header.GetType(), t.route.GetName(), t.route.GetNamespace())
 						return errors.New(LATTICE_UNSUPPORTED_HEADER_MATCH_TYPE)
 					}
 
 					glog.V(6).Infof("Found HeaderExactMatch==%v for HTTPRoute %v, namespace %v",
-						header.Value, t.httpRoute.Name, t.httpRoute.Namespace)
+						header.GetValue(), t.route.GetName(), t.route.GetNamespace())
 
 					matchType := vpclattice.HeaderMatchType{
-						Exact: aws.String(header.Value),
+						Exact: aws.String(header.GetValue()),
 					}
 					ruleSpec.MatchedHeaders[i].Match = &matchType
-					header_name := header.Name
+					header_name := header.GetName()
 
 					glog.V(6).Infof("Found matching i = %d header_name %v", i, &header_name)
 
-					ruleSpec.MatchedHeaders[i].Name = (*string)(&header_name)
+					ruleSpec.MatchedHeaders[i].Name = &header_name
 				}
 			}
 
-			// controller do not support these match type today
-			if match.Method != nil || match.QueryParams != nil {
-				glog.V(2).Infof("Unsupported Match Method %v for httproute %v, namespace %v",
-					match.Method, t.httpRoute.Name, t.httpRoute.Namespace)
-				return errors.New(LATTICE_UNSUPPORTED_MATCH_TYPE)
-			}
 			glog.V(6).Infof("Generated ruleSpec is: %v", ruleSpec)
 
 			tgList := []*latticemodel.RuleTargetGroup{}
 
-			for _, httpBackendRef := range httpRule.BackendRefs {
-				glog.V(6).Infof("buildRoutingPolicy - examing backendRef %v\n", httpBackendRef)
-				glog.V(6).Infof("backendref kind: %v\n", *httpBackendRef.BackendObjectReference.Kind)
+			for _, backendRef := range rule.GetBackendRefs() {
+				glog.V(6).Infof("buildRoutingPolicy - examining backendRef %v\n", backendRef)
+				glog.V(6).Infof("backendRef kind: %v\n", *backendRef.GetKind())
 
 				ruleTG := latticemodel.RuleTargetGroup{}
 
-				if string(*httpBackendRef.BackendObjectReference.Kind) == "Service" {
-					namespace := t.httpRoute.Namespace
-					if httpBackendRef.BackendObjectReference.Namespace != nil {
-						namespace = string(*httpBackendRef.BackendObjectReference.Namespace)
+				if string(*backendRef.GetKind()) == "Service" {
+					namespace := t.route.GetNamespace()
+					if backendRef.GetNamespace() != nil {
+						namespace = string(*backendRef.GetNamespace())
 					}
-					ruleTG.Name = string(httpBackendRef.BackendObjectReference.Name)
+					ruleTG.Name = string(backendRef.GetName())
 					ruleTG.Namespace = namespace
-					ruleTG.RouteName = t.httpRoute.Name
+					ruleTG.RouteName = t.route.GetName()
 					ruleTG.IsServiceImport = false
-					if httpBackendRef.Weight != nil {
-						ruleTG.Weight = int64(*httpBackendRef.Weight)
+					if backendRef.GetWeight() != nil {
+						ruleTG.Weight = int64(*backendRef.GetWeight())
 					}
 
 				}
 
-				if string(*httpBackendRef.BackendObjectReference.Kind) == "ServiceImport" {
+				if string(*backendRef.GetKind()) == "ServiceImport" {
 					// TODO
 					glog.V(6).Infof("Handle ServiceImport Routing Policy\n")
 					/* I think this need to be done at policy manager API call
-					tg, err := t.Datastore.GetTargetGroup(string(httpBackendRef.BackendObjectReference.Name),
+					tg, err := t.Datastore.GetTargetGroup(string(backendRef.GetName()),
 						"default", true) // isServiceImport==true
 					if err != nil {
 						glog.V(6).Infof("ServiceImport %s Not found, continue \n",
-							string(httpBackendRef.BackendObjectReference.Name))
+							string(backendRef.GetName()))
 						continue
 
 					}
 					*/
-					ruleTG.Name = string(httpBackendRef.BackendObjectReference.Name)
-					ruleTG.Namespace = t.httpRoute.Namespace
-					if httpBackendRef.BackendObjectReference.Namespace != nil {
-						ruleTG.Namespace = string(*httpBackendRef.BackendObjectReference.Namespace)
+					ruleTG.Name = string(backendRef.GetName())
+					ruleTG.Namespace = t.route.GetNamespace()
+					if backendRef.GetNamespace() != nil {
+						ruleTG.Namespace = string(*backendRef.GetNamespace())
 					}
 					// the routename for serviceimport is always ""
 					ruleTG.RouteName = ""
 					ruleTG.IsServiceImport = true
 
-					if httpBackendRef.Weight != nil {
-						ruleTG.Weight = int64(*httpBackendRef.Weight)
+					if backendRef.GetWeight() != nil {
+						ruleTG.Weight = int64(*backendRef.GetWeight())
 					}
 
 				}
@@ -190,7 +194,7 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context) error {
 			ruleAction := latticemodel.RuleAction{
 				TargetGroups: tgList,
 			}
-			latticemodel.NewRule(t.stack, ruleIDName, t.httpRoute.Name, t.httpRoute.Namespace, port,
+			latticemodel.NewRule(t.stack, ruleIDName, t.route.GetName(), t.route.GetNamespace(), port,
 				protocol, ruleAction, ruleSpec)
 			ruleID++
 

--- a/pkg/gateway/model_build_rule_test.go
+++ b/pkg/gateway/model_build_rule_test.go
@@ -88,7 +88,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -120,7 +120,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -152,7 +152,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -187,7 +187,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -244,7 +244,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "non-default",
@@ -394,7 +394,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 	var serviceKind gateway_api.Kind = "Service"
 
 	var namespace = gateway_api.Namespace("default")
-	var path1 = string("/ver1")
+	var path1 = "/ver1"
 	//var path2 = string("/ver2")
 	var k8sPathMatchExactType = gateway_api.PathMatchExact
 	var k8sPathMatchPrefixType = gateway_api.PathMatchPathPrefix
@@ -428,7 +428,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -474,7 +474,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -519,7 +519,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -583,7 +583,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -651,7 +651,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -726,7 +726,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -801,7 +801,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -869,7 +869,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -964,7 +964,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -1016,7 +1016,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",

--- a/pkg/gateway/model_build_rule_test.go
+++ b/pkg/gateway/model_build_rule_test.go
@@ -88,7 +88,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -120,7 +120,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -152,7 +152,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -187,7 +187,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -244,7 +244,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "non-default",
@@ -428,7 +428,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -474,7 +474,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -519,7 +519,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -583,7 +583,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -651,7 +651,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -726,7 +726,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -801,7 +801,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -869,7 +869,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -964,7 +964,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -1016,7 +1016,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",

--- a/pkg/gateway/model_build_rule_test.go
+++ b/pkg/gateway/model_build_rule_test.go
@@ -88,7 +88,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -112,7 +112,7 @@ func Test_RuleModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "rule, default serviceimport action",
@@ -120,7 +120,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -144,7 +144,7 @@ func Test_RuleModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "rule, weighted target group",
@@ -152,7 +152,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -179,7 +179,7 @@ func Test_RuleModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "rule, path based target group",
@@ -187,7 +187,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -236,7 +236,7 @@ func Test_RuleModelBuild(t *testing.T) {
 						},
 					},
 				},
-			}},
+			}),
 		},
 		{
 			name:               "rule, different namespace combination",
@@ -244,7 +244,7 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "non-default",
@@ -303,8 +303,8 @@ func Test_RuleModelBuild(t *testing.T) {
 						},
 					},
 				},
-			},
-			}},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		fmt.Printf("Testing >>> %v\n", tt.name)
@@ -322,7 +322,7 @@ func Test_RuleModelBuild(t *testing.T) {
 					if tt.k8sGatewayReturnOK {
 						gw.Spec.Listeners = append(gw.Spec.Listeners, gateway_api.Listener{
 							Port: tt.gwListenerPort,
-							Name: *tt.route.GetSpec().GetParentRefs()[0].SectionName,
+							Name: *tt.route.Spec().ParentRefs()[0].SectionName,
 						})
 						return nil
 					} else {
@@ -334,7 +334,7 @@ func Test_RuleModelBuild(t *testing.T) {
 
 		ds := latticestore.NewLatticeDataStore()
 
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route)))
+		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
 		task := &latticeServiceModelBuildTask{
 			route:           tt.route,
@@ -363,20 +363,20 @@ func Test_RuleModelBuild(t *testing.T) {
 
 			assert.Equal(t, resRule.Spec.ListenerPort, int64(tt.gwListenerPort))
 			// Defer this to dedicate rule check			assert.Equal(t, resRule.Spec.PathMatchValue, tt.route.)
-			assert.Equal(t, resRule.Spec.ServiceName, tt.route.GetName())
-			assert.Equal(t, resRule.Spec.ServiceNamespace, tt.route.GetNamespace())
+			assert.Equal(t, resRule.Spec.ServiceName, tt.route.Name())
+			assert.Equal(t, resRule.Spec.ServiceNamespace, tt.route.Namespace())
 
 			var j = 0
 			for _, tg := range resRule.Spec.Action.TargetGroups {
 
-				assert.Equal(t, gateway_api.ObjectName(tg.Name), tt.route.GetSpec().GetRules()[i-1].GetBackendRefs()[j].GetName())
-				if tt.route.GetSpec().GetRules()[i-1].GetBackendRefs()[j].GetNamespace() != nil {
-					assert.Equal(t, gateway_api.Namespace(tg.Namespace), *tt.route.GetSpec().GetRules()[i-1].GetBackendRefs()[j].GetNamespace())
+				assert.Equal(t, gateway_api.ObjectName(tg.Name), tt.route.Spec().Rules()[i-1].BackendRefs()[j].Name())
+				if tt.route.Spec().Rules()[i-1].BackendRefs()[j].Namespace() != nil {
+					assert.Equal(t, gateway_api.Namespace(tg.Namespace), *tt.route.Spec().Rules()[i-1].BackendRefs()[j].Namespace())
 				} else {
-					assert.Equal(t, tg.Namespace, tt.route.GetNamespace())
+					assert.Equal(t, tg.Namespace, tt.route.Namespace())
 				}
 
-				if *tt.route.GetSpec().GetRules()[i-1].GetBackendRefs()[j].GetKind() == "ServiceImport" {
+				if *tt.route.Spec().Rules()[i-1].BackendRefs()[j].Kind() == "ServiceImport" {
 					assert.Equal(t, tg.IsServiceImport, true)
 				} else {
 					assert.Equal(t, tg.IsServiceImport, false)
@@ -428,7 +428,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -460,8 +460,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchExact: true,
 				PathMatchValue: path1,
@@ -474,7 +474,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -506,8 +506,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchPrefix: true,
 				PathMatchValue:  path1,
@@ -519,7 +519,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -558,8 +558,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				NumOfHeaderMatches: 1,
 				MatchedHeaders: [5]vpclattice.HeaderMatch{
@@ -583,7 +583,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -622,8 +622,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				NumOfHeaderMatches: 2,
 				MatchedHeaders: [5]vpclattice.HeaderMatch{
@@ -651,7 +651,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -695,8 +695,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchExact:     true,
 				PathMatchValue:     path1,
@@ -726,7 +726,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -770,8 +770,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchPrefix:    true,
 				PathMatchValue:     path1,
@@ -801,7 +801,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -840,8 +840,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				NumOfHeaderMatches: 2,
 				MatchedHeaders: [5]vpclattice.HeaderMatch{
@@ -869,7 +869,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -933,8 +933,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchExact:     true,
 				PathMatchValue:     path1,
@@ -964,7 +964,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -1003,8 +1003,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchExact: true,
 				PathMatchValue: path1,
@@ -1016,7 +1016,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
@@ -1046,8 +1046,8 @@ func Test_HeadersRuleBuild(t *testing.T) {
 							},
 						},
 					},
-				}},
-			},
+				},
+			}),
 			expectedRuleSpec: latticemodel.RuleSpec{
 				PathMatchExact: true,
 				PathMatchValue: path1,
@@ -1069,7 +1069,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 
 				gw.Spec.Listeners = append(gw.Spec.Listeners, gateway_api.Listener{
 					Port: tt.gwListenerPort,
-					Name: *tt.route.GetSpec().GetParentRefs()[0].SectionName,
+					Name: *tt.route.Spec().ParentRefs()[0].SectionName,
 				})
 				return nil
 
@@ -1078,7 +1078,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 
 		ds := latticestore.NewLatticeDataStore()
 
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route)))
+		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
 		task := &latticeServiceModelBuildTask{
 			route:           tt.route,

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -60,7 +60,7 @@ type targetGroupModelBuildTask struct {
 
 // for serviceexport
 func (b *targetGroupBuilder) Build(ctx context.Context, srvExport *mcs_api.ServiceExport) (core.Stack, *latticemodel.TargetGroup, error) {
-	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName((srvExport))))
+	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(srvExport)))
 
 	task := &targetGroupModelBuildTask{
 		serviceExport: srvExport,

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -198,7 +198,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -235,7 +235,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
@@ -274,7 +274,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Create LatticeService where backend K8S service does NOT exist",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service3",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
@@ -312,7 +312,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Create LatticeService where backend mcs serviceimport does NOT exist",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service4",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
@@ -457,7 +457,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "serviceimport1",
 				},
@@ -494,7 +494,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService, implicit namespace",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "serviceimport1",
 					Namespace: "tg1-ns2",
@@ -531,7 +531,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.HTTPRoute{gateway_api.HTTPRoute{
+			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "serviceimport2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -198,7 +198,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
@@ -235,7 +235,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
@@ -274,7 +274,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Create LatticeService where backend K8S service does NOT exist",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service3",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
@@ -312,7 +312,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Create LatticeService where backend mcs serviceimport does NOT exist",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service4",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
@@ -457,7 +457,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "serviceimport1",
 				},
@@ -494,7 +494,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService, implicit namespace",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "serviceimport1",
 					Namespace: "tg1-ns2",
@@ -531,7 +531,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
+			route: &core.HTTPRoute{HTTPRoute: gateway_api.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "serviceimport2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -1,12 +1,16 @@
 package k8s
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
+type NamespacedAndNamed interface {
+	GetNamespace() string
+	GetName() string
+}
+
 // NamespacedName returns the namespaced name for k8s objects
-func NamespacedName(obj metav1.Object) types.NamespacedName {
+func NamespacedName(obj NamespacedAndNamed) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),

--- a/pkg/model/core/route.go
+++ b/pkg/model/core/route.go
@@ -20,27 +20,27 @@ type HTTPRoute struct {
 	gateway_api_v1beta1.HTTPRoute
 }
 
-func (r HTTPRoute) GetSpec() RouteSpec {
-	return HTTPRouteSpec{r.Spec}
+func (r *HTTPRoute) GetSpec() RouteSpec {
+	return &HTTPRouteSpec{r.Spec}
 }
 
-func (r HTTPRoute) GetStatus() RouteStatus {
-	return HTTPRouteStatus{r.Status}
+func (r *HTTPRoute) GetStatus() RouteStatus {
+	return &HTTPRouteStatus{r.Status}
 }
 
-func (r HTTPRoute) GetName() string {
+func (r *HTTPRoute) GetName() string {
 	return r.Name
 }
 
-func (r HTTPRoute) GetNamespace() string {
+func (r *HTTPRoute) GetNamespace() string {
 	return r.Namespace
 }
 
-func (r HTTPRoute) GetDeletionTimestamp() *v1.Time {
+func (r *HTTPRoute) GetDeletionTimestamp() *v1.Time {
 	return r.DeletionTimestamp
 }
 
-func (r HTTPRoute) GetRuntimeObject() runtime.Object {
+func (r *HTTPRoute) GetRuntimeObject() runtime.Object {
 	return &r.HTTPRoute
 }
 
@@ -48,27 +48,27 @@ type GRPCRoute struct {
 	gateway_api_v1alpha2.GRPCRoute
 }
 
-func (r GRPCRoute) GetSpec() RouteSpec {
-	return GRPCRouteSpec{r.Spec}
+func (r *GRPCRoute) GetSpec() RouteSpec {
+	return &GRPCRouteSpec{r.Spec}
 }
 
-func (r GRPCRoute) GetStatus() RouteStatus {
-	return GRPCRouteStatus{r.Status}
+func (r *GRPCRoute) GetStatus() RouteStatus {
+	return &GRPCRouteStatus{r.Status}
 }
 
-func (r GRPCRoute) GetName() string {
+func (r *GRPCRoute) GetName() string {
 	return r.Name
 }
 
-func (r GRPCRoute) GetNamespace() string {
+func (r *GRPCRoute) GetNamespace() string {
 	return r.Namespace
 }
 
-func (r GRPCRoute) GetDeletionTimestamp() *v1.Time {
+func (r *GRPCRoute) GetDeletionTimestamp() *v1.Time {
 	return r.DeletionTimestamp
 }
 
-func (r GRPCRoute) GetRuntimeObject() runtime.Object {
+func (r *GRPCRoute) GetRuntimeObject() runtime.Object {
 	return &r.GRPCRoute
 }
 
@@ -82,18 +82,18 @@ type HTTPRouteSpec struct {
 	gateway_api_v1beta1.HTTPRouteSpec
 }
 
-func (s HTTPRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
+func (s *HTTPRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
 	return s.ParentRefs
 }
 
-func (s HTTPRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
+func (s *HTTPRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
 	return s.Hostnames
 }
 
-func (s HTTPRouteSpec) GetRules() []RouteRule {
+func (s *HTTPRouteSpec) GetRules() []RouteRule {
 	var rules []RouteRule
 	for _, rule := range s.Rules {
-		rules = append(rules, HTTPRouteRule{rule})
+		rules = append(rules, &HTTPRouteRule{rule})
 	}
 	return rules
 }
@@ -102,18 +102,18 @@ type GRPCRouteSpec struct {
 	gateway_api_v1alpha2.GRPCRouteSpec
 }
 
-func (s GRPCRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
+func (s *GRPCRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
 	return s.ParentRefs
 }
 
-func (s GRPCRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
+func (s *GRPCRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
 	return s.Hostnames
 }
 
-func (s GRPCRouteSpec) GetRules() []RouteRule {
+func (s *GRPCRouteSpec) GetRules() []RouteRule {
 	var rules []RouteRule
 	for _, rule := range s.Rules {
-		rules = append(rules, GRPCRouteRule{rule})
+		rules = append(rules, &GRPCRouteRule{rule})
 	}
 	return rules
 }
@@ -126,7 +126,7 @@ type HTTPRouteStatus struct {
 	gateway_api_v1beta1.HTTPRouteStatus
 }
 
-func (s HTTPRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
+func (s *HTTPRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
 	return s.Parents
 }
 
@@ -134,7 +134,7 @@ type GRPCRouteStatus struct {
 	gateway_api_v1alpha2.GRPCRouteStatus
 }
 
-func (s GRPCRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
+func (s *GRPCRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
 	return s.Parents
 }
 
@@ -147,18 +147,18 @@ type HTTPRouteRule struct {
 	gateway_api_v1beta1.HTTPRouteRule
 }
 
-func (r HTTPRouteRule) GetBackendRefs() []BackendRef {
+func (r *HTTPRouteRule) GetBackendRefs() []BackendRef {
 	var backendRefs []BackendRef
 	for _, backendRef := range r.BackendRefs {
-		backendRefs = append(backendRefs, HTTPBackendRef{backendRef})
+		backendRefs = append(backendRefs, &HTTPBackendRef{backendRef})
 	}
 	return backendRefs
 }
 
-func (r HTTPRouteRule) GetMatches() []RouteMatch {
+func (r *HTTPRouteRule) GetMatches() []RouteMatch {
 	var routeMatches []RouteMatch
 	for _, routeMatch := range r.Matches {
-		routeMatches = append(routeMatches, HTTPRouteMatch{routeMatch})
+		routeMatches = append(routeMatches, &HTTPRouteMatch{routeMatch})
 	}
 	return routeMatches
 }
@@ -167,18 +167,18 @@ type GRPCRouteRule struct {
 	gateway_api_v1alpha2.GRPCRouteRule
 }
 
-func (r GRPCRouteRule) GetBackendRefs() []BackendRef {
+func (r *GRPCRouteRule) GetBackendRefs() []BackendRef {
 	var backendRefs []BackendRef
 	for _, backendRef := range r.BackendRefs {
-		backendRefs = append(backendRefs, GRPCBackendRef{backendRef})
+		backendRefs = append(backendRefs, &GRPCBackendRef{backendRef})
 	}
 	return backendRefs
 }
 
-func (r GRPCRouteRule) GetMatches() []RouteMatch {
+func (r *GRPCRouteRule) GetMatches() []RouteMatch {
 	var routeMatches []RouteMatch
 	for _, routeMatch := range r.Matches {
-		routeMatches = append(routeMatches, GRPCRouteMatch{routeMatch})
+		routeMatches = append(routeMatches, &GRPCRouteMatch{routeMatch})
 	}
 	return routeMatches
 }
@@ -196,27 +196,27 @@ type HTTPBackendRef struct {
 	gateway_api_v1beta1.HTTPBackendRef
 }
 
-func (r HTTPBackendRef) GetWeight() *int32 {
+func (r *HTTPBackendRef) GetWeight() *int32 {
 	return r.Weight
 }
 
-func (r HTTPBackendRef) GetGroup() *gateway_api_v1beta1.Group {
+func (r *HTTPBackendRef) GetGroup() *gateway_api_v1beta1.Group {
 	return r.Group
 }
 
-func (r HTTPBackendRef) GetKind() *gateway_api_v1beta1.Kind {
+func (r *HTTPBackendRef) GetKind() *gateway_api_v1beta1.Kind {
 	return r.Kind
 }
 
-func (r HTTPBackendRef) GetName() gateway_api_v1beta1.ObjectName {
+func (r *HTTPBackendRef) GetName() gateway_api_v1beta1.ObjectName {
 	return r.Name
 }
 
-func (r HTTPBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
+func (r *HTTPBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
 	return r.Namespace
 }
 
-func (r HTTPBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
+func (r *HTTPBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
 	return r.Port
 }
 
@@ -224,27 +224,27 @@ type GRPCBackendRef struct {
 	gateway_api_v1alpha2.GRPCBackendRef
 }
 
-func (r GRPCBackendRef) GetWeight() *int32 {
+func (r *GRPCBackendRef) GetWeight() *int32 {
 	return r.Weight
 }
 
-func (r GRPCBackendRef) GetGroup() *gateway_api_v1beta1.Group {
+func (r *GRPCBackendRef) GetGroup() *gateway_api_v1beta1.Group {
 	return r.Group
 }
 
-func (r GRPCBackendRef) GetKind() *gateway_api_v1beta1.Kind {
+func (r *GRPCBackendRef) GetKind() *gateway_api_v1beta1.Kind {
 	return r.Kind
 }
 
-func (r GRPCBackendRef) GetName() gateway_api_v1beta1.ObjectName {
+func (r *GRPCBackendRef) GetName() gateway_api_v1beta1.ObjectName {
 	return r.Name
 }
 
-func (r GRPCBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
+func (r *GRPCBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
 	return r.Namespace
 }
 
-func (r GRPCBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
+func (r *GRPCBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
 	return r.Port
 }
 
@@ -256,23 +256,23 @@ type HTTPRouteMatch struct {
 	gateway_api_v1beta1.HTTPRouteMatch
 }
 
-func (r HTTPRouteMatch) GetHeaders() []HeaderMatch {
+func (r *HTTPRouteMatch) GetHeaders() []HeaderMatch {
 	var headerMatches []HeaderMatch
 	for _, headerMatch := range r.Headers {
-		headerMatches = append(headerMatches, HTTPHeaderMatch{headerMatch})
+		headerMatches = append(headerMatches, &HTTPHeaderMatch{headerMatch})
 	}
 	return headerMatches
 }
 
-func (r HTTPRouteMatch) GetPath() *gateway_api_v1beta1.HTTPPathMatch {
+func (r *HTTPRouteMatch) GetPath() *gateway_api_v1beta1.HTTPPathMatch {
 	return r.Path
 }
 
-func (r HTTPRouteMatch) GetQueryParams() []gateway_api_v1beta1.HTTPQueryParamMatch {
+func (r *HTTPRouteMatch) GetQueryParams() []gateway_api_v1beta1.HTTPQueryParamMatch {
 	return r.QueryParams
 }
 
-func (r HTTPRouteMatch) GetMethod() *gateway_api_v1beta1.HTTPMethod {
+func (r *HTTPRouteMatch) GetMethod() *gateway_api_v1beta1.HTTPMethod {
 	return r.Method
 }
 
@@ -280,15 +280,15 @@ type GRPCRouteMatch struct {
 	gateway_api_v1alpha2.GRPCRouteMatch
 }
 
-func (r GRPCRouteMatch) GetHeaders() []HeaderMatch {
+func (r *GRPCRouteMatch) GetHeaders() []HeaderMatch {
 	var headerMatches []HeaderMatch
 	for _, headerMatch := range r.Headers {
-		headerMatches = append(headerMatches, GRPCHeaderMatch{headerMatch})
+		headerMatches = append(headerMatches, &GRPCHeaderMatch{headerMatch})
 	}
 	return headerMatches
 }
 
-func (r GRPCRouteMatch) GetMethod() *gateway_api_v1alpha2.GRPCMethodMatch {
+func (r *GRPCRouteMatch) GetMethod() *gateway_api_v1alpha2.GRPCMethodMatch {
 	return r.Method
 }
 
@@ -302,15 +302,15 @@ type HTTPHeaderMatch struct {
 	gateway_api_v1beta1.HTTPHeaderMatch
 }
 
-func (r HTTPHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
+func (r *HTTPHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
 	return r.Type
 }
 
-func (r HTTPHeaderMatch) GetName() string {
+func (r *HTTPHeaderMatch) GetName() string {
 	return string(r.Name)
 }
 
-func (r HTTPHeaderMatch) GetValue() string {
+func (r *HTTPHeaderMatch) GetValue() string {
 	return r.Value
 }
 
@@ -318,14 +318,14 @@ type GRPCHeaderMatch struct {
 	gateway_api_v1alpha2.GRPCHeaderMatch
 }
 
-func (r GRPCHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
+func (r *GRPCHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
 	return r.Type
 }
 
-func (r GRPCHeaderMatch) GetName() string {
+func (r *GRPCHeaderMatch) GetName() string {
 	return string(r.Name)
 }
 
-func (r GRPCHeaderMatch) GetValue() string {
+func (r *GRPCHeaderMatch) GetValue() string {
 	return r.Value
 }

--- a/pkg/model/core/route.go
+++ b/pkg/model/core/route.go
@@ -119,23 +119,23 @@ func (s GRPCRouteSpec) GetRules() []RouteRule {
 }
 
 type RouteStatus interface {
-	GetRouteStatus() gateway_api_v1beta1.RouteStatus
+	GetParents() []gateway_api_v1beta1.RouteParentStatus
 }
 
 type HTTPRouteStatus struct {
 	gateway_api_v1beta1.HTTPRouteStatus
 }
 
-func (s HTTPRouteStatus) GetRouteStatus() gateway_api_v1beta1.RouteStatus {
-	return s.RouteStatus
+func (s HTTPRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
+	return s.Parents
 }
 
 type GRPCRouteStatus struct {
 	gateway_api_v1alpha2.GRPCRouteStatus
 }
 
-func (s GRPCRouteStatus) GetRouteStatus() gateway_api_v1beta1.RouteStatus {
-	return s.RouteStatus
+func (s GRPCRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
+	return s.Parents
 }
 
 type RouteRule interface {

--- a/pkg/model/core/route.go
+++ b/pkg/model/core/route.go
@@ -2,330 +2,342 @@ package core
 
 import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gateway_api_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type Route interface {
-	GetSpec() RouteSpec
-	GetStatus() RouteStatus
-	GetName() string
-	GetNamespace() string
-	GetDeletionTimestamp() *v1.Time
-	GetRuntimeObject() runtime.Object
+	Spec() RouteSpec
+	Status() RouteStatus
+	Name() string
+	Namespace() string
+	DeletionTimestamp() *v1.Time
+	K8sObject() client.Object
 }
 
 type HTTPRoute struct {
-	gateway_api_v1beta1.HTTPRoute
+	r gateway_api_v1beta1.HTTPRoute
 }
 
-func (r *HTTPRoute) GetSpec() RouteSpec {
-	return &HTTPRouteSpec{r.Spec}
+func NewHTTPRoute(route gateway_api_v1beta1.HTTPRoute) *HTTPRoute {
+	return &HTTPRoute{r: route}
 }
 
-func (r *HTTPRoute) GetStatus() RouteStatus {
-	return &HTTPRouteStatus{r.Status}
+func (r *HTTPRoute) Spec() RouteSpec {
+	return &HTTPRouteSpec{r.r.Spec}
 }
 
-func (r *HTTPRoute) GetName() string {
-	return r.Name
+func (r *HTTPRoute) Status() RouteStatus {
+	return &HTTPRouteStatus{r.r.Status}
 }
 
-func (r *HTTPRoute) GetNamespace() string {
-	return r.Namespace
+func (r *HTTPRoute) Name() string {
+	return r.r.Name
 }
 
-func (r *HTTPRoute) GetDeletionTimestamp() *v1.Time {
-	return r.DeletionTimestamp
+func (r *HTTPRoute) Namespace() string {
+	return r.r.Namespace
 }
 
-func (r *HTTPRoute) GetRuntimeObject() runtime.Object {
-	return &r.HTTPRoute
+func (r *HTTPRoute) DeletionTimestamp() *v1.Time {
+	return r.r.DeletionTimestamp
+}
+
+func (r *HTTPRoute) K8sObject() client.Object {
+	return &r.r
+}
+
+func (r *HTTPRoute) Inner() *gateway_api_v1beta1.HTTPRoute {
+	return &r.r
 }
 
 type GRPCRoute struct {
-	gateway_api_v1alpha2.GRPCRoute
+	r gateway_api_v1alpha2.GRPCRoute
 }
 
-func (r *GRPCRoute) GetSpec() RouteSpec {
-	return &GRPCRouteSpec{r.Spec}
+func NewGRPCRoute(route gateway_api_v1alpha2.GRPCRoute) *GRPCRoute {
+	return &GRPCRoute{r: route}
 }
 
-func (r *GRPCRoute) GetStatus() RouteStatus {
-	return &GRPCRouteStatus{r.Status}
+func (r *GRPCRoute) Spec() RouteSpec {
+	return &GRPCRouteSpec{r.r.Spec}
 }
 
-func (r *GRPCRoute) GetName() string {
-	return r.Name
+func (r *GRPCRoute) Status() RouteStatus {
+	return &GRPCRouteStatus{r.r.Status}
 }
 
-func (r *GRPCRoute) GetNamespace() string {
-	return r.Namespace
+func (r *GRPCRoute) Name() string {
+	return r.r.Name
 }
 
-func (r *GRPCRoute) GetDeletionTimestamp() *v1.Time {
-	return r.DeletionTimestamp
+func (r *GRPCRoute) Namespace() string {
+	return r.r.Namespace
 }
 
-func (r *GRPCRoute) GetRuntimeObject() runtime.Object {
-	return &r.GRPCRoute
+func (r *GRPCRoute) DeletionTimestamp() *v1.Time {
+	return r.r.DeletionTimestamp
+}
+
+func (r *GRPCRoute) K8sObject() client.Object {
+	return &r.r
 }
 
 type RouteSpec interface {
-	GetParentRefs() []gateway_api_v1beta1.ParentReference
-	GetHostnames() []gateway_api_v1beta1.Hostname
-	GetRules() []RouteRule
+	ParentRefs() []gateway_api_v1beta1.ParentReference
+	Hostnames() []gateway_api_v1beta1.Hostname
+	Rules() []RouteRule
 }
 
 type HTTPRouteSpec struct {
-	gateway_api_v1beta1.HTTPRouteSpec
+	s gateway_api_v1beta1.HTTPRouteSpec
 }
 
-func (s *HTTPRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
-	return s.ParentRefs
+func (s *HTTPRouteSpec) ParentRefs() []gateway_api_v1beta1.ParentReference {
+	return s.s.ParentRefs
 }
 
-func (s *HTTPRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
-	return s.Hostnames
+func (s *HTTPRouteSpec) Hostnames() []gateway_api_v1beta1.Hostname {
+	return s.s.Hostnames
 }
 
-func (s *HTTPRouteSpec) GetRules() []RouteRule {
+func (s *HTTPRouteSpec) Rules() []RouteRule {
 	var rules []RouteRule
-	for _, rule := range s.Rules {
+	for _, rule := range s.s.Rules {
 		rules = append(rules, &HTTPRouteRule{rule})
 	}
 	return rules
 }
 
 type GRPCRouteSpec struct {
-	gateway_api_v1alpha2.GRPCRouteSpec
+	s gateway_api_v1alpha2.GRPCRouteSpec
 }
 
-func (s *GRPCRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
-	return s.ParentRefs
+func (s *GRPCRouteSpec) ParentRefs() []gateway_api_v1beta1.ParentReference {
+	return s.s.ParentRefs
 }
 
-func (s *GRPCRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
-	return s.Hostnames
+func (s *GRPCRouteSpec) Hostnames() []gateway_api_v1beta1.Hostname {
+	return s.s.Hostnames
 }
 
-func (s *GRPCRouteSpec) GetRules() []RouteRule {
+func (s *GRPCRouteSpec) Rules() []RouteRule {
 	var rules []RouteRule
-	for _, rule := range s.Rules {
+	for _, rule := range s.s.Rules {
 		rules = append(rules, &GRPCRouteRule{rule})
 	}
 	return rules
 }
 
 type RouteStatus interface {
-	GetParents() []gateway_api_v1beta1.RouteParentStatus
+	Parents() []gateway_api_v1beta1.RouteParentStatus
 }
 
 type HTTPRouteStatus struct {
-	gateway_api_v1beta1.HTTPRouteStatus
+	s gateway_api_v1beta1.HTTPRouteStatus
 }
 
-func (s *HTTPRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
-	return s.Parents
+func (s *HTTPRouteStatus) Parents() []gateway_api_v1beta1.RouteParentStatus {
+	return s.s.Parents
 }
 
 type GRPCRouteStatus struct {
-	gateway_api_v1alpha2.GRPCRouteStatus
+	s gateway_api_v1alpha2.GRPCRouteStatus
 }
 
-func (s *GRPCRouteStatus) GetParents() []gateway_api_v1beta1.RouteParentStatus {
-	return s.Parents
+func (s *GRPCRouteStatus) Parents() []gateway_api_v1beta1.RouteParentStatus {
+	return s.s.Parents
 }
 
 type RouteRule interface {
-	GetBackendRefs() []BackendRef
-	GetMatches() []RouteMatch
+	BackendRefs() []BackendRef
+	Matches() []RouteMatch
 }
 
 type HTTPRouteRule struct {
-	gateway_api_v1beta1.HTTPRouteRule
+	r gateway_api_v1beta1.HTTPRouteRule
 }
 
-func (r *HTTPRouteRule) GetBackendRefs() []BackendRef {
+func (r *HTTPRouteRule) BackendRefs() []BackendRef {
 	var backendRefs []BackendRef
-	for _, backendRef := range r.BackendRefs {
+	for _, backendRef := range r.r.BackendRefs {
 		backendRefs = append(backendRefs, &HTTPBackendRef{backendRef})
 	}
 	return backendRefs
 }
 
-func (r *HTTPRouteRule) GetMatches() []RouteMatch {
+func (r *HTTPRouteRule) Matches() []RouteMatch {
 	var routeMatches []RouteMatch
-	for _, routeMatch := range r.Matches {
+	for _, routeMatch := range r.r.Matches {
 		routeMatches = append(routeMatches, &HTTPRouteMatch{routeMatch})
 	}
 	return routeMatches
 }
 
 type GRPCRouteRule struct {
-	gateway_api_v1alpha2.GRPCRouteRule
+	r gateway_api_v1alpha2.GRPCRouteRule
 }
 
-func (r *GRPCRouteRule) GetBackendRefs() []BackendRef {
+func (r *GRPCRouteRule) BackendRefs() []BackendRef {
 	var backendRefs []BackendRef
-	for _, backendRef := range r.BackendRefs {
+	for _, backendRef := range r.r.BackendRefs {
 		backendRefs = append(backendRefs, &GRPCBackendRef{backendRef})
 	}
 	return backendRefs
 }
 
-func (r *GRPCRouteRule) GetMatches() []RouteMatch {
+func (r *GRPCRouteRule) Matches() []RouteMatch {
 	var routeMatches []RouteMatch
-	for _, routeMatch := range r.Matches {
+	for _, routeMatch := range r.r.Matches {
 		routeMatches = append(routeMatches, &GRPCRouteMatch{routeMatch})
 	}
 	return routeMatches
 }
 
 type BackendRef interface {
-	GetWeight() *int32
-	GetGroup() *gateway_api_v1beta1.Group
-	GetKind() *gateway_api_v1beta1.Kind
-	GetName() gateway_api_v1beta1.ObjectName
-	GetNamespace() *gateway_api_v1beta1.Namespace
-	GetPort() *gateway_api_v1beta1.PortNumber
+	Weight() *int32
+	Group() *gateway_api_v1beta1.Group
+	Kind() *gateway_api_v1beta1.Kind
+	Name() gateway_api_v1beta1.ObjectName
+	Namespace() *gateway_api_v1beta1.Namespace
+	Port() *gateway_api_v1beta1.PortNumber
 }
 
 type HTTPBackendRef struct {
-	gateway_api_v1beta1.HTTPBackendRef
+	r gateway_api_v1beta1.HTTPBackendRef
 }
 
-func (r *HTTPBackendRef) GetWeight() *int32 {
-	return r.Weight
+func (r *HTTPBackendRef) Weight() *int32 {
+	return r.r.Weight
 }
 
-func (r *HTTPBackendRef) GetGroup() *gateway_api_v1beta1.Group {
-	return r.Group
+func (r *HTTPBackendRef) Group() *gateway_api_v1beta1.Group {
+	return r.r.Group
 }
 
-func (r *HTTPBackendRef) GetKind() *gateway_api_v1beta1.Kind {
-	return r.Kind
+func (r *HTTPBackendRef) Kind() *gateway_api_v1beta1.Kind {
+	return r.r.Kind
 }
 
-func (r *HTTPBackendRef) GetName() gateway_api_v1beta1.ObjectName {
-	return r.Name
+func (r *HTTPBackendRef) Name() gateway_api_v1beta1.ObjectName {
+	return r.r.Name
 }
 
-func (r *HTTPBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
-	return r.Namespace
+func (r *HTTPBackendRef) Namespace() *gateway_api_v1beta1.Namespace {
+	return r.r.Namespace
 }
 
-func (r *HTTPBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
-	return r.Port
+func (r *HTTPBackendRef) Port() *gateway_api_v1beta1.PortNumber {
+	return r.r.Port
 }
 
 type GRPCBackendRef struct {
-	gateway_api_v1alpha2.GRPCBackendRef
+	r gateway_api_v1alpha2.GRPCBackendRef
 }
 
-func (r *GRPCBackendRef) GetWeight() *int32 {
-	return r.Weight
+func (r *GRPCBackendRef) Weight() *int32 {
+	return r.r.Weight
 }
 
-func (r *GRPCBackendRef) GetGroup() *gateway_api_v1beta1.Group {
-	return r.Group
+func (r *GRPCBackendRef) Group() *gateway_api_v1beta1.Group {
+	return r.r.Group
 }
 
-func (r *GRPCBackendRef) GetKind() *gateway_api_v1beta1.Kind {
-	return r.Kind
+func (r *GRPCBackendRef) Kind() *gateway_api_v1beta1.Kind {
+	return r.r.Kind
 }
 
-func (r *GRPCBackendRef) GetName() gateway_api_v1beta1.ObjectName {
-	return r.Name
+func (r *GRPCBackendRef) Name() gateway_api_v1beta1.ObjectName {
+	return r.r.Name
 }
 
-func (r *GRPCBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
-	return r.Namespace
+func (r *GRPCBackendRef) Namespace() *gateway_api_v1beta1.Namespace {
+	return r.r.Namespace
 }
 
-func (r *GRPCBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
-	return r.Port
+func (r *GRPCBackendRef) Port() *gateway_api_v1beta1.PortNumber {
+	return r.r.Port
 }
 
 type RouteMatch interface {
-	GetHeaders() []HeaderMatch
+	Headers() []HeaderMatch
 }
 
 type HTTPRouteMatch struct {
-	gateway_api_v1beta1.HTTPRouteMatch
+	m gateway_api_v1beta1.HTTPRouteMatch
 }
 
-func (r *HTTPRouteMatch) GetHeaders() []HeaderMatch {
+func (m *HTTPRouteMatch) Headers() []HeaderMatch {
 	var headerMatches []HeaderMatch
-	for _, headerMatch := range r.Headers {
+	for _, headerMatch := range m.m.Headers {
 		headerMatches = append(headerMatches, &HTTPHeaderMatch{headerMatch})
 	}
 	return headerMatches
 }
 
-func (r *HTTPRouteMatch) GetPath() *gateway_api_v1beta1.HTTPPathMatch {
-	return r.Path
+func (m *HTTPRouteMatch) Path() *gateway_api_v1beta1.HTTPPathMatch {
+	return m.m.Path
 }
 
-func (r *HTTPRouteMatch) GetQueryParams() []gateway_api_v1beta1.HTTPQueryParamMatch {
-	return r.QueryParams
+func (m *HTTPRouteMatch) QueryParams() []gateway_api_v1beta1.HTTPQueryParamMatch {
+	return m.m.QueryParams
 }
 
-func (r *HTTPRouteMatch) GetMethod() *gateway_api_v1beta1.HTTPMethod {
-	return r.Method
+func (m *HTTPRouteMatch) Method() *gateway_api_v1beta1.HTTPMethod {
+	return m.m.Method
 }
 
 type GRPCRouteMatch struct {
-	gateway_api_v1alpha2.GRPCRouteMatch
+	m gateway_api_v1alpha2.GRPCRouteMatch
 }
 
-func (r *GRPCRouteMatch) GetHeaders() []HeaderMatch {
+func (m *GRPCRouteMatch) Headers() []HeaderMatch {
 	var headerMatches []HeaderMatch
-	for _, headerMatch := range r.Headers {
+	for _, headerMatch := range m.m.Headers {
 		headerMatches = append(headerMatches, &GRPCHeaderMatch{headerMatch})
 	}
 	return headerMatches
 }
 
-func (r *GRPCRouteMatch) GetMethod() *gateway_api_v1alpha2.GRPCMethodMatch {
-	return r.Method
+func (m *GRPCRouteMatch) Method() *gateway_api_v1alpha2.GRPCMethodMatch {
+	return m.m.Method
 }
 
 type HeaderMatch interface {
-	GetType() *gateway_api_v1beta1.HeaderMatchType
-	GetName() string
-	GetValue() string
+	Type() *gateway_api_v1beta1.HeaderMatchType
+	Name() string
+	Value() string
 }
 
 type HTTPHeaderMatch struct {
-	gateway_api_v1beta1.HTTPHeaderMatch
+	m gateway_api_v1beta1.HTTPHeaderMatch
 }
 
-func (r *HTTPHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
-	return r.Type
+func (m *HTTPHeaderMatch) Type() *gateway_api_v1beta1.HeaderMatchType {
+	return m.m.Type
 }
 
-func (r *HTTPHeaderMatch) GetName() string {
-	return string(r.Name)
+func (m *HTTPHeaderMatch) Name() string {
+	return string(m.m.Name)
 }
 
-func (r *HTTPHeaderMatch) GetValue() string {
-	return r.Value
+func (m *HTTPHeaderMatch) Value() string {
+	return m.m.Value
 }
 
 type GRPCHeaderMatch struct {
-	gateway_api_v1alpha2.GRPCHeaderMatch
+	m gateway_api_v1alpha2.GRPCHeaderMatch
 }
 
-func (r *GRPCHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
-	return r.Type
+func (m *GRPCHeaderMatch) Type() *gateway_api_v1beta1.HeaderMatchType {
+	return m.m.Type
 }
 
-func (r *GRPCHeaderMatch) GetName() string {
-	return string(r.Name)
+func (m *GRPCHeaderMatch) Name() string {
+	return string(m.m.Name)
 }
 
-func (r *GRPCHeaderMatch) GetValue() string {
-	return r.Value
+func (m *GRPCHeaderMatch) Value() string {
+	return m.m.Value
 }

--- a/pkg/model/core/route.go
+++ b/pkg/model/core/route.go
@@ -1,0 +1,331 @@
+package core
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gateway_api_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type Route interface {
+	GetSpec() RouteSpec
+	GetStatus() RouteStatus
+	GetName() string
+	GetNamespace() string
+	GetDeletionTimestamp() *v1.Time
+	GetRuntimeObject() runtime.Object
+}
+
+type HTTPRoute struct {
+	gateway_api_v1beta1.HTTPRoute
+}
+
+func (r HTTPRoute) GetSpec() RouteSpec {
+	return HTTPRouteSpec{r.Spec}
+}
+
+func (r HTTPRoute) GetStatus() RouteStatus {
+	return HTTPRouteStatus{r.Status}
+}
+
+func (r HTTPRoute) GetName() string {
+	return r.Name
+}
+
+func (r HTTPRoute) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r HTTPRoute) GetDeletionTimestamp() *v1.Time {
+	return r.DeletionTimestamp
+}
+
+func (r HTTPRoute) GetRuntimeObject() runtime.Object {
+	return &r.HTTPRoute
+}
+
+type GRPCRoute struct {
+	gateway_api_v1alpha2.GRPCRoute
+}
+
+func (r GRPCRoute) GetSpec() RouteSpec {
+	return GRPCRouteSpec{r.Spec}
+}
+
+func (r GRPCRoute) GetStatus() RouteStatus {
+	return GRPCRouteStatus{r.Status}
+}
+
+func (r GRPCRoute) GetName() string {
+	return r.Name
+}
+
+func (r GRPCRoute) GetNamespace() string {
+	return r.Namespace
+}
+
+func (r GRPCRoute) GetDeletionTimestamp() *v1.Time {
+	return r.DeletionTimestamp
+}
+
+func (r GRPCRoute) GetRuntimeObject() runtime.Object {
+	return &r.GRPCRoute
+}
+
+type RouteSpec interface {
+	GetParentRefs() []gateway_api_v1beta1.ParentReference
+	GetHostnames() []gateway_api_v1beta1.Hostname
+	GetRules() []RouteRule
+}
+
+type HTTPRouteSpec struct {
+	gateway_api_v1beta1.HTTPRouteSpec
+}
+
+func (s HTTPRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
+	return s.ParentRefs
+}
+
+func (s HTTPRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
+	return s.Hostnames
+}
+
+func (s HTTPRouteSpec) GetRules() []RouteRule {
+	var rules []RouteRule
+	for _, rule := range s.Rules {
+		rules = append(rules, HTTPRouteRule{rule})
+	}
+	return rules
+}
+
+type GRPCRouteSpec struct {
+	gateway_api_v1alpha2.GRPCRouteSpec
+}
+
+func (s GRPCRouteSpec) GetParentRefs() []gateway_api_v1beta1.ParentReference {
+	return s.ParentRefs
+}
+
+func (s GRPCRouteSpec) GetHostnames() []gateway_api_v1beta1.Hostname {
+	return s.Hostnames
+}
+
+func (s GRPCRouteSpec) GetRules() []RouteRule {
+	var rules []RouteRule
+	for _, rule := range s.Rules {
+		rules = append(rules, GRPCRouteRule{rule})
+	}
+	return rules
+}
+
+type RouteStatus interface {
+	GetRouteStatus() gateway_api_v1beta1.RouteStatus
+}
+
+type HTTPRouteStatus struct {
+	gateway_api_v1beta1.HTTPRouteStatus
+}
+
+func (s HTTPRouteStatus) GetRouteStatus() gateway_api_v1beta1.RouteStatus {
+	return s.RouteStatus
+}
+
+type GRPCRouteStatus struct {
+	gateway_api_v1alpha2.GRPCRouteStatus
+}
+
+func (s GRPCRouteStatus) GetRouteStatus() gateway_api_v1beta1.RouteStatus {
+	return s.RouteStatus
+}
+
+type RouteRule interface {
+	GetBackendRefs() []BackendRef
+	GetMatches() []RouteMatch
+}
+
+type HTTPRouteRule struct {
+	gateway_api_v1beta1.HTTPRouteRule
+}
+
+func (r HTTPRouteRule) GetBackendRefs() []BackendRef {
+	var backendRefs []BackendRef
+	for _, backendRef := range r.BackendRefs {
+		backendRefs = append(backendRefs, HTTPBackendRef{backendRef})
+	}
+	return backendRefs
+}
+
+func (r HTTPRouteRule) GetMatches() []RouteMatch {
+	var routeMatches []RouteMatch
+	for _, routeMatch := range r.Matches {
+		routeMatches = append(routeMatches, HTTPRouteMatch{routeMatch})
+	}
+	return routeMatches
+}
+
+type GRPCRouteRule struct {
+	gateway_api_v1alpha2.GRPCRouteRule
+}
+
+func (r GRPCRouteRule) GetBackendRefs() []BackendRef {
+	var backendRefs []BackendRef
+	for _, backendRef := range r.BackendRefs {
+		backendRefs = append(backendRefs, GRPCBackendRef{backendRef})
+	}
+	return backendRefs
+}
+
+func (r GRPCRouteRule) GetMatches() []RouteMatch {
+	var routeMatches []RouteMatch
+	for _, routeMatch := range r.Matches {
+		routeMatches = append(routeMatches, GRPCRouteMatch{routeMatch})
+	}
+	return routeMatches
+}
+
+type BackendRef interface {
+	GetWeight() *int32
+	GetGroup() *gateway_api_v1beta1.Group
+	GetKind() *gateway_api_v1beta1.Kind
+	GetName() gateway_api_v1beta1.ObjectName
+	GetNamespace() *gateway_api_v1beta1.Namespace
+	GetPort() *gateway_api_v1beta1.PortNumber
+}
+
+type HTTPBackendRef struct {
+	gateway_api_v1beta1.HTTPBackendRef
+}
+
+func (r HTTPBackendRef) GetWeight() *int32 {
+	return r.Weight
+}
+
+func (r HTTPBackendRef) GetGroup() *gateway_api_v1beta1.Group {
+	return r.Group
+}
+
+func (r HTTPBackendRef) GetKind() *gateway_api_v1beta1.Kind {
+	return r.Kind
+}
+
+func (r HTTPBackendRef) GetName() gateway_api_v1beta1.ObjectName {
+	return r.Name
+}
+
+func (r HTTPBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
+	return r.Namespace
+}
+
+func (r HTTPBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
+	return r.Port
+}
+
+type GRPCBackendRef struct {
+	gateway_api_v1alpha2.GRPCBackendRef
+}
+
+func (r GRPCBackendRef) GetWeight() *int32 {
+	return r.Weight
+}
+
+func (r GRPCBackendRef) GetGroup() *gateway_api_v1beta1.Group {
+	return r.Group
+}
+
+func (r GRPCBackendRef) GetKind() *gateway_api_v1beta1.Kind {
+	return r.Kind
+}
+
+func (r GRPCBackendRef) GetName() gateway_api_v1beta1.ObjectName {
+	return r.Name
+}
+
+func (r GRPCBackendRef) GetNamespace() *gateway_api_v1beta1.Namespace {
+	return r.Namespace
+}
+
+func (r GRPCBackendRef) GetPort() *gateway_api_v1beta1.PortNumber {
+	return r.Port
+}
+
+type RouteMatch interface {
+	GetHeaders() []HeaderMatch
+}
+
+type HTTPRouteMatch struct {
+	gateway_api_v1beta1.HTTPRouteMatch
+}
+
+func (r HTTPRouteMatch) GetHeaders() []HeaderMatch {
+	var headerMatches []HeaderMatch
+	for _, headerMatch := range r.Headers {
+		headerMatches = append(headerMatches, HTTPHeaderMatch{headerMatch})
+	}
+	return headerMatches
+}
+
+func (r HTTPRouteMatch) GetPath() *gateway_api_v1beta1.HTTPPathMatch {
+	return r.Path
+}
+
+func (r HTTPRouteMatch) GetQueryParams() []gateway_api_v1beta1.HTTPQueryParamMatch {
+	return r.QueryParams
+}
+
+func (r HTTPRouteMatch) GetMethod() *gateway_api_v1beta1.HTTPMethod {
+	return r.Method
+}
+
+type GRPCRouteMatch struct {
+	gateway_api_v1alpha2.GRPCRouteMatch
+}
+
+func (r GRPCRouteMatch) GetHeaders() []HeaderMatch {
+	var headerMatches []HeaderMatch
+	for _, headerMatch := range r.Headers {
+		headerMatches = append(headerMatches, GRPCHeaderMatch{headerMatch})
+	}
+	return headerMatches
+}
+
+func (r GRPCRouteMatch) GetMethod() *gateway_api_v1alpha2.GRPCMethodMatch {
+	return r.Method
+}
+
+type HeaderMatch interface {
+	GetType() *gateway_api_v1beta1.HeaderMatchType
+	GetName() string
+	GetValue() string
+}
+
+type HTTPHeaderMatch struct {
+	gateway_api_v1beta1.HTTPHeaderMatch
+}
+
+func (r HTTPHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
+	return r.Type
+}
+
+func (r HTTPHeaderMatch) GetName() string {
+	return string(r.Name)
+}
+
+func (r HTTPHeaderMatch) GetValue() string {
+	return r.Value
+}
+
+type GRPCHeaderMatch struct {
+	gateway_api_v1alpha2.GRPCHeaderMatch
+}
+
+func (r GRPCHeaderMatch) GetType() *gateway_api_v1beta1.HeaderMatchType {
+	return r.Type
+}
+
+func (r GRPCHeaderMatch) GetName() string {
+	return string(r.Name)
+}
+
+func (r GRPCHeaderMatch) GetValue() string {
+	return r.Value
+}

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -145,7 +145,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
 		for _, tg := range retrievedTargetGroups {
 			Logger(ctx).Infof("Found TargetGroup: %v, checking it whether it's created by current EKS Cluster", tg)
-			if currentClusterVpcId != *tg.VpcIdentifier {
+			if tg.VpcIdentifier != nil && currentClusterVpcId != *tg.VpcIdentifier {
 				//This tg is not created by current EKS Cluster, skip it
 				continue
 			}
@@ -161,7 +161,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 					//so we temporarily skip to verify whether ServiceExport created TargetGroup is deleted or not
 					continue
 				}
-				Expect(*tg.Name).To(Not(ContainElements(BeKeyOf(env.TestCasesCreatedServiceNames))))
+				Expect(env.TestCasesCreatedServiceNames).To(Not(ContainElements(BeKeyOf(*tg.Name))))
 			}
 		}
 	}).Should(Succeed())

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -145,7 +145,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
 		for _, tg := range retrievedTargetGroups {
 			Logger(ctx).Infof("Found TargetGroup: %s, checking it whether it's created by current EKS Cluster", *tg.Id)
-			if currentClusterVpcId != *tg.VpcIdentifier {
+			if tg.VpcIdentifier != nil && currentClusterVpcId != *tg.VpcIdentifier {
 				Logger(ctx).Infof("Target group VPC Id: %s, does not match current EKS Cluster VPC Id: %s", *tg.VpcIdentifier, currentClusterVpcId)
 				//This tg is not created by current EKS Cluster, skip it
 				continue
@@ -163,7 +163,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 					//so we temporarily skip to verify whether ServiceExport created TargetGroup is deleted or not
 					continue
 				}
-				Expect(*tg.Name).To(Not(ContainElements(BeKeyOf(env.TestCasesCreatedServiceNames))))
+				Expect(env.TestCasesCreatedServiceNames).To(Not(ContainElements(BeKeyOf(*tg.Name))))
 			}
 		}
 	}).Should(Succeed())


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
This is a preliminary step for #25 

**What does this PR do / Why do we need it**:
The primary goal of this PR is to abstract away Gateway API's route constructs. There are no functionality changes made here.

Currently, HTTPRoute is available in the v1beta1 package, but GRPCRoute is only available in v1alpha2. Due to their different types and packages, they have no common parent. Additionally, changes are expected in the future, as these are experimental packages. Putting all Gateway API Route constructs behind an abstraction gives us more control over how the rest of our code interacts with them and reduces the amount of refactoring needed in the future. In the case of #25 , we need to support multiple types of routes instead of assume every route is an HTTPRoute. Abstracting all route types behind a new interface, Route, will allow us to simplify the code for supporting GRPCRoutes.

This change also includes 2 fixes for e2e tests (in framework.go). One fixes a bug where, if the account has a Lambda target group in it, then the e2e tests will fail due to a nil pointer when dereferencing the target group's VPC id. The other is a fix for logic to ensure a set of created service names does not contain a specific target group name (previously, it would check that a target group name does not contain the set of created service names, which is backwards).

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
N/A

**Testing done on this change**:
```
Ran 7 of 7 Specs in 3102.354 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (3103.37s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   3104.103s
```

Unit tests were also modified to support the abstract routes

**Automation added to e2e**:
N/A, as no functional behaviour is changed in this PR

**Will this PR introduce any new dependencies?**:
No, as no functional behaviour is changed in this PR

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
No.

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.