### PR TITLE
feat: create targets if backendRef svc port match

### DIFF
--- a/controllers/eventhandlers/serviceimport.go
+++ b/controllers/eventhandlers/serviceimport.go
@@ -82,7 +82,7 @@ func (h *enqueueRequestsForServiceImportEvent) enqueueImpactedService(queue work
 func isServiceImportUsedByHTTPRoute(httpRoute gateway_api.HTTPRoute, serviceImport *mcs_api.ServiceImport) bool {
 	for _, httpRule := range httpRoute.Spec.Rules {
 		for _, httpBackendRef := range httpRule.BackendRefs {
-			if string(*httpBackendRef.BackendObjectReference.Kind) != "serviceimport" {
+			if string(*httpBackendRef.BackendObjectReference.Kind) != "ServiceImport" {
 				continue
 			}
 

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -145,11 +145,17 @@ func (t *latticeServiceModelBuildTask) buildTargets(ctx context.Context) error {
 				backendNamespace = string(*httpBackendRef.Namespace())
 			}
 
+			port := int64(0)
+			if httpBackendRef.Port() != nil {
+				port = int64(*httpBackendRef.Port())
+			}
+
 			targetTask := &latticeTargetsModelBuildTask{
 				Client:      t.Client,
 				tgName:      string(httpBackendRef.Name()),
 				tgNamespace: backendNamespace,
 				routename:   t.route.Name(),
+				port:        port,
 				stack:       t.stack,
 				datastore:   t.Datastore,
 			}

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -406,7 +407,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 					for _, httpBackendRef := range httpRules.BackendRefs() {
 						tgName := latticestore.TargetGroupName(string(httpBackendRef.Name()), string(*httpBackendRef.Namespace()))
 
-						fmt.Printf("httpBacndendRef %s\n", *httpBackendRef.Kind())
+						fmt.Printf("httpBackendRef %s\n", *httpBackendRef.Kind())
 						if "Service" == *httpBackendRef.Kind() {
 							if tt.wantIsDeleted {
 								tg := task.tgByResID[tgName]
@@ -628,7 +629,7 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 					}
 					tgName := latticestore.TargetGroupName(string(httpBackendRef.Name()), ns)
 
-					fmt.Printf("httpBacndendRef %s\n", *httpBackendRef.Kind())
+					fmt.Printf("httpBackendRef %s\n", *httpBackendRef.Kind())
 					if "Service" == *httpBackendRef.Kind() {
 						if tt.wantIsDeleted {
 							tg := task.tgByResID[tgName]

--- a/pkg/gateway/model_build_targets_test.go
+++ b/pkg/gateway/model_build_targets_test.go
@@ -28,6 +28,7 @@ func Test_Targets(t *testing.T) {
 		name               string
 		srvExportName      string
 		srvExportNamespace string
+		port               int64
 		endPoints          []corev1.Endpoints
 		svc                corev1.Service
 		serviceExport      mcs_api.ServiceExport
@@ -41,6 +42,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Add all endpoints to build spec",
 			srvExportName:      "export1",
 			srvExportNamespace: "ns1",
+			port:               0,
 			endPoints: []corev1.Endpoints{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -88,6 +90,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Add all endpoints to build spec with port annotation",
 			srvExportName:      "export1",
 			srvExportNamespace: "ns1",
+			port:               3090,
 			endPoints: []corev1.Endpoints{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -135,6 +138,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Delete svc and all endpoints to build spec",
 			srvExportName:      "export1",
 			srvExportNamespace: "ns1",
+			port:               0,
 			endPoints: []corev1.Endpoints{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -167,6 +171,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Delete svc and no endpoints to build spec",
 			srvExportName:      "export1",
 			srvExportNamespace: "ns1",
+			port:               0,
 			endPoints:          []corev1.Endpoints{},
 			svc: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -186,6 +191,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Endpoints without TargetGroup",
 			srvExportName:      "export2",
 			srvExportNamespace: "ns1",
+			port:               0,
 			endPoints: []corev1.Endpoints{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -215,6 +221,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Endpoints's TargetGroup is NOT referenced by serviceexport",
 			srvExportName:      "export3",
 			srvExportNamespace: "ns1",
+			port:               0,
 			endPoints: []corev1.Endpoints{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -245,6 +252,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Endpoints does NOT exists",
 			srvExportName:      "export4",
 			srvExportNamespace: "ns1",
+			port:               0,
 			inDataStore:        false,
 			refByServiceExport: true,
 			wantErrIsNil:       false,
@@ -260,6 +268,7 @@ func Test_Targets(t *testing.T) {
 			name:               "Add all endpoints to build spec",
 			srvExportName:      "export5",
 			srvExportNamespace: "ns1",
+			port:               0,
 			endPoints: []corev1.Endpoints{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -284,6 +293,134 @@ func Test_Targets(t *testing.T) {
 			inDataStore:  true,
 			refByService: true,
 			wantErrIsNil: true,
+			expectedTargetList: []latticemodel.Target{
+				{
+					TargetIP: "10.10.1.1",
+					Port:     8675,
+				},
+				{
+					TargetIP: "10.10.1.1",
+					Port:     309,
+				},
+				{
+					TargetIP: "10.10.2.2",
+					Port:     8675,
+				},
+				{
+					TargetIP: "10.10.2.2",
+					Port:     309,
+				},
+			},
+		},
+		{
+			name:               "Only add endpoints for port 8675 to build spec",
+			srvExportName:      "export6",
+			srvExportNamespace: "ns1",
+			port:               8675,
+			endPoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "export6",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
+							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+						},
+					},
+				},
+			},
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "ns1",
+					Name:              "export6",
+					DeletionTimestamp: nil,
+				},
+			},
+			inDataStore:        true,
+			refByServiceExport: true,
+			wantErrIsNil:       true,
+			expectedTargetList: []latticemodel.Target{
+				{
+					TargetIP: "10.10.1.1",
+					Port:     8675,
+				},
+				{
+					TargetIP: "10.10.2.2",
+					Port:     8675,
+				},
+			},
+		},
+		{
+			name:               "BackendRef port does not match service port",
+			srvExportName:      "export7",
+			srvExportNamespace: "ns1",
+			port:               8750,
+			endPoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "export7",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
+							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+						},
+					},
+				},
+			},
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "ns1",
+					Name:              "export7",
+					DeletionTimestamp: nil,
+				},
+			},
+			inDataStore:        false,
+			refByService:       true,
+			refByServiceExport: true,
+			wantErrIsNil:       false,
+		},
+		{
+			name:               "One port added via backendref match, one port added via service export annotation",
+			srvExportName:      "export8",
+			srvExportNamespace: "ns1",
+			port:               8675,
+			endPoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "export7",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
+							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+						},
+					},
+				},
+			},
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "ns1",
+					Name:              "export7",
+					DeletionTimestamp: nil,
+				},
+			},
+			serviceExport: mcs_api.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "ns1",
+					Name:              "export1",
+					DeletionTimestamp: nil,
+					Annotations:       map[string]string{"multicluster.x-k8s.io/port": "309"},
+				},
+			},
+			inDataStore:        false,
+			refByService:       true,
+			refByServiceExport: true,
+			wantErrIsNil:       false,
 			expectedTargetList: []latticemodel.Target{
 				{
 					TargetIP: "10.10.1.1",
@@ -349,6 +486,7 @@ func Test_Targets(t *testing.T) {
 			tgName:      tt.srvExportName,
 			tgNamespace: tt.srvExportNamespace,
 			datastore:   ds,
+			port:        tt.port,
 			stack:       core.NewDefaultStack(core.StackID(srvName)),
 		}
 		err := targetTask.buildLatticeTargets(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#241 

**What does this PR do / Why do we need it**:
it only creates targets if the backend ref port or service export port matches the service port.  Matches all ports if no port specified

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
test cases.  no access to e2e test automation.  Added new test cases
**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
no
**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
no
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no
**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note
fix: only creates targets if the backend ref port or service export port matches the service port
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.