### PR TITLE
Update docs with latest guide on health checks

### DIFF
--- a/docs/configure/environment.md
+++ b/docs/configure/environment.md
@@ -4,13 +4,23 @@ The following environment variables are available, and all of them are optional.
 
 ---
 
+#### `CLUSTER_NAME`
+
+Type: string
+
+Default: Inferred from IMDS metadata
+
+A unique name to identify a cluster. This will be used in AWS resource tags to record ownership.
+
+---
+
 #### `CLUSTER_VPC_ID`
 
 Type: string
 
-Default: ""
+Default: Inferred from IMDS metadata
 
-When running AWS Gateway API Controller outside the Kubernetes Cluster, this specify the VPC of the cluster.
+When running AWS Gateway API Controller outside the Kubernetes Cluster, this specifies the VPC of the cluster.
 
 ---
 
@@ -18,9 +28,9 @@ When running AWS Gateway API Controller outside the Kubernetes Cluster, this spe
 
 Type: string
 
-Default: ""
+Default: Inferred from IMDS metadata
 
-When running AWS Gateway API Controller outside the Kubernetes Cluster, this specify the AWS account.
+When running AWS Gateway API Controller outside the Kubernetes Cluster, this specifies the AWS account.
 
 ---
 
@@ -30,7 +40,7 @@ Type: string
 
 Default: "us-west-2"
 
-When running AWS Gateway API Controller outside the Kubernetes Cluster, this specify the region of VPC lattice service endpoint
+When running AWS Gateway API Controller outside the Kubernetes Cluster, this specifies the region of VPC lattice service endpoint
 
 ---
 
@@ -40,7 +50,7 @@ Type: string
 
 Default: "info"
 
-When it is set as "debug", the AWS Gateway API Controller prints detailed debugging information.  Otherwise, it is only prints the key information
+When set as "debug", the AWS Gateway API Controller will emit debug level logs.
 
 
 ---
@@ -51,7 +61,8 @@ Type: string
 
 Default: "NO_DEFAULT_SERVICE_NETWORK"
 
-When it is set to something different than "NO_DEFAULT_SERVICE_NETWORK", the AWS Gateway API Controller will associate its correspoding Lattice Service Network to cluster's VPC.  Also, all HTTPRoutes will automatically have an additional parentref to this `CLUSTER_LOCAL_GATEWAY`
+When it is set to something different from "NO_DEFAULT_SERVICE_NETWORK", the AWS Gateway API Controller will associate its correspoding Lattice Service Network to cluster's VPC.
+Also, all HTTPRoutes will automatically have an additional parentref to this `CLUSTER_LOCAL_GATEWAY`.
 
 ---
 
@@ -61,27 +72,25 @@ Type: string
 
 Default:  "short"
 
-***If it is set to "long"*** 
- AWS Gateway API will create Lattice Target Group as follows
+When set to "long", the controller will create Lattice TargetGroup as follows.
 
-for backendRef of a Kubernetes Service:
+For Kubernetes Service as BackendRef:
 
-k8s-(k8s service name)-(k8s service namespace)-(k8s httproute name)-(VPC ID)
+`k8s-(k8s service name)-(k8s service namespace)-(k8s httproute name)-(VPC ID)-(protocol)-(protocol version)`
 
-for serviceexport of a Kubernetes Servic:
+For ServiceExport of a Kubernetes Service:
 
-k8s-(k8s service name)-(k8s service namespace)-(VPC-ID)
+`k8s-(k8s service name)-(k8s service namespace)-(VPC-ID)-(protocol)-(protocol version)`
 
-***By default***
-  AWS Gateway API will create Lattice Target Group as follows
+By default, the controller will create Lattice TargetGroup as follows
 
-for backendRef of a Kubernetes Service:
+For Kubernetes Service as BackendRef:
 
-k8s-(k8s service name)-(k8s service namespace)
+`k8s-(k8s service name)-(k8s service namespace)-(protocol)-(protocol version)`
 
-for serviceexport of a Kubernetes Service:
+For ServiceExport of a Kubernetes Service:
 
-k8s-(k8s service name)-(k8s service namespace)
+`k8s-(k8s service name)-(k8s service namespace)-(protocol)-(protocol version)`
 
 
 ```

--- a/docs/configure/environment.md
+++ b/docs/configure/environment.md
@@ -1,4 +1,4 @@
-### Configuration Variables
+### Environment Variables
 AWS Gateway API Controller for VPC Lattice supports a number of configuration options, which are set through environment variables.
 The following environment variables are available, and all of them are optional.
 

--- a/docs/reference/target-group-policy.md
+++ b/docs/reference/target-group-policy.md
@@ -63,7 +63,7 @@ For the detailed explanation and supported values, please refer to [VPC Lattice 
 * Omitting `healthCheck` results in [VPC Lattice default behavior](https://docs.aws.amazon.com/vpc-lattice/latest/ug/target-group-health-checks.html) depending on the protocol.
   * Health check is enabled by default for HTTP1 target groups.
   * Health check is disabled by default for HTTP2/gRPC target groups.
-* For targets behind GRPCRoute, you should create a separate endpoint to enable health checks - HTTP/2 health check directly on gRPC endpoints is not supported.
+* For targets behind GRPCRoute, you should create a separate endpoint dedicated for health checks - HTTP/2 health check directly on gRPC endpoints is not supported.
 
 |Field	|Description	|
 |---	|---	|

--- a/docs/reference/target-group-policy.md
+++ b/docs/reference/target-group-policy.md
@@ -21,8 +21,7 @@ The policy will not take effect if:
 These restrictions are not forced; for example, users may create a policy that targets a service that is not created yet.
 However, the policy will not take effect unless the target is valid.
 
-### Notes
-
+**Limitations and Considerations**
 * Attaching TargetGroupPolicy to a resource that is already referenced by a route will result in a replacement
 of VPC Lattice TargetGroup resource, except for health check updates.
 * Removing TargetGroupPolicy of a resource will roll back protocol configuration to default setting. (HTTP1/HTTP plaintext)
@@ -42,6 +41,9 @@ TargetGroupPolicySpec defines the desired state of TargetGroupPolicy.
 
 Updates to this configuration result in a replacement of VPC Lattice TargetGroup resource, except for `healthCheck` field.
 
+**Limitations and Considerations**
+* `HTTP2` protocolVersion is only allowed for services under TLS gateway listeners, as per VPC Lattice specification.
+
 |Field	| Description|
 |---	|---|
 |`targetRef` *[PolicyTargetReference](https://gateway-api.sigs.k8s.io/geps/gep-713/#policy-targetref-api)*	| TargetRef points to the kubernetes `Service` resource that will have this policy attached. This field is following the guidelines of Kubernetes Gateway API policy attachment. |
@@ -53,7 +55,15 @@ Updates to this configuration result in a replacement of VPC Lattice TargetGroup
 
 Appears on: TargetGroupPolicySpec
 
-HealthCheckConfig defines health check configuration for given VPC Lattice target group. For the detailed explanation and supported values, please refer to [VPC Lattice documentation](https://docs.aws.amazon.com/vpc-lattice/latest/ug/target-group-health-checks.html) on health checks.
+HealthCheckConfig defines health check configuration for given VPC Lattice target group.
+
+For the detailed explanation and supported values, please refer to [VPC Lattice documentation](https://docs.aws.amazon.com/vpc-lattice/latest/ug/target-group-health-checks.html) on health checks.
+
+**Limitations and Considerations**
+* Omitting `healthCheck` results in [VPC Lattice default behavior](https://docs.aws.amazon.com/vpc-lattice/latest/ug/target-group-health-checks.html) depending on the protocol.
+  * Health check is enabled by default for HTTP1 target groups.
+  * Health check is disabled by default for HTTP2/gRPC target groups.
+* For targets behind GRPCRoute, you should create a separate endpoint to enable health checks - HTTP/2 health check directly on gRPC endpoints is not supported.
 
 |Field	|Description	|
 |---	|---	|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Developer Guide: developer.md
   - Configuration:
     - Overview: configure/index.md
+    - Environment Variables: configure/environment.md
     - TLS: configure/https.md
     - Custom Domain Name: configure/custom-domain-name.md
     - GRPC: configure/grpc.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

documentation

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

* Updates TargetGroupPolicy reference to mention restrictions on gRPC health checks.
* Also restructured doc a bit, now includes environment setting in the website

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.