### PR TITLE
add e2e cleanup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,12 @@ manifest: ## Generate CRD manifest
 	go run k8s.io/code-generator/cmd/register-gen@v0.28.0 --input-dirs ./pkg/apis/applicationnetworking/v1alpha1 --output-base ./ --go-header-file hack/boilerplate.go.txt
 	cp config/crds/bases/application-networking.k8s.aws* helm/crds
 
+e2e-test-namespace := "e2e-test"
+
 ## Run e2e tests against cluster pointed to by ~/.kube/config
-.PHONY: e2etest
-e2etest:
+.PHONY: e2e-test
+e2e-test:
+	@kubectl create namespace $(e2e-test-namespace) > /dev/null 2>&1 || true # ignore already exists error
 	cd test && go test \
 		-p 1 \
 		-count 1 \
@@ -106,3 +109,11 @@ e2etest:
 		--ginkgo.focus="${FOCUS}" \
 		--ginkgo.timeout=90m \
 		--ginkgo.v
+
+.SILENT:
+.PHONY: e2e-clean
+e2e-clean:
+	@echo -n "Cleaning up e2e tests... "
+	@kubectl delete namespace $(e2e-test-namespace) > /dev/null 2>&1
+	@kubectl create namespace $(e2e-test-namespace) > /dev/null 2>&1
+	@echo "Done!"

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -65,7 +65,7 @@ eksctl create iamserviceaccount \
 Once cluster is ready. We need to apply CRDs for gateway-api resources.
 
 ```bash
-$kubectl apply -f config/crds/bases/k8s-gateway-v0.6.1.yaml
+kubectl apply -f config/crds/bases/k8s-gateway-v0.6.1.yaml
 kubectl apply -f config/crds/bases/multicluster.x-k8s.io_serviceexports.yaml
 kubectl apply -f config/crds/bases/multicluster.x-k8s.io_serviceimports.yaml
 kubectl apply -f config/crds/bases/externaldns.k8s.io_dnsendpoints.yaml
@@ -73,10 +73,10 @@ kubectl apply -f config/crds/bases/application-networking.k8s.aws_targetgrouppol
 kubectl apply -f examples/gatewayclass.yaml
 ```
 
-And create non-default namespace for e2etest. In case you want to run them.
+When e2e tests are terminated during execution, it might break clean-up stage and resources will leak. To delete dangling resources manually use cleanup script:
 
 ```bash
-kubectl create namespace non-default
+make e2e-clean
 ```
 
 ## Local Development
@@ -110,7 +110,7 @@ And use "EnvFile" GoLand plugin to read the env variables from the generated `.e
 For larger changes it's recommended to run e2e suites on your local cluster.
 
 ```
-REGION=us-west-2 make e2etest
+REGION=us-west-2 make e2e-test
 ```
 
 You can use `FOCUS` environment variable to run some specific test cases based on filter condition.
@@ -125,7 +125,7 @@ var _ = Describe("HTTPRoute path matches", func() {
 ```
 export FOCUS="HTTPRoute should support multiple path matches"
 export REGION=us-west-2
-make e2etest
+make e2e-test
 ```
 
 For example, to run the test case "HTTPRoute should support multiple path matches", you could run the following command:
@@ -150,10 +150,10 @@ make presubmit
 
 For larger, functional changes, run e2e tests:
 ```sh
-make e2etest
+make e2e-test
 ```
 
-It is recommended to run `make e2etest` in both environments where `DNSEndpoint` CRD exists and does not exist,
+It is recommended to run `make e2e-test` in both environments where `DNSEndpoint` CRD exists and does not exist,
 as the controller is designed to support both use cases.
 
 ## Make Docker Image

--- a/test/pkg/test/grpcurl_runner.go
+++ b/test/pkg/test/grpcurl_runner.go
@@ -6,11 +6,11 @@ import (
 )
 
 // https://github.com/fullstorydev/grpcurl
-func NewGrpcurlRunnerPod() *v1.Pod {
+func NewGrpcurlRunnerPod(name, namespace string) *v1.Pod {
 	grpcurlPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "grpcurl-runner",
+			Namespace: namespace,
+			Name:      name,
 			Labels: map[string]string{
 				"app": "grpcurl-runner",
 			},

--- a/test/pkg/test/metadata.go
+++ b/test/pkg/test/metadata.go
@@ -24,7 +24,7 @@ func New[T client.Object](t T, mergeFrom ...T) T {
 		t.SetName(RandomName())
 	}
 	if t.GetNamespace() == "" {
-		t.SetNamespace("default")
+		t.SetNamespace("e2e-test")
 	}
 	t.SetLabels(map[string]string{DiscoveryLabel: "true"})
 	return MustMerge(t, mergeFrom...)

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	k8snamespace = "non-default"
+	k8snamespace = "e2e-test"
 )
 
 var testFramework *test.Framework
@@ -32,7 +32,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	testFramework.ExpectToBeClean(ctx)
-	grpcurlRunnerPod := test.NewGrpcurlRunnerPod()
+	grpcurlRunnerPod := test.NewGrpcurlRunnerPod("grpc-runner", k8snamespace)
 	if err := testFramework.Get(ctx, client.ObjectKeyFromObject(grpcurlRunnerPod), testFramework.GrpcurlRunner); err != nil {
 		if apierrors.IsNotFound(err) {
 			testFramework.ExpectCreated(ctx, grpcurlRunnerPod)


### PR DESCRIPTION
Note:
- Change e2e tests namespace from "non-default" to "e2e-test"
- Create e2e-test namespace if does not exists in Makefile
- Add cleanup script in Makefile. Namespace deletion and creation is an ultimate cleaner, no need to track resources individually.

Tested with running, terminating, cleaning, and running again e2e-tests.

Closes #293
Closes #231