### PR TITLE
Use right port on backendRef port match

### DIFF
--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -145,9 +145,9 @@ func (t *latticeServiceModelBuildTask) buildTargets(ctx context.Context) error {
 				backendNamespace = string(*httpBackendRef.Namespace())
 			}
 
-			port := int64(0)
+			var port int32
 			if httpBackendRef.Port() != nil {
-				port = int64(*httpBackendRef.Port())
+				port = int32(*httpBackendRef.Port())
 			}
 
 			targetTask := &latticeTargetsModelBuildTask{

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -151,14 +151,14 @@ func (t *latticeServiceModelBuildTask) buildTargets(ctx context.Context) error {
 			}
 
 			targetTask := &latticeTargetsModelBuildTask{
-				Client:      t.Client,
-				tgName:      string(httpBackendRef.Name()),
-				tgNamespace: backendNamespace,
-				routename:   t.route.Name(),
-				port:        port,
-				stack:       t.stack,
-				datastore:   t.Datastore,
-				route:       t.route,
+				Client:         t.Client,
+				tgName:         string(httpBackendRef.Name()),
+				tgNamespace:    backendNamespace,
+				routename:      t.route.Name(),
+				backendRefPort: port,
+				stack:          t.stack,
+				datastore:      t.Datastore,
+				route:          t.route,
 			}
 
 			err := targetTask.buildLatticeTargets(ctx)

--- a/pkg/gateway/model_build_targets_test.go
+++ b/pkg/gateway/model_build_targets_test.go
@@ -487,13 +487,13 @@ func Test_Targets(t *testing.T) {
 			Namespace: tt.srvExportNamespace,
 		}
 		targetTask := &latticeTargetsModelBuildTask{
-			Client:      k8sClient,
-			tgName:      tt.srvExportName,
-			tgNamespace: tt.srvExportNamespace,
-			datastore:   ds,
-			port:        tt.port,
-			stack:       core.NewDefaultStack(core.StackID(srvName)),
-			route:       tt.route,
+			Client:         k8sClient,
+			tgName:         tt.srvExportName,
+			tgNamespace:    tt.srvExportNamespace,
+			datastore:      ds,
+			backendRefPort: tt.port,
+			stack:          core.NewDefaultStack(core.StackID(srvName)),
+			route:          tt.route,
 		}
 		err := targetTask.buildLatticeTargets(ctx)
 		if tt.wantErrIsNil {

--- a/pkg/gateway/model_build_targets_test.go
+++ b/pkg/gateway/model_build_targets_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func Test_Targets(t *testing.T) {
@@ -28,7 +29,7 @@ func Test_Targets(t *testing.T) {
 		name               string
 		srvExportName      string
 		srvExportNamespace string
-		port               int64
+		port               int32
 		endPoints          []corev1.Endpoints
 		svc                corev1.Service
 		serviceExport      mcs_api.ServiceExport
@@ -53,7 +54,7 @@ func Test_Targets(t *testing.T) {
 					Subsets: []corev1.EndpointSubset{
 						{
 							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+							Ports:     []corev1.EndpointPort{{Port: 8675}},
 						},
 					},
 				},
@@ -65,25 +66,71 @@ func Test_Targets(t *testing.T) {
 					DeletionTimestamp: nil,
 				},
 			},
-			inDataStore:        true,
-			refByServiceExport: true,
-			wantErrIsNil:       true,
+			inDataStore:  true,
+			refByService: true,
+			wantErrIsNil: true,
 			expectedTargetList: []latticemodel.Target{
 				{
 					TargetIP: "10.10.1.1",
 					Port:     8675,
 				},
 				{
-					TargetIP: "10.10.1.1",
-					Port:     309,
-				},
-				{
 					TargetIP: "10.10.2.2",
+					Port:     8675,
+				},
+			},
+		},
+		{
+			name:               "Add endpoints with matching service port to build spec",
+			srvExportName:      "export1",
+			srvExportNamespace: "ns1",
+			port:               80,
+			endPoints: []corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "export1",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
+							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+						},
+					},
+				},
+			},
+			svc: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "ns1",
+					Name:              "export1",
+					DeletionTimestamp: nil,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "a",
+							Port:       80,
+							TargetPort: intstr.FromInt(8675),
+						},
+						{
+							Name:       "b",
+							Port:       81,
+							TargetPort: intstr.FromInt(309),
+						},
+					},
+				},
+			},
+			inDataStore:  true,
+			refByService: true,
+			wantErrIsNil: true,
+			expectedTargetList: []latticemodel.Target{
+				{
+					TargetIP: "10.10.1.1",
 					Port:     8675,
 				},
 				{
 					TargetIP: "10.10.2.2",
-					Port:     309,
+					Port:     8675,
 				},
 			},
 		},
