### PR TITLE
Add GRPC e2etest helper functions

### DIFF
--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -68,6 +68,7 @@ type Framework struct {
 	namespace                           string
 	controllerRuntimeConfig             *rest.Config
 	LatticeClient                       services.Lattice
+	GrpcurlRunner                       *v1.Pod
 	TestCasesCreatedServiceNetworkNames map[string]bool //key: ServiceNetworkName; value: not in use, meaningless
 	TestCasesCreatedServiceNames        map[string]bool //key: ServiceName; value not in use, meaningless
 	TestCasesCreatedTargetGroupNames    map[string]bool //key: TargetGroupName; value: not in use, meaningless
@@ -85,6 +86,7 @@ func NewFramework(ctx context.Context, testNamespace string) *Framework {
 	framework := &Framework{
 		Client:                              lo.Must(client.New(controllerRuntimeConfig, client.Options{Scheme: scheme})),
 		LatticeClient:                       services.NewDefaultLattice(session.Must(session.NewSession()), config.Region), // region is currently hardcoded
+		GrpcurlRunner:                       &v1.Pod{},
 		ctx:                                 ctx,
 		k8sScheme:                           scheme,
 		namespace:                           testNamespace,
@@ -633,6 +635,42 @@ func (env *Framework) GetVpcLatticeServiceDns(httpRouteName string, httpRouteNam
 	env.Get(env.ctx, types.NamespacedName{Name: httpRouteName, Namespace: httpRouteNamespace}, &httproute)
 	vpcLatticeServiceDns := httproute.Annotations[controllers.LatticeAssignedDomainName]
 	return vpcLatticeServiceDns
+}
+
+type RunGrpcurlCmdOptions struct {
+	GrpcServerHostName  string
+	GrpcServerPort      string
+	Service             string
+	Method              string
+	ReqParamsJsonString string
+	UseTLS              bool
+}
+
+// https://github.com/fullstorydev/grpcurl
+func (env *Framework) RunGrpcurlCmd(opts RunGrpcurlCmdOptions) (string, string, error) {
+	log.Println("CreateGrpcurlRunnerPod: ")
+	Expect(env.GrpcurlRunner).To(Not(BeNil()))
+
+	tlsOption := "-plaintext"
+	if opts.UseTLS {
+		tlsOption = "-insecure"
+	}
+	reqParams := ""
+	if opts.ReqParamsJsonString != "" {
+		reqParams = fmt.Sprintf("-d '%s'", opts.ReqParamsJsonString)
+	}
+
+	cmd := fmt.Sprintf("/grpcurl %s %s %s:%s %s/%s",
+		tlsOption,
+		reqParams,
+		opts.GrpcServerHostName,
+		opts.GrpcServerPort,
+		opts.Service,
+		opts.Method)
+
+	stdoutStr, stderrStr, err := env.PodExec(env.GrpcurlRunner.Namespace, env.GrpcurlRunner.Name, cmd, false)
+	return stdoutStr, stderrStr, err
+
 }
 
 func (env *Framework) SleepForRouteDeletion() {

--- a/test/pkg/test/grpc_helloworld.go
+++ b/test/pkg/test/grpc_helloworld.go
@@ -1,0 +1,69 @@
+package test
+
+import (
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// https://github.com/grpc/grpc-go/tree/master/examples/helloworld
+func (env *Framework) NewGrpcHelloWorld(options GrpcAppOptions) (*appsv1.Deployment, *v1.Service) {
+
+	deployment := New(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: lo.ToPtr(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": options.AppName,
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: options.Namespace,
+					Labels: map[string]string{
+						"app":          options.AppName,
+						DiscoveryLabel: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:  options.AppName,
+						Image: "aguilbau/hello-world-grpc:latest",
+					}},
+				},
+			},
+		},
+	})
+
+	service := New(&v1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"app": options.AppName,
+			},
+			Ports: []v1.ServicePort{
+				{
+					Name:       "hello-world-grpc",
+					Protocol:   v1.ProtocolTCP,
+					Port:       int32(10051),
+					TargetPort: intstr.FromInt(50051),
+				},
+			},
+		},
+	})
+	env.TestCasesCreatedTargetGroupNames[latticestore.TargetGroupName(service.Name, service.Namespace)] = true
+	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, service, deployment)
+	return deployment, service
+
+}

--- a/test/pkg/test/grpcbin.go
+++ b/test/pkg/test/grpcbin.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type GrpcAppOptions struct {
+	AppName   string
+	Namespace string
+}
+
+// https://github.com/moul/grpcbin
+func (env *Framework) NewGrpcBin(options GrpcAppOptions) (*appsv1.Deployment, *v1.Service) {
+
+	deployment := New(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: lo.ToPtr(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": options.AppName,
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: options.Namespace,
+					Labels: map[string]string{
+						"app":          options.AppName,
+						DiscoveryLabel: "true",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:  options.AppName,
+						Image: "moul/grpcbin:latest",
+					}},
+				},
+			},
+		},
+	})
+
+	service := New(&v1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: options.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"app": options.AppName,
+			},
+			Ports: []v1.ServicePort{
+				{
+					Name:       "grpcbin-over-http",
+					Protocol:   v1.ProtocolTCP,
+					Port:       int32(19000),
+					TargetPort: intstr.FromInt(9000),
+				},
+				{
+					Name:       "grpcbin-over-https",
+					Protocol:   v1.ProtocolTCP,
+					Port:       int32(19001),
+					TargetPort: intstr.FromInt(9001),
+				},
+			},
+		},
+	})
+	env.TestCasesCreatedTargetGroupNames[latticestore.TargetGroupName(service.Name, service.Namespace)] = true
+	env.TestCasesCreatedK8sResource = append(env.TestCasesCreatedK8sResource, service, deployment)
+	return deployment, service
+}

