### PR TITLE
e2e test enhancements for better performance and reliability

### DIFF
--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -64,6 +64,7 @@ type Framework struct {
 	client.Client
 	ctx                                 context.Context
 	k8sScheme                           *runtime.Scheme
+	namespace                           string
 	controllerRuntimeConfig             *rest.Config
 	LatticeClient                       services.Lattice
 	TestCasesCreatedServiceNetworkNames map[string]bool //key: ServiceNetworkName; value: not in use, meaningless
@@ -74,7 +75,7 @@ type Framework struct {
 	TestCasesCreatedK8sResource []client.Object
 }
 
-func NewFramework(ctx context.Context) *Framework {
+func NewFramework(ctx context.Context, testNamespace string) *Framework {
 	var scheme = scheme.Scheme
 	lo.Must0(v1beta1.Install(scheme))
 	lo.Must0(v1alpha1.Install(scheme))
@@ -85,6 +86,7 @@ func NewFramework(ctx context.Context) *Framework {
 		LatticeClient:                       services.NewDefaultLattice(session.Must(session.NewSession()), config.Region), // region is currently hardcoded
 		ctx:                                 ctx,
 		k8sScheme:                           scheme,
+		namespace:                           testNamespace,
 		controllerRuntimeConfig:             controllerRuntimeConfig,
 		TestCasesCreatedServiceNetworkNames: make(map[string]bool),
 		TestCasesCreatedServiceNames:        make(map[string]bool),
@@ -92,8 +94,6 @@ func NewFramework(ctx context.Context) *Framework {
 	}
 	SetDefaultEventuallyTimeout(3 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
-	BeforeEach(func() { framework.ExpectToBeClean(ctx) })
-	AfterEach(func() { framework.ExpectToBeClean(ctx) })
 	return framework
 }
 
@@ -108,12 +108,12 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 	retrievedServiceNetworkVpcAssociations, _ := env.LatticeClient.ListServiceNetworkVpcAssociationsAsList(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{
 		VpcIdentifier: aws.String(CurrentClusterVpcId),
 	})
-	Logger(ctx).Infof("Expect VPC used by current cluster don't have any ServiceNetworkVPCAssociation, if it has you should manually delete it")
+	Logger(ctx).Infof("Expect VPC used by current cluster has no ServiceNetworkVPCAssociation, if it does you should manually delete it")
 	Expect(len(retrievedServiceNetworkVpcAssociations)).To(Equal(0))
 	Eventually(func(g Gomega) {
 		retrievedServiceNetworks, _ := env.LatticeClient.ListServiceNetworksAsList(ctx, &vpclattice.ListServiceNetworksInput{})
 		for _, sn := range retrievedServiceNetworks {
-			Logger(ctx).Infof("Found service network, checking whether it's created by current EKS Cluster: %v", sn)
+			Logger(ctx).Infof("Found service network, checking if created by current EKS Cluster: %v", sn)
 			g.Expect(*sn.Name).Should(Not(BeKeyOf(env.TestCasesCreatedServiceNetworkNames)))
 			retrievedTags, err := env.LatticeClient.ListTagsForResourceWithContext(ctx, &vpclattice.ListTagsForResourceInput{
 				ResourceArn: sn.Arn,
@@ -130,7 +130,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 
 		retrievedServices, _ := env.LatticeClient.ListServicesAsList(ctx, &vpclattice.ListServicesInput{})
 		for _, service := range retrievedServices {
-			Logger(ctx).Infof("Found service, checking whether it's created by current EKS Cluster: %v", service)
+			Logger(ctx).Infof("Found service, checking if created by current EKS Cluster: %v", service)
 			g.Expect(*service.Name).Should(Not(BeKeyOf(env.TestCasesCreatedServiceNames)))
 			retrievedTags, err := env.LatticeClient.ListTagsForResourceWithContext(ctx, &vpclattice.ListTagsForResourceInput{
 				ResourceArn: service.Arn,
@@ -146,7 +146,7 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 
 		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
 		for _, tg := range retrievedTargetGroups {
-			Logger(ctx).Infof("Found TargetGroup: %s, checking it whether it's created by current EKS Cluster", *tg.Id)
+			Logger(ctx).Infof("Found TargetGroup: %s, checking if created by current EKS Cluster", *tg.Id)
 			if tg.VpcIdentifier != nil && CurrentClusterVpcId != *tg.VpcIdentifier {
 				Logger(ctx).Infof("Target group VPC Id: %s, does not match current EKS Cluster VPC Id: %s", *tg.VpcIdentifier, CurrentClusterVpcId)
 				//This tg is not created by current EKS Cluster, skip it
@@ -165,12 +165,13 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 					//so we temporarily skip to verify whether ServiceExport created TargetGroup is deleted or not
 					continue
 				}
-				Expect(env.TestCasesCreatedServiceNames).To(Not(ContainElements(BeKeyOf(*tg.Name))))
+				g.Expect(env.TestCasesCreatedServiceNames).To(Not(ContainElements(BeKeyOf(*tg.Name))))
 			}
 		}
 	}).Should(Succeed())
 }
 
+// if we still want this method, we should tag the things we create with the test suite
 func (env *Framework) CleanTestEnvironment(ctx context.Context) {
 	defer GinkgoRecover()
 	Logger(ctx).Info("Cleaning the test environment")
@@ -209,10 +210,21 @@ func (env *Framework) ExpectUpdated(ctx context.Context, objects ...client.Objec
 	}
 }
 
+func (env *Framework) ExpectDeletedThenNotFound(ctx context.Context, objects ...client.Object) {
+	env.ExpectDeleted(ctx, objects...)
+	env.EventuallyExpectNotFound(ctx, objects...)
+}
+
 func (env *Framework) ExpectDeleted(ctx context.Context, objects ...client.Object) {
 	for _, object := range objects {
 		Logger(ctx).Infof("Deleting %s %s/%s", reflect.TypeOf(object), object.GetNamespace(), object.GetName())
-		Expect(env.Delete(ctx, object)).WithOffset(1).To(Succeed())
+		err := env.Delete(ctx, object)
+		if err != nil {
+			// not found is probably OK - means it was deleted elsewhere
+			if !errors.IsNotFound(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
 	}
 }
 
@@ -223,8 +235,10 @@ func (env *Framework) ExpectDeleteAllToSucceed(ctx context.Context, object clien
 func (env *Framework) EventuallyExpectNotFound(ctx context.Context, objects ...client.Object) {
 	Eventually(func(g Gomega) {
 		for _, object := range objects {
-			Logger(ctx).Infof("Checking whether %s %s %s is not found", reflect.TypeOf(object), object.GetNamespace(), object.GetName())
-			g.Expect(errors.IsNotFound(env.Get(ctx, client.ObjectKeyFromObject(object), object))).To(BeTrue())
+			if object != nil {
+				Logger(ctx).Infof("Checking whether %s %s/%s is not found", reflect.TypeOf(object), object.GetNamespace(), object.GetName())
+				g.Expect(errors.IsNotFound(env.Get(ctx, client.ObjectKeyFromObject(object), object))).To(BeTrue())
+			}
 		}
 		// Wait for 7 minutes at maximum just in case the k8sService deletion triggered targets draining time
 		// and httproute deletion need to wait for that targets draining time finish then it can return
@@ -267,6 +281,7 @@ func (env *Framework) GetVpcLatticeService(ctx context.Context, httpRoute *v1bet
 		}
 		g.Expect(found).ToNot(BeNil())
 		g.Expect(found.Status).To(Equal(lo.ToPtr(vpclattice.ServiceStatusActive)))
+		g.Expect(found.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
 	}).WithOffset(1).Should(Succeed())
 
 	return found
@@ -293,7 +308,7 @@ func (env *Framework) GetTargetGroup(ctx context.Context, service *v1.Service) *
 func (env *Framework) GetTargets(ctx context.Context, targetGroup *vpclattice.TargetGroupSummary, deployment *appsv1.Deployment) []*vpclattice.TargetSummary {
 	var found []*vpclattice.TargetSummary
 	Eventually(func(g Gomega) {
-		log.Println("Trying to retrieve registered targets for targetGroup", targetGroup)
+		log.Println("Trying to retrieve registered targets for targetGroup: ", *targetGroup.Id)
 		log.Println("deployment.Spec.Selector.MatchLabels:", deployment.Spec.Selector.MatchLabels)
 		podList := &v1.PodList{}
 		expectedMatchingLabels := make(map[string]string, len(deployment.Spec.Selector.MatchLabels))
@@ -524,8 +539,6 @@ func (env *Framework) DeleteAllFrameworkTracedVpcLatticeServices(ctx aws.Context
 }
 
 func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
-	log.Println("DeleteAllFrameworkTracedTargetGroups ", env.TestCasesCreatedTargetGroupNames)
-	var tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted []string
 	targetGroups, err := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
 	Expect(err).ToNot(HaveOccurred())
 	filteredTgs := lo.Filter(targetGroups, func(targetGroup *vpclattice.TargetGroupSummary, _ int) bool {
@@ -538,13 +551,35 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 
 	log.Println("Number of traced target groups to delete is:", len(tgIds))
 
+	var tgsToDeregister []string
 	for _, tgId := range tgIds {
-		targetSummaries, err := env.LatticeClient.ListTargetsAsList(ctx, &vpclattice.ListTargetsInput{
+		log.Println("Attempting to delete target group: ", tgId)
+
+		_, err := env.LatticeClient.DeleteTargetGroup(&vpclattice.DeleteTargetGroupInput{
 			TargetGroupIdentifier: tgId,
 		})
+		if err != nil {
+			tgsToDeregister = append(tgsToDeregister, *tgId)
+		} else {
+			log.Println("Deleted target group: ", tgId)
+		}
+	}
+
+	// next try to deregister targets
+	var tgsToDelete []string
+	for _, tgId := range tgsToDeregister {
+		targetSummaries, err := env.LatticeClient.ListTargetsAsList(ctx, &vpclattice.ListTargetsInput{
+			TargetGroupIdentifier: &tgId,
+		})
+
+		if err.(awserr.Error).Code() == vpclattice.ErrCodeResourceNotFoundException {
+			log.Println("Target group already deleted: ", tgId)
+			continue
+		}
+
 		Expect(err).ToNot(HaveOccurred())
+		tgsToDelete = append(tgsToDelete, tgId)
 		if len(targetSummaries) > 0 {
-			tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted = append(tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted, *tgId)
 			var targets []*vpclattice.Target = lo.Map(targetSummaries, func(targetSummary *vpclattice.TargetSummary, _ int) *vpclattice.Target {
 				return &vpclattice.Target{
 					Id:   targetSummary.Id,
@@ -552,32 +587,20 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 				}
 			})
 			env.LatticeClient.DeregisterTargetsWithContext(ctx, &vpclattice.DeregisterTargetsInput{
-				TargetGroupIdentifier: tgId,
+				TargetGroupIdentifier: &tgId,
 				Targets:               targets,
 			})
-		} else {
-			Logger(ctx).Infof("Target group %s no longer has targets registered. Deleting now.", *tgId)
-			Eventually(func() bool {
-				_, err := env.LatticeClient.DeleteTargetGroup(&vpclattice.DeleteTargetGroupInput{
-					TargetGroupIdentifier: tgId,
-				})
-				if err != nil {
-					// Allow time for related service to be deleted prior
-					return err.(awserr.Error).Code() == vpclattice.ErrCodeResourceNotFoundException
-				}
-				return true
-			}).WithPolling(15 * time.Second).WithTimeout(2 * time.Minute).Should(BeTrue())
 		}
 	}
 
-	if len(tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted) > 0 {
-		log.Println("Need to wait for draining targets to be deregistered", tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted)
-		//After initiating the DeregisterTargets call, the Targets will be in `draining` status for the next 5 minutes,
-		//And VPC lattice backend will run a background job to completely delete the targets within 6 minutes at maximum in total.
+	if len(tgsToDelete) > 0 {
+		log.Println("Need to wait for draining targets to be deregistered", tgsToDelete)
+		// After initiating the DeregisterTargets call, the Targets will be in `draining` status for the next 5 minutes,
+		// And VPC lattice backend will run a background job to completely delete the targets within 6 minutes at maximum in total.
 		Eventually(func(g Gomega) {
-			log.Println("Trying to clear Target group", tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted, "need to wait for draining targets to be deregistered")
+			log.Println("Trying to clear Target group", tgsToDelete, "need to wait for draining targets to be deregistered")
 
-			for _, tgId := range tgIdsThatNeedToWaitForDrainingTargetsToBeDeleted {
+			for _, tgId := range tgsToDelete {
 				_, err := env.LatticeClient.DeleteTargetGroupWithContext(ctx, &vpclattice.DeleteTargetGroupInput{
 					TargetGroupIdentifier: &tgId,
 				})
@@ -585,7 +608,7 @@ func (env *Framework) DeleteAllFrameworkTracedTargetGroups(ctx aws.Context) {
 					g.Expect(err.(awserr.Error).Code()).To(Equal(vpclattice.ErrCodeResourceNotFoundException))
 				}
 			}
-		}).WithPolling(time.Minute).WithTimeout(7 * time.Minute).Should(Succeed())
+		}).WithPolling(15 * time.Second).WithTimeout(7 * time.Minute).Should(Succeed())
 
 	}
 	env.TestCasesCreatedServiceNames = make(map[string]bool)
@@ -597,4 +620,8 @@ func (env *Framework) GetVpcLatticeServiceDns(httpRouteName string, httpRouteNam
 	env.Get(env.ctx, types.NamespacedName{Name: httpRouteName, Namespace: httpRouteNamespace}, &httproute)
 	vpcLatticeServiceDns := httproute.Annotations[controllers.LatticeAssignedDomainName]
 	return vpcLatticeServiceDns
+}
+
+func (env *Framework) SleepForRouteDeletion() {
+	time.Sleep(30 * time.Second)
 }

--- a/test/pkg/test/header_match_httproute.go
+++ b/test/pkg/test/header_match_httproute.go
@@ -3,6 +3,7 @@ package test
 import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
@@ -40,6 +41,9 @@ func (env *Framework) NewHeaderMatchHttpRoute(parentRefsGateway *v1beta1.Gateway
 		rules = append(rules, rule)
 	}
 	httpRoute := New(&v1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: env.namespace,
+		},
 		Spec: v1beta1.HTTPRouteSpec{
 			CommonRouteSpec: v1beta1.CommonRouteSpec{
 				ParentRefs: []v1beta1.ParentReference{{
@@ -51,7 +55,7 @@ func (env *Framework) NewHeaderMatchHttpRoute(parentRefsGateway *v1beta1.Gateway
 		},
 	})
 
-	env.TestCasesCreatedServiceNames[latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)] = true
+	env.TestCasesCreatedServiceNames[latticestore.LatticeServiceName(httpRoute.Name, parentRefsGateway.Namespace)] = true
 	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, httpRoute)
 	return httpRoute
 }

--- a/test/pkg/test/service_export_import.go
+++ b/test/pkg/test/service_export_import.go
@@ -15,7 +15,8 @@ func (env *Framework) CreateServiceExportAndServiceImportByService(service *v1.S
 			Kind:       "ServiceExport",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: service.Name,
+			Name:      service.Name,
+			Namespace: service.Namespace,
 			Annotations: map[string]string{
 				"multicluster.x-k8s.io/federation": "amazon-vpc-lattice",
 			},
@@ -27,7 +28,8 @@ func (env *Framework) CreateServiceExportAndServiceImportByService(service *v1.S
 			Kind:       "ServiceImport",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: service.Name,
+			Name:      service.Name,
+			Namespace: service.Namespace,
 		},
 		Spec: v1alpha1.ServiceImportSpec{
 			Type: v1alpha1.ClusterSetIP,

--- a/test/pkg/test/weighted_routing_httproute.go
+++ b/test/pkg/test/weighted_routing_httproute.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -36,6 +37,9 @@ func (env *Framework) NewWeightedRoutingHttpRoute(parentRefsGateway *v1beta1.Gat
 		})
 	}
 	httpRoute := New(&v1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: parentRefsGateway.Namespace,
+		},
 		Spec: v1beta1.HTTPRouteSpec{
 			CommonRouteSpec: v1beta1.CommonRouteSpec{
 				ParentRefs: parentRefs,

--- a/test/suites/integration/httproute_creation_test.go
+++ b/test/suites/integration/httproute_creation_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -8,30 +9,19 @@ import (
 	"os"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
-	"time"
-
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
-	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
 var _ = Describe("HTTPRoute Creation", func() {
 
 	var (
-		gateway           *v1beta1.Gateway
-		deployment        *appsv1.Deployment
-		service           *v1.Service
-		serviceExport     *v1alpha1.ServiceExport
-		serviceImport     *v1alpha1.ServiceImport
-		httpRoute         *v1beta1.HTTPRoute
-		vpcLatticeService *vpclattice.ServiceSummary
-		targetGroup       *vpclattice.TargetGroupSummary
+		deployment    *appsv1.Deployment
+		service       *v1.Service
+		serviceExport *v1alpha1.ServiceExport
+		serviceImport *v1alpha1.ServiceImport
+		httpRoute     *v1beta1.HTTPRoute
 	)
 
 	BeforeEach(func() {
-		gateway = testFramework.NewGateway("test-gateway", k8snamespace)
-		testFramework.ExpectCreated(ctx, gateway)
-
 		deployment, service = testFramework.NewElasticApp(test.ElasticSearchOptions{
 			Name:      "port-test",
 			Namespace: k8snamespace,
@@ -43,7 +33,7 @@ var _ = Describe("HTTPRoute Creation", func() {
 			serviceImport = testFramework.CreateServiceImport(service)
 			testFramework.ExpectCreated(ctx, serviceImport)
 
-			httpRoute = testFramework.NewHttpRoute(gateway, service)
+			httpRoute = testFramework.NewHttpRoute(testGateway, service)
 			testFramework.ExpectCreated(ctx, httpRoute)
 
 			serviceExport = testFramework.CreateServiceExport(service)
@@ -51,13 +41,13 @@ var _ = Describe("HTTPRoute Creation", func() {
 
 			testFramework.ExpectCreated(ctx, service, deployment)
 
-			verifyResourceCreation(vpcLatticeService, httpRoute, targetGroup, service)
+			verifyResourceCreation(httpRoute, service)
 		})
 	})
 
 	Context("Order #2: httpRoute, serviceImport, service, & serviceExport", func() {
 		It("creates successfully", func() {
-			httpRoute = testFramework.NewHttpRoute(gateway, service)
+			httpRoute = testFramework.NewHttpRoute(testGateway, service)
 			testFramework.ExpectCreated(ctx, httpRoute)
 
 			serviceImport = testFramework.CreateServiceImport(service)
@@ -68,7 +58,7 @@ var _ = Describe("HTTPRoute Creation", func() {
 			serviceExport = testFramework.CreateServiceExport(service)
 			testFramework.ExpectCreated(ctx, serviceExport)
 
-			verifyResourceCreation(vpcLatticeService, httpRoute, targetGroup, service)
+			verifyResourceCreation(httpRoute, service)
 		})
 	})
 
@@ -77,7 +67,7 @@ var _ = Describe("HTTPRoute Creation", func() {
 			serviceExport = testFramework.CreateServiceExport(service)
 			testFramework.ExpectCreated(ctx, serviceExport)
 
-			httpRoute = testFramework.NewHttpRoute(gateway, service)
+			httpRoute = testFramework.NewHttpRoute(testGateway, service)
 			testFramework.ExpectCreated(ctx, httpRoute)
 
 			serviceImport = testFramework.CreateServiceImport(service)
@@ -85,30 +75,30 @@ var _ = Describe("HTTPRoute Creation", func() {
 
 			testFramework.ExpectCreated(ctx, service, deployment)
 
-			verifyResourceCreation(vpcLatticeService, httpRoute, targetGroup, service)
+			verifyResourceCreation(httpRoute, service)
 		})
 	})
 
 	AfterEach(func() {
-		testFramework.ExpectDeleted(ctx, gateway, httpRoute)
-		time.Sleep(30 * time.Second) // Use a trick to delete httpRoute first and then delete the service and deployment to avoid draining lattice targets
-		testFramework.ExpectDeleted(ctx, deployment, service, serviceExport, serviceImport)
-		testFramework.EventuallyExpectNotFound(ctx, gateway, httpRoute, deployment, service, serviceExport, serviceImport)
+		testFramework.ExpectDeleted(ctx, httpRoute)
+		testFramework.SleepForRouteDeletion()
+		testFramework.ExpectDeletedThenNotFound(ctx,
+			deployment,
+			service,
+			serviceImport,
+			serviceExport,
+			httpRoute,
+		)
 	})
 })
 
 func verifyResourceCreation(
-	vpcLatticeService *vpclattice.ServiceSummary,
 	httpRoute *v1beta1.HTTPRoute,
-	targetGroup *vpclattice.TargetGroupSummary,
 	service *v1.Service,
 ) {
-	Eventually(func(g Gomega) {
-		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, httpRoute)
-		g.Expect(vpcLatticeService).NotTo(BeNil())
-		g.Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
-	}).Should(Succeed())
-	targetGroup = testFramework.GetTargetGroup(ctx, service)
+	_ = testFramework.GetVpcLatticeService(ctx, httpRoute)
+
+	targetGroup := testFramework.GetTargetGroup(ctx, service)
 	Expect(*targetGroup.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
 	Expect(*targetGroup.Protocol).To(Equal("HTTP"))
 }

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -2,46 +2,49 @@ package integration
 
 import (
 	"fmt"
-	"log"
-	"regexp"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"log"
+	"regexp"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"time"
 
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
 var _ = Describe("HTTPRoute header matches", func() {
-	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
-		gateway := testFramework.NewGateway("", "")
 
-		deployment3, service3 := testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3"})
-		headerMatchHttpRoute := testFramework.NewHeaderMatchHttpRoute(gateway, []*v1.Service{service3})
+	var (
+		deployment           *appsv1.Deployment
+		service              *v1.Service
+		headerMatchHttpRoute *v1beta1.HTTPRoute
+	)
+
+	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
+		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3", Namespace: k8snamespace})
+		headerMatchHttpRoute = testFramework.NewHeaderMatchHttpRoute(testGateway, []*v1.Service{service})
 
 		testFramework.ExpectCreated(ctx,
-			gateway,
 			headerMatchHttpRoute,
-			service3,
-			deployment3)
+			service,
+			deployment)
 
-		time.Sleep(3 * time.Minute)
 		vpcLatticeService := testFramework.GetVpcLatticeService(ctx, headerMatchHttpRoute)
-		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(headerMatchHttpRoute.Name, headerMatchHttpRoute.Namespace)))
+
+		log.Println("Verifying VPC lattice service listeners and rules")
 		Eventually(func(g Gomega) {
-			log.Println("Verifying VPC lattice service listeners and rules")
 			listListenerResp, err := testFramework.LatticeClient.ListListenersWithContext(ctx, &vpclattice.ListListenersInput{
 				ServiceIdentifier: vpcLatticeService.Id,
 			})
 			g.Expect(err).To(BeNil())
 			g.Expect(len(listListenerResp.Items)).To(BeEquivalentTo(1))
 			listener := listListenerResp.Items[0]
-			g.Expect(*listener.Port).To(BeEquivalentTo(gateway.Spec.Listeners[0].Port))
+			g.Expect(*listener.Port).To(BeEquivalentTo(testGateway.Spec.Listeners[0].Port))
 			listenerId := listener.Id
 			listRulesResp, err := testFramework.LatticeClient.ListRulesWithContext(ctx, &vpclattice.ListRulesInput{
 				ListenerIdentifier: listenerId,
@@ -49,49 +52,58 @@ var _ = Describe("HTTPRoute header matches", func() {
 			})
 
 			headerMatchRuleNameRegExp := regexp.MustCompile("^k8s-[0-9]+-rule-1$")
-			Expect(listRulesResp.Items).To(HaveLen(2)) //1 default rules + 1 newly added header match rule
+			g.Expect(listRulesResp.Items).To(HaveLen(2)) //1 default rules + 1 newly added header match rule
 			filteredRules := lo.Filter(listRulesResp.Items, func(rule *vpclattice.RuleSummary, _ int) bool {
 				return headerMatchRuleNameRegExp.MatchString(*rule.Name)
 			})
-			Expect(filteredRules).To(HaveLen(1))
+			g.Expect(filteredRules).To(HaveLen(1))
 			headerMatchRule, err := testFramework.LatticeClient.GetRuleWithContext(ctx, &vpclattice.GetRuleInput{
 				ServiceIdentifier:  vpcLatticeService.Id,
 				ListenerIdentifier: listenerId,
 				RuleIdentifier:     filteredRules[0].Id,
 			})
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			headerMatches := headerMatchRule.Match.HttpMatch.HeaderMatches
-			Expect(headerMatches).To(HaveLen(2))
-			Expect(*headerMatches[0].Name).To(Equal("my-header-name1"))
-			Expect(*headerMatches[0].Match.Exact).To(Equal("my-header-value1"))
-			Expect(*headerMatches[1].Name).To(Equal("my-header-name2"))
-			Expect(*headerMatches[1].Match.Exact).To(Equal("my-header-value2"))
+			g.Expect(headerMatches).To(HaveLen(2))
+			g.Expect(*headerMatches[0].Name).To(Equal("my-header-name1"))
+			g.Expect(*headerMatches[0].Match.Exact).To(Equal("my-header-value1"))
+			g.Expect(*headerMatches[1].Name).To(Equal("my-header-name2"))
+			g.Expect(*headerMatches[1].Match.Exact).To(Equal("my-header-value2"))
 		}).WithOffset(1).Should(Succeed())
 
-		log.Println("Verifying traffic")
 		dnsName := testFramework.GetVpcLatticeServiceDns(headerMatchHttpRoute.Name, headerMatchHttpRoute.Namespace)
-		testFramework.Get(ctx, types.NamespacedName{Name: deployment3.Name, Namespace: deployment3.Namespace}, deployment3)
-		pods := testFramework.GetPodsByDeploymentName(deployment3.Name, deployment3.Namespace)
+		testFramework.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment)
+		pods := testFramework.GetPodsByDeploymentName(deployment.Name, deployment.Namespace)
 		Expect(len(pods)).To(BeEquivalentTo(1))
 		log.Println("pods[0].Name:", pods[0].Name)
 
-		cmd := fmt.Sprintf("curl %s -H \"my-header-name1: my-header-value1\" -H \"my-header-name2: my-header-value2\"", dnsName)
-		stdout, _, err := testFramework.PodExec(pods[0].Namespace, pods[0].Name, cmd, true)
-		Expect(err).To(BeNil())
-		Expect(stdout).To(ContainSubstring("test-v3 handler pod"))
+		// after rules in place, it can take some time for listener rules to fully propagate
+		log.Println("Verifying traffic")
 
-		invalidCmd := fmt.Sprintf("curl %s -H \"my-header-name1: my-header-value1\" -H \"my-header-name2: value2-invalid\"", dnsName)
-		stdout2, _, err2 := testFramework.PodExec(pods[0].Namespace, pods[0].Name, invalidCmd, true)
-		Expect(err2).To(BeNil())
-		Expect(stdout2).To(ContainSubstring("Not Found"))
+		// check correct headers
+		Eventually(func(g Gomega) {
+			cmd := fmt.Sprintf("curl %s -H \"my-header-name1: my-header-value1\" -H \"my-header-name2: my-header-value2\"", dnsName)
+			stdout, _, err := testFramework.PodExec(pods[0].Namespace, pods[0].Name, cmd, true)
+			g.Expect(err).To(BeNil())
+			g.Expect(stdout).To(ContainSubstring("test-v3 handler pod"))
+		}).WithTimeout(30 * time.Second).WithOffset(1).Should(Succeed())
 
-		testFramework.ExpectDeleted(ctx, gateway, headerMatchHttpRoute)
-		time.Sleep(30 * time.Second) // Use a trick to delete httpRoute first and then delete the service and deployment to avoid draining lattice targets
-		testFramework.ExpectDeleted(ctx, deployment3, service3)
-		testFramework.EventuallyExpectNotFound(ctx,
-			gateway,
+		// check incorrect headers
+		Eventually(func(g Gomega) {
+			invalidCmd := fmt.Sprintf("curl %s -H \"my-header-name1: my-header-value1\" -H \"my-header-name2: value2-invalid\"", dnsName)
+			stdout, _, err := testFramework.PodExec(pods[0].Namespace, pods[0].Name, invalidCmd, true)
+			g.Expect(err).To(BeNil())
+			g.Expect(stdout).To(ContainSubstring("Not Found"))
+		}).WithTimeout(30 * time.Second).WithOffset(1).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		testFramework.ExpectDeleted(ctx, headerMatchHttpRoute)
+		testFramework.SleepForRouteDeletion()
+		testFramework.ExpectDeletedThenNotFound(ctx,
 			headerMatchHttpRoute,
-			deployment3,
-			service3)
+			service,
+			deployment,
+		)
 	})
 })

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -27,9 +27,16 @@ var _ = BeforeSuite(func() {
 
 	testFramework.ExpectToBeClean(ctx)
 
-	// would be good to simply wait here until service network has been provisioned and associated
+	// provision gateway, wait for service network association
 	testGateway = testFramework.NewGateway("test-gateway", k8snamespace)
 	testFramework.ExpectCreated(ctx, testGateway)
+
+	sn := testFramework.GetServiceNetwork(ctx, testGateway)
+
+	test.Logger(ctx).Infof("Expecting VPC %s and service network %s association", vpcid, *sn.Id)
+	Eventually(func(g Gomega) {
+		g.Expect(testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcid, sn)).To(BeTrue())
+	})
 })
 
 func TestIntegration(t *testing.T) {

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -36,7 +36,7 @@ var _ = BeforeSuite(func() {
 	test.Logger(ctx).Infof("Expecting VPC %s and service network %s association", vpcid, *sn.Id)
 	Eventually(func(g Gomega) {
 		g.Expect(testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcid, sn)).To(BeTrue())
-	})
+	}).Should(Succeed())
 })
 
 func TestIntegration(t *testing.T) {

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"os"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	"testing"
 
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
@@ -10,19 +11,34 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	k8snamespace = "non-default"
+)
+
 var testFramework *test.Framework
 var ctx context.Context
+var testGateway *v1beta1.Gateway
 
 var _ = BeforeSuite(func() {
 	vpcid := os.Getenv("CLUSTER_VPC_ID")
 	if vpcid == "" {
 		Fail("CLUSTER_VPC_ID environment variable must be set to run integration tests")
 	}
+
+	testFramework.ExpectToBeClean(ctx)
+
+	// would be good to simply wait here until service network has been provisioned and associated
+	testGateway = testFramework.NewGateway("test-gateway", k8snamespace)
+	testFramework.ExpectCreated(ctx, testGateway)
 })
 
 func TestIntegration(t *testing.T) {
 	ctx = test.NewContext(t)
-	testFramework = test.NewFramework(ctx)
+	testFramework = test.NewFramework(ctx, k8snamespace)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration")
 }
+
+var _ = AfterSuite(func() {
+	testFramework.ExpectDeletedThenNotFound(ctx, testGateway)
+})


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Improves dev quality of life, following on from https://github.com/aws/aws-application-networking-k8s/pull/330, this PR further improves the performance of e2e tests, their reliability, and resource cleanup. Main features of this PR:

* Provision a single gateway for the test suite
* Create all objects against the "non-default" namespace
* Move all persistent objects out of individual tests to allow cleanup even on failure
* Update all ```Eventually()``` blocks to use local expectations so failed assertions do not break out
* reliability enhancements
* minor refactoring

**Testing done on this change**:
e2e tests
```
Ran 11 of 11 Specs in 1744.934 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (1746.05s)
PASS
ok  	github.com/aws/aws-application-networking-k8s/test/suites/integration	1746.793s
```

**Will this PR introduce any new dependencies?**:
n/a

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.