### PR TITLE
Make EC2 instance metadata unavailable in controller config tests

### DIFF
--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -41,6 +41,10 @@ func GetClusterLocalGateway() (string, error) {
 func ConfigInit() error {
 	sess, _ := session.NewSession()
 	metadata := NewEC2Metadata(sess)
+	return configInit(metadata)
+}
+
+func configInit(metadata EC2Metadata) error {
 	var err error
 
 	// CLUSTER_VPC_ID

--- a/pkg/config/controller_config_test.go
+++ b/pkg/config/controller_config_test.go
@@ -1,11 +1,31 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type ec2MetadataUnavaialble struct {
+}
+
+func (m ec2MetadataUnavaialble) Region() (string, error) {
+	return "", errors.New("EC2 metadata not available in this test on purpose")
+}
+
+func (m ec2MetadataUnavaialble) VpcID() (string, error) {
+	return "", errors.New("EC2 metadata not available in this test on purpose")
+}
+
+func (m ec2MetadataUnavaialble) AccountId() (string, error) {
+	return "", errors.New("EC2 metadata not available in this test on purpose")
+}
+
+func ec2MetadataUnavailable() EC2Metadata {
+	return ec2MetadataUnavaialble{}
+}
 
 func Test_config_init_with_partial_env_var(t *testing.T) {
 	// Test variable
@@ -18,7 +38,7 @@ func Test_config_init_with_partial_env_var(t *testing.T) {
 	os.Setenv(CLUSTER_LOCAL_GATEWAY, testClusterLocalGateway)
 	os.Unsetenv(AWS_ACCOUNT_ID)
 	os.Unsetenv(TARGET_GROUP_NAME_LEN_MODE)
-	err := ConfigInit()
+	err := configInit(ec2MetadataUnavailable())
 	assert.NotNil(t, err)
 }
 
@@ -28,7 +48,7 @@ func Test_config_init_no_env_var(t *testing.T) {
 	os.Unsetenv(CLUSTER_LOCAL_GATEWAY)
 	os.Unsetenv(AWS_ACCOUNT_ID)
 	os.Unsetenv(TARGET_GROUP_NAME_LEN_MODE)
-	err := ConfigInit()
+	err := configInit(ec2MetadataUnavailable())
 	assert.NotNil(t, err)
 
 }
@@ -46,7 +66,7 @@ func Test_config_init_with_all_env_var(t *testing.T) {
 	os.Setenv(CLUSTER_LOCAL_GATEWAY, testClusterLocalGateway)
 	os.Setenv(AWS_ACCOUNT_ID, testAwsAccountId)
 	os.Setenv(TARGET_GROUP_NAME_LEN_MODE, testTargetGroupNameLenMode)
-	ConfigInit()
+	configInit(ec2MetadataUnavailable())
 	assert.Equal(t, Region, testRegion)
 	assert.Equal(t, VpcID, testClusterVpcId)
 	assert.Equal(t, AccountID, testAwsAccountId)


### PR DESCRIPTION
The code under test falls back to reading AWS region, account ID, and VPC ID from Instance Metadata Service. The tests currently assume that this service is unavaiable. This means they fail when run in environments where this service is available to tests.

This commit fixes this issue by making the tests use a mock Instance Metadata Service which returns an error. This ensures that these tests work as expected regardless of whether Instance Metadata Service is available/reachable.