### PR TITLE
Fix resource clean up for defined_target_ports_test.go

### DIFF
--- a/test/suites/integration/defined_target_ports_test.go
+++ b/test/suites/integration/defined_target_ports_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
-var _ = Describe("Defined Target Ports", Focus, func() {
+var _ = Describe("Defined Target Ports", func() {
 	var (
 		deployment        *appsv1.Deployment
 		service           *v1.Service


### PR DESCRIPTION
This PR change the way to clean up e2e test and seems it break the `defined_target_ports_test.go `, we should change this test file accordingly.  https://github.com/aws/aws-application-networking-k8s/pull/344

`make e2etest` success for `defined_target_ports_test.go` :
Ran 3 of 13 Specs in 741.309 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 10 Skipped
PASS | FOCUSED




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.