--- a/test/pkg/test/grpcurl_runner.go
+++ b/test/pkg/test/grpcurl_runner.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// https://github.com/fullstorydev/grpcurl
+func NewGrpcurlRunnerPod() *v1.Pod {
+	grpcurlPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "grpcurl-runner",
+			Labels: map[string]string{
+				"app": "grpcurl-runner",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "grpcurl-runner-container",
+					Image: "networld/grpcurl:latest",
+					Command: []string{
+						"/bin/sh",
+						"-c",
+						"while true; do sleep 5; done;",
+					},
+				},
+			},
+		},
+	}
+	return grpcurlPod
+}

--- a/test/suites/integration/defined_target_ports_test.go
+++ b/test/suites/integration/defined_target_ports_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
-var _ = Describe("Defined Target Ports", Focus, func() {
+var _ = Describe("Defined Target Ports", func() {
 	var (
 		deployment        *appsv1.Deployment
 		service           *v1.Service

--- a/test/suites/integration/grpcroute_traffic_test.go
+++ b/test/suites/integration/grpcroute_traffic_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"strconv"
+	"time"
+)
+
+var _ = Describe("GRPCRoute traffic test", func() {
+
+	var (
+		grpcBinDeployment        *appsv1.Deployment
+		grpcBinService           *v1.Service
+		grpcHelloWorldDeployment *appsv1.Deployment
+		grpcHelloWorldService    *v1.Service
+	)
+
+	BeforeEach(func() {
+		grpcBinDeployment, grpcBinService = testFramework.NewGrpcBin(test.GrpcAppOptions{AppName: "my-grpcbin-1", Namespace: k8snamespace})
+		grpcHelloWorldDeployment, grpcHelloWorldService = testFramework.NewGrpcHelloWorld(test.GrpcAppOptions{AppName: "my-grpc-hello-world-1", Namespace: k8snamespace})
+		testFramework.ExpectCreated(ctx, grpcBinDeployment, grpcBinService, grpcHelloWorldDeployment, grpcHelloWorldService)
+		time.Sleep(10 * time.Second)
+
+	})
+
+	It("Test GRPC traffic by k8s network only and don't use vpc lattice, "+
+		"only a demo for how to use grpc helper functions, this test case will be removed later", func() {
+
+		grpcurlCmdOptions := test.RunGrpcurlCmdOptions{
+			GrpcServerHostName: grpcBinService.Name + "." + grpcBinService.Namespace + ".svc.cluster.local",
+			GrpcServerPort:     "19000",
+			Service:            " grpcbin.GRPCBin",
+			Method:             "DummyUnary",
+			ReqParamsJsonString: `{
+								  "f_string": "myTestString",
+								  "f_int32": 42,
+								  "f_bool": true,
+								  "f_bytes": "SGVsbG8gV29ybGQ="
+								}`,
+			UseTLS: false,
+		}
+		stdoutStr, stderrStr, err := testFramework.RunGrpcurlCmd(grpcurlCmdOptions)
+		Expect(err).To(BeNil())
+		Expect(stderrStr).To(BeEmpty())
+		Expect(stdoutStr).To(ContainSubstring(`"fString": "myTestString"`))
+		Expect(stdoutStr).To(ContainSubstring(`"fInt32": 42`))
+
+		grpcurlCmdOptions = test.RunGrpcurlCmdOptions{
+			GrpcServerHostName:  grpcBinService.Name + "." + grpcBinService.Namespace + ".svc.cluster.local",
+			GrpcServerPort:      "19001",
+			Service:             " addsvc.Add",
+			Method:              "Sum",
+			ReqParamsJsonString: `{"a": 5, "b": 6}`,
+			UseTLS:              true,
+		}
+		stdoutStr, stderrStr, err = testFramework.RunGrpcurlCmd(grpcurlCmdOptions)
+		Expect(err).To(BeNil())
+		Expect(stderrStr).To(BeEmpty())
+		Expect(stdoutStr).To(ContainSubstring("\"v\": " + strconv.Itoa(5+6)))
+
+		grpcurlCmdOptions = test.RunGrpcurlCmdOptions{
+			GrpcServerHostName:  grpcHelloWorldService.Name + "." + grpcHelloWorldService.Namespace + ".svc.cluster.local",
+			GrpcServerPort:      "10051",
+			Service:             "helloworld.Greeter",
+			Method:              "SayHello",
+			ReqParamsJsonString: `{"name": "myTestName"}`,
+			UseTLS:              false,
+		}
+		stdoutStr, stderrStr, err = testFramework.RunGrpcurlCmd(grpcurlCmdOptions)
+		Expect(err).To(BeNil())
+		Expect(stderrStr).To(BeEmpty())
+		Expect(stdoutStr).To(ContainSubstring("Hello myTestName"))
+
+	})
+
+	AfterEach(func() {
+		testFramework.ExpectDeletedThenNotFound(ctx,
+			grpcBinService,
+			grpcBinDeployment,
+			grpcHelloWorldService,
+			grpcHelloWorldDeployment,
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: feature


**What does this PR do / Why do we need it**:

- Add grpcurl as a grpc client pod
- Add helper function `RunGrpcurlCmd()` to send grpc request
- Add grpc server grpcbin.go and grpc_helloworld.go


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Newly added test case can pass
```
Ran 1 of 14 Specs in 102.793 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 13 Skipped
PASS | FOCUSED
```

All e2e test can pass
```

Ran 14 of 14 Specs in 1993.337 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (1993.66s)
PASS
```

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.