### PR TITLE
ignore errors when get tags for service - Sn association

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -110,7 +110,7 @@ func (c *defaultCloud) IsArnManaged(arn string) (bool, error) {
 	tagsReq := &vpclattice.ListTagsForResourceInput{ResourceArn: &arn}
 	resp, err := c.lattice.ListTagsForResource(tagsReq)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	isManaged := c.ContainsManagedBy(resp.Tags)
 	return isManaged, nil

--- a/pkg/aws/cloud_test.go
+++ b/pkg/aws/cloud_test.go
@@ -75,7 +75,8 @@ func TestIsArnManaged(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		lat.EXPECT().ListTagsForResource(gomock.Any()).
 			Return(nil, errors.New(":("))
-		_, err := cl.IsArnManaged("arn")
-		assert.NotNil(t, err)
+		managed, err := cl.IsArnManaged("arn")
+		assert.Nil(t, err)
+		assert.False(t, managed)
 	})
 }


### PR DESCRIPTION
`lattice.ListTagsForResource(tagsReq)` can return NotFound error when I search association tags.

Error observed when association was created in different account. Use case
**Service A** exists in **account A**. Service **A** shared with _account  B_. _Account B_ creates association with _SN in B_ with **service A**. 

So Association belongs to account B, but service is managed by controller in account A.

For some reason ListTagsForResource does not return Lattice ResourceNotFoundException, but generic not found. Following error handling **is not working**

```go
		if aerr, ok := err.(awserr.Error); ok {
			if aerr.Code() == vpclattice.ErrCodeResourceNotFoundException {
				err = nil
			}
		}
```