### PR TITLE
Add `ec2:DescribeTags` permission in VPCLatticeControllerIAMPolicy

### DIFF
--- a/config/iam/recommended-inline-policy.json
+++ b/config/iam/recommended-inline-policy.json
@@ -7,7 +7,8 @@
                 "vpc-lattice:*",
                 "iam:CreateServiceLinkedRole",
                 "ec2:DescribeVpcs",
-                "ec2:DescribeSubnets"
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags"
             ],
             "Resource": "*"
         }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -36,7 +36,8 @@ Run through them again for a second cluster to use with the extended example sho
                    "vpc-lattice:*",
                    "iam:CreateServiceLinkedRole",
                    "ec2:DescribeVpcs",
-                   "ec2:DescribeSubnets"
+                   "ec2:DescribeSubnets",
+                   "ec2:DescribeTags"
                ],
                "Resource": "*"
            }

--- a/examples/recommended-inline-policy.json
+++ b/examples/recommended-inline-policy.json
@@ -7,7 +7,8 @@
                 "vpc-lattice:*",
                 "iam:CreateServiceLinkedRole",
                 "ec2:DescribeVpcs",
-                "ec2:DescribeSubnets"
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
We recently change `getClusterName()` it will invoke `ec2Client.DescribeTags(tagReq)` to get the cluster name, so that the controller's iamserviceaccount should have this permission as well, otherwise it has this error:
```
{“level”:“fatal”,“ts”:1693435021.1204855,“logger”:“setup”,“caller”:“workspace/main.go:104”,“msg”:“init config failed: cannot get cluster name: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: dbe973a6-ea26-4548-add4-9d4e2d3772ab”,“stacktrace”:“main.main\n\t/workspace/main.go:104\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250”}
``` 

https://github.com/aws/aws-application-networking-k8s/blob/3fdd1c954162eef02bea4b0261b0ab334a9a4f53/pkg/config/controller_config.go#L125C27-L125C39

## Test
Add this permision and run controller by helm chart again, `configInit()` could success

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.