### PR TITLE
Bug fix, make sure delete k8sService de-registering targets

### DIFF
--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -8,12 +8,6 @@ import (
 
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
-	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
-	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
-	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +19,13 @@ import (
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcs_api "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
 func Test_TGModelByServicexportBuild(t *testing.T) {
@@ -398,7 +399,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 			wantError:           nil,
 			wantName:            "service1",
 			wantIsDeleted:       false,
-			wantErrIsNil:        false,
+			wantErrIsNil:        true,
 			wantIPv6TargetGroup: false,
 		},
 		{

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,8 +103,14 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 	}
 
 	if err := t.client.Get(ctx, namespacedName, svc); err != nil {
-		errmsg := fmt.Sprintf("Build Targets failed because K8S service %s does not exist", namespacedName)
-		return errors.New(errmsg)
+		glog.V(6).Infof("K8S service %s does not exist", namespacedName)
+		t.latticeTargets = latticemodel.NewTargets(t.stack, tgName, latticemodel.TargetsSpec{
+			Name:         t.tgName,
+			Namespace:    t.tgNamespace,
+			RouteName:    t.routeName,
+			TargetIPList: []latticemodel.Target{},
+		})
+		return nil
 	}
 
 	definedPorts := make(map[int32]struct{})

--- a/pkg/model/lattice/targetgroup.go
+++ b/pkg/model/lattice/targetgroup.go
@@ -1,8 +1,9 @@
 package lattice
 
 import (
-	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 )
 
 const (
@@ -22,11 +23,12 @@ type TargetGroup struct {
 }
 
 type TargetGroupSpec struct {
-	Name      string
-	Config    TargetGroupConfig `json:"config"`
-	Type      TargetGroupType
-	IsDeleted bool
-	LatticeID string
+	Name             string
+	Config           TargetGroupConfig `json:"config"`
+	Type             TargetGroupType
+	IsDeleted        bool
+	LatticeID        string
+	K8sServiceExists bool
 }
 
 type TargetGroupConfig struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** bug fix for #331 

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:  bug fix for #331 


**What does this PR do / Why do we need it**:

- make sure model_build_targetgroup.go and model_build_targets.go don't return too early so that when handing k8sService deletion event, route_controller.go could finally hit `targetsSynthesizer.Synthesize(ctx)` to deregister the targets
- Add a new field `K8sServiceExists bool` in TargetGroupSpec. Do `targetGroupManager.Create()` in `SynthesizeTriggeredTargetGroupsCreation` only if corresponding K8sServices exist




**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
Use  `my-hotel-gateway.yaml`, `inventory-route-path.yaml`(modified version, have 2 Kind:Service backendrefs), `inventory-ver1.yaml`, `inventory-ver2.yaml` to test various 2 k8sServices and httproute creation and deletion orders, all looks good


**Automation added to e2e**:
- un-commented one previous failed e2etest, whole e2etest suite can pass
```
Ran 29 of 29 Specs in 1928.783 seconds
SUCCESS! -- 29 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (1929.29s)
PASS
```

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.