### PR TITLE
Fix DNSEndpoint owner reference for GRPCRoute

### DIFF
--- a/pkg/deploy/externaldns/dnsendpoint_manager.go
+++ b/pkg/deploy/externaldns/dnsendpoint_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/golang/glog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -13,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/external-dns/endpoint"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type DnsEndpointManager interface {
@@ -44,12 +44,20 @@ func (s *defaultDnsEndpointManager) Create(ctx context.Context, service *lattice
 		return nil
 	}
 
-	httproute := &gateway_api.HTTPRoute{}
+	var (
+		route core.Route
+		err   error
+	)
 	routeNamespacedName := types.NamespacedName{
 		Namespace: service.Spec.Namespace,
 		Name:      service.Spec.Name,
 	}
-	if err := s.k8sClient.Get(ctx, routeNamespacedName, httproute); err != nil {
+	if service.Spec.RouteType == core.GrpcRouteType {
+		route, err = core.GetGRPCRoute(ctx, s.k8sClient, routeNamespacedName)
+	} else {
+		route, err = core.GetHTTPRoute(ctx, s.k8sClient, routeNamespacedName)
+	}
+	if err != nil {
 		glog.V(2).Infof("Skipping creation of %s: Could not find corresponding route", namespacedName.String())
 		return nil
 	}
@@ -77,7 +85,7 @@ func (s *defaultDnsEndpointManager) Create(ctx context.Context, service *lattice
 					},
 				},
 			}
-			controllerutil.SetControllerReference(httproute, ep, s.k8sClient.Scheme())
+			controllerutil.SetControllerReference(route.K8sObject(), ep, s.k8sClient.Scheme())
 			if err = s.k8sClient.Create(ctx, ep); err != nil {
 				glog.V(2).Infof("Failed creating DNSEndpoint: %s", err.Error())
 				return err

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -115,12 +115,15 @@ func (t *latticeServiceModelBuildTask) buildModel(ctx context.Context) error {
 }
 
 func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) error {
-	pro := "HTTP"
-	protocols := []*string{&pro}
+	routeType := core.HttpRouteType
+	if _, ok := t.route.(*core.GRPCRoute); ok {
+		routeType = core.GrpcRouteType
+	}
+
 	spec := latticemodel.ServiceSpec{
 		Name:      t.route.Name(),
 		Namespace: t.route.Namespace(),
-		Protocols: protocols,
+		RouteType: routeType,
 		//ServiceNetworkNames: string(t.route.Spec().ParentRefs()[0].Name),
 	}
 

--- a/pkg/gateway/model_build_lattice_service_test.go
+++ b/pkg/gateway/model_build_lattice_service_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func Test_LatticeServiceModelBuild(t *testing.T) {
@@ -55,6 +56,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		wantError     error
 		wantErrIsNil  bool
 		wantName      string
+		wantRouteType core.RouteType
 		wantIsDeleted bool
 	}{
 		{
@@ -80,6 +82,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			wantError:     nil,
 			wantName:      "service1",
+			wantRouteType: core.HttpRouteType,
 			wantIsDeleted: false,
 			wantErrIsNil:  true,
 		},
@@ -102,6 +105,29 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			wantError:     nil,
 			wantName:      "service1",
+			wantRouteType: core.HttpRouteType,
+			wantIsDeleted: false,
+			wantErrIsNil:  true,
+		},
+		{
+			name: "Add LatticeService with GRPCRoute",
+			route: core.NewGRPCRoute(gateway_api_v1alpha2.GRPCRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "service1",
+				},
+				Spec: gateway_api_v1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gateway_api.CommonRouteSpec{
+						ParentRefs: []gateway_api.ParentReference{
+							{
+								Name: "gateway1",
+							},
+						},
+					},
+				},
+			}),
+			wantError:     nil,
+			wantName:      "service1",
+			wantRouteType: core.GrpcRouteType,
 			wantIsDeleted: false,
 			wantErrIsNil:  true,
 		},
@@ -139,6 +165,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 
 			wantError:     nil,
 			wantName:      "service2",
+			wantRouteType: core.HttpRouteType,
 			wantIsDeleted: true,
 			wantErrIsNil:  true,
 		},

--- a/pkg/model/lattice/service.go
+++ b/pkg/model/lattice/service.go
@@ -14,8 +14,9 @@ type Service struct {
 }
 
 type ServiceSpec struct {
-	Name                string    `json:"name"`
-	Namespace           string    `json:"namespace"`
+	Name                string `json:"name"`
+	Namespace           string `json:"namespace"`
+	RouteType           core.RouteType
 	Protocols           []*string `json:"protocols"`
 	ServiceNetworkNames []string  `json:"servicenetworkhname"`
 	CustomerDomainName  string    `json:"customerdomainname"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Sets correct owner reference for DNSEndpoint if parent is GRPCRoute.


**What does this PR do / Why do we need it**:

Prevents leaking DNSEndpoint resource.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.