### PR TITLE
[Bugfix] Fix serviceexport deletion leaks targetgroup

### DIFF
--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -286,7 +286,6 @@ func (t *targetGroupSynthesizer) SynthesizeSDKTargetGroups(ctx context.Context) 
 			}
 
 		}
-
 		// the routename for serviceimport is ""
 		if tg, err := t.latticeDataStore.GetTargetGroup(*sdkTG.getTargetGroupOutput.Name, "", true); err == nil {
 			glog.V(6).Infof("Ignore target group created by service import %v\n", tg)
@@ -423,7 +422,7 @@ func (t *targetGroupSynthesizer) SynthesizeTriggeredTargetGroupsDeletion(ctx con
 
 		if resTargetGroup.Spec.Config.IsServiceImport {
 			glog.V(2).Infof("Deleting service import target group from local datastore %v", resTargetGroup.Spec.LatticeID)
-			t.latticeDataStore.DelTargetGroup(resTargetGroup.Spec.Name, resTargetGroup.Spec.Config.K8SHTTPRouteName, resTargetGroup.Spec.Config.IsServiceImport)
+			t.latticeDataStore.DelTargetGroup(resTargetGroup.Spec.Name, "", resTargetGroup.Spec.Config.IsServiceImport)
 		} else {
 			// For delete TargetGroup request triggered by k8s service, invoke vpc lattice api to delete it, if success, delete the tg in the datastore as well
 			err := t.targetGroupManager.Delete(ctx, resTargetGroup)

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -116,6 +116,10 @@ func Test_SynthesizeTriggeredServiceExport(t *testing.T) {
 			mockTGManager := NewMockTargetGroupManager(c)
 
 			ds := latticestore.NewLatticeDataStore()
+			if !tt.svcExport.DeletionTimestamp.IsZero() {
+				tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
+				ds.AddTargetGroup(tgName, "vpc-123456789", "123456789", "tg-123", false, "")
+			}
 
 			builder := gateway.NewTargetGroupBuilder(k8sClient, ds, nil)
 
@@ -824,9 +828,11 @@ func Test_SynthesizeTriggeredTargetGroupsCreation_TriggeredByServiceExport(t *te
 			mockTGManager := NewMockTargetGroupManager(c)
 
 			ds := latticestore.NewLatticeDataStore()
-
 			builder := gateway.NewTargetGroupBuilder(k8sClient, ds, nil)
-
+			if !tt.svcExport.DeletionTimestamp.IsZero() {
+				tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
+				ds.AddTargetGroup(tgName, "vpc-123456789", "arn123", "4567", false, "")
+			}
 			stack, tg, err := builder.Build(ctx, tt.svcExport)
 			assert.Nil(t, err)
 

--- a/pkg/latticestore/latticestore.go
+++ b/pkg/latticestore/latticestore.go
@@ -351,6 +351,11 @@ func (ds *LatticeDataStore) AddTargetGroup(name string, vpc string, arn string, 
 	return nil
 }
 
+// TODO: make this SetTargetGroupByBackendRef() method to be private, create seperate methods:
+//
+//	SetTargetGroupByBackendRefForK8sService(k8sServiceName string, routeName string, byServiceExport bool)
+//	SetTargetGroupByBackendRefForServiceImport(serviceImportName string, byServiceExport bool)
+//	SetTargetGroupByBackendRefForServiceExport(serviceExportName string, byServiceExport bool)
 func (ds *LatticeDataStore) SetTargetGroupByServiceExport(name string, isServiceImport bool, byServiceExport bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
@@ -371,6 +376,11 @@ func (ds *LatticeDataStore) SetTargetGroupByServiceExport(name string, isService
 
 }
 
+// TODO: make this SetTargetGroupByBackendRef() method to be private, create seperate methods:
+//
+//	SetTargetGroupByBackendRefForK8sService(name string, routeName string, byBackendRef bool),
+//	SetTargetGroupByBackendRefForServiceExport(name string, byBackendRef bool),
+//	SetTargetGroupByBackendRefForServiceImport(name string, byBackendRef bool)
 func (ds *LatticeDataStore) SetTargetGroupByBackendRef(name string, routeName string, isServiceImport bool, byBackendRef bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()
@@ -392,6 +402,11 @@ func (ds *LatticeDataStore) SetTargetGroupByBackendRef(name string, routeName st
 
 }
 
+// TODO: make this DelTargetGroup() method to be private, create seperate methods:
+//
+//	DelTargetGroupForK8sService(name string,routeName string)
+//	DelTargetGroupForServiceImport(name string)
+//	DelTargetGroupForServiceExport(name string)
 func (ds *LatticeDataStore) DelTargetGroup(name string, routeName string, isServiceImport bool) error {
 	ds.lock.Lock()
 	defer ds.lock.Unlock()

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -158,14 +158,6 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 			})
 			if err == nil {
 				Logger(ctx).Infof("Found Tags for tg %v tags: %v", *tg.Name, retrievedTags)
-				tagValue, ok := retrievedTags.Tags[lattice.K8SParentRefTypeKey]
-				if ok && *tagValue == lattice.K8SServiceExportType {
-					Logger(ctx).Infof("TargetGroup: %s was created by k8s controller, by a ServiceExport", *tg.Id)
-					//This tg is created by k8s controller, by a ServiceExport,
-					//ServiceExport still have a known targetGroup leaking issue,
-					//so we temporarily skip to verify whether ServiceExport created TargetGroup is deleted or not
-					continue
-				}
 				g.Expect(env.TestCasesCreatedServiceNames).To(Not(ContainElements(BeKeyOf(*tg.Name))))
 			}
 		}

--- a/test/suites/integration/defined_target_ports_test.go
+++ b/test/suites/integration/defined_target_ports_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
-var _ = Describe("Defined Target Ports", Focus, func() {
+var _ = Describe("Defined Target Ports", func() {
 	var (
 		deployment        *appsv1.Deployment
 		service           *v1.Service


### PR DESCRIPTION
**What type of PR is this?**
bug fix for serviceexport deletion leaks targetgroup issue  #269 


**Changes**:

- Refactor (t *targetGroupModelBuildTask) BuildTargetGroup(), make sure it can build model for serviceExport deletion request (the key point is the built model should have `IsDeleted: true`,`tg.Spec.LatticeID = dsTG.ID` )
- Split the ServiceExport creation and delete logic into 2 smaller helper functions: `buildTargetGroupForServiceExportCreation` and `buildTargetGroupForServiceExportDeletion` to make code eaiser to read
- Make sure we add/delete/update the correct latticeDataStore TargetGroup cache, so that the garbage collector logic: `SynthesizeSDKTargetGroups()` could be able to identifed the correct stale tgs, check the code changes for detail



**Testing done on this change**:

Run multiple times, all e2etest cases pass
```
[AfterSuite] PASSED [30.210 seconds]
------------------------------

Ran 13 of 13 Specs in 2320.742 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2321.24s)
```
Checked the aws vpc lattice console after e2etest finished, no target group leaking


### Manual test:

- Scenario 1: stand-alone serviceExport(No httproute created, in other words, created targetGroups don't have latticeServiceRule refer to it):

    - Scenario 1.1 create k8Service, serviceExport,tg created success, delete k8Service first, then delete serviceExport, tg, targets deleted success, no TG leak
    - Scenario 1.2 create k8Service, serviceExport, delete serviceExport first, then delete k8Service, , tg, targets deleted success, no TG leak

- Scenario 2: serviceExport's serviceImport referenced by a httproute
    - Scenario 2.1 Create httproute, k8Service, serviceImport serviceExport, all lattice created success. then, delete serviceExport first, tg will not be deleted as expected, since this tg is refered by latticeService. `kubectl delete serviceExport inventory-ver2` will not be stuck. Then, delete the httproute, the garbage collector logic `SynthesizeSDKTargetGroups()` be able to clean this inventory-ver2 tg, no any lattice resource leak
    - Scenario 2.2 Create httproute, k8Service, serviceImport serviceExport, all lattice created success. then, delete the the httproute first, then the  serviceExport become "stand-alone" status, delete this serviceExport could delete `inventory-ver2` tg success



**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->



```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.