@@ -112,13 +159,27 @@ func Test_Targets(t *testing.T) {
 					Name:              "export1",
 					DeletionTimestamp: nil,
 				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "a",
+							Port:       80,
+							TargetPort: intstr.FromInt(8675),
+						},
+						{
+							Name:       "b",
+							Port:       81,
+							TargetPort: intstr.FromInt(3090),
+						},
+					},
+				},
 			},
 			serviceExport: mcs_api.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:         "ns1",
 					Name:              "export1",
 					DeletionTimestamp: nil,
-					Annotations:       map[string]string{"multicluster.x-k8s.io/port": "3090"},
+					Annotations:       map[string]string{"multicluster.x-k8s.io/port": "81"},
 				},
 			},
 			inDataStore:        true,
@@ -436,13 +497,14 @@ func Test_Targets(t *testing.T) {
 		}
 		err := targetTask.buildLatticeTargets(ctx)
 		if tt.wantErrIsNil {
+			assert.Nil(t, err)
+
 			fmt.Printf("t.latticeTargets %v \n", targetTask.latticeTargets)
 			assert.Equal(t, tt.srvExportName, targetTask.latticeTargets.Spec.Name)
 			assert.Equal(t, tt.srvExportNamespace, targetTask.latticeTargets.Spec.Namespace)
 
 			// verify targets, ports are built correctly
 			assert.Equal(t, tt.expectedTargetList, targetTask.latticeTargets.Spec.TargetIPList)
-			assert.Nil(t, err)
 
 		} else {
 			assert.NotNil(t, err)

--- a/test/suites/integration/defined_target_ports_test.go
+++ b/test/suites/integration/defined_target_ports_test.go
@@ -1,21 +1,16 @@
 package integration
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/samber/lo"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"os"
-	"sigs.k8s.io/gateway-api/apis/v1beta1"
-	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
-	"time"
-
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"os"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 var _ = Describe("Defined Target Ports", func() {
@@ -23,131 +18,63 @@ var _ = Describe("Defined Target Ports", func() {
 		deployment        *appsv1.Deployment
 		service           *v1.Service
 		serviceExport     *v1alpha1.ServiceExport
-		serviceImport     *v1alpha1.ServiceImport
 		httpRoute         *v1beta1.HTTPRoute
 		vpcLatticeService *vpclattice.ServiceSummary
-		targetGroup       *vpclattice.TargetGroupSummary
 		definedPorts      []int64
 	)
 
-	const definedPort = 82
-
 	BeforeEach(func() {
 		deployment, service = testFramework.NewNginxApp(test.ElasticSearchOptions{
-			Name:      "e2e-ports-test",
+			Name:      "http",
+			Port:      8080,
+			Port2:     8081,
 			Namespace: k8snamespace,
 		})
+		serviceExport = testFramework.CreateServiceExport(service)
+		httpRoute = testFramework.NewHttpRoute(testGateway, service, "Service")
 	})
 
 	AfterEach(func() {
 		testFramework.ExpectDeleted(ctx, httpRoute)
 		testFramework.SleepForRouteDeletion()
 		testFramework.ExpectDeletedThenNotFound(ctx,
-			deployment,
-			service,
-			serviceImport,
 			serviceExport,
+			deployment,
+			service,
 			httpRoute,
 		)
 	})
 
-	It("Port Annotation on Service Export", func() {
-
-		serviceExport = testFramework.CreateServiceExport(service)
-		serviceImport = testFramework.CreateServiceImport(service)
-		httpRoute = testFramework.NewHttpRoute(testGateway, service, "ServiceImport")
+	It("take effect when on port annotation of ServiceExport", func() {
 		testFramework.ExpectCreated(
 			ctx,
+			service,
+			deployment,
 			serviceExport,
-			serviceImport,
-			service,
-			deployment,
-			httpRoute,
 		)
-		definedPorts = []int64{int64(service.Spec.Ports[0].Port), int64(service.Spec.Ports[1].Port)}
-		// Verify VPC Lattice Service exists
-		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, httpRoute)
-		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
-
-		performVerification(targetGroup, service, deployment, definedPorts)
+		definedPorts = []int64{int64(service.Spec.Ports[0].TargetPort.IntVal)}
+		performVerification(service, deployment, definedPorts)
 	})
 
-	It("Modify service port", func() {
-
-		serviceExport = testFramework.CreateServiceExport(service)
-		serviceImport = testFramework.CreateServiceImport(service)
-		httpRoute = testFramework.NewHttpRoute(testGateway, service, "Service")
+	It("take effect when on HttpRoute BackendRef", func() {
 		testFramework.ExpectCreated(
 			ctx,
 			service,
 			deployment,
 			httpRoute,
 		)
-		definedPorts = []int64{int64(service.Spec.Ports[0].Port), int64(service.Spec.Ports[1].Port)}
+		definedPorts = []int64{int64(service.Spec.Ports[0].TargetPort.IntVal)}
 		// Verify VPC Lattice Service exists
 		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, httpRoute)
 		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
 
-		performVerification(targetGroup, service, deployment, definedPorts)
-
-		definedPorts = []int64{int64(service.Spec.Ports[0].Port), int64(definedPort)}
-		testFramework.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, service)
-		service.Spec.Ports[1].Port = definedPort
-		service.Spec.Ports[1].TargetPort = intstr.FromInt(definedPort)
-		err := testFramework.Update(ctx, service)
-		Expect(err).To(BeNil())
-		testFramework.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, service)
-
-		targetGroup = testFramework.GetTargetGroup(ctx, service)
-		Expect(*targetGroup.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
-		Expect(*targetGroup.Protocol).To(Equal("HTTP"))
-
-		var verifiedIps []string
-		podIps, targets := testFramework.GetAllTargets(ctx, targetGroup, deployment)
-		Eventually(func(g Gomega) {
-			podIps, targets = testFramework.GetAllTargets(ctx, targetGroup, deployment)
-			for _, target := range targets {
-				if lo.Contains(verifiedIps, *target.Id) {
-					continue
-				} else if targetUsesDefinedPort(definedPorts, target) {
-					verifiedIps = append(verifiedIps, *target.Id)
-
-					// Health checks are completed on port 80 currently, once this is configurable we can check for healthy
-					g.Expect(*target.Status).To(Or(
-						Equal(vpclattice.TargetStatusInitial),
-						Equal(vpclattice.TargetStatusDraining),
-						Equal(vpclattice.TargetStatusUnhealthy),
-					))
-				}
-			}
-			g.Expect(podIps).Should(HaveLen(len(verifiedIps)))
-		}).WithPolling(10 * time.Second).WithTimeout(5 * time.Minute).Should(Succeed())
-	})
-
-	It("BackendRef Ports registered only", func() {
-
-		serviceExport = testFramework.CreateServiceExport(service)
-		serviceImport = testFramework.CreateServiceImport(service)
-		httpRoute = testFramework.NewHttpRoute(testGateway, service, "Service")
-		testFramework.ExpectCreated(
-			ctx,
-			service,
-			deployment,
-			httpRoute,
-		)
-		//time.Sleep(resourceCreationWaitTime)
-		definedPorts = []int64{int64(service.Spec.Ports[0].Port), int64(service.Spec.Ports[1].Port)}
-		// Verify VPC Lattice Service exists
-		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, httpRoute)
-		Expect(*vpcLatticeService.DnsEntry).To(ContainSubstring(latticestore.LatticeServiceName(httpRoute.Name, httpRoute.Namespace)))
-
-		performVerification(targetGroup, service, deployment, definedPorts)
+		performVerification(service, deployment, definedPorts)
 	})
 })
 
-func performVerification(targetGroup *vpclattice.TargetGroupSummary, service *v1.Service, deployment *appsv1.Deployment, definedPorts []int64) {
+func performVerification(service *v1.Service, deployment *appsv1.Deployment, definedPorts []int64) {
 	// Verify VPC Lattice Target Group exists
-	targetGroup = testFramework.GetTargetGroup(ctx, service)
+	targetGroup := testFramework.GetTargetGroup(ctx, service)
 	Expect(*targetGroup.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
 	Expect(*targetGroup.Protocol).To(Equal("HTTP"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

#241 

**What does this PR do / Why do we need it**:

Interpret backendRef port "correctly", it should be service port, not target port per [gwapi documentation](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.BackendObjectReference).

To do this, we need to figure out what is the right set of endpoint ports only based on the service port. We can deduce this by the following logic:

* [A service port MUST have a name if there are multiple ports exposed from a service](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services). Therefore, if a port is named, endpoint port is only relevant if it has the same name.
* If a service port is unnamed, it MUST be the only port that is exposed from a service. In this case, as long as the service port is matching with backendRef/annotations, we can consider all endpoints valid

This is also commented in the code.



**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
unit tests and e2e tests.

**Automation added to e2e**:
Fixed existing e2e test case, I just simplified it into two test scenarios that seems relevant to this use case.

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.