### PR TITLE
[Bug fix] Revive serviceReconciler.reconcileTargetsResource() to handle k8sService deletion de-registering targets

### DIFF
--- a/test/suites/integration/deregister_targets_test.go
+++ b/test/suites/integration/deregister_targets_test.go
@@ -15,66 +15,74 @@ import (
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 )
 
-var _ = Describe("Deregister Targets", func() {
+var _ = Describe("Deregister Targets", Ordered, func() {
 	var (
-		deployment         *appsv1.Deployment
-		service            *v1.Service
+		deployments        = make([]*appsv1.Deployment, 2)
+		services           = make([]*v1.Service, 2)
+		targetGroups       = make([]*vpclattice.TargetGroupSummary, 2)
 		pathMatchHttpRoute *v1beta1.HTTPRoute
-		targetGroup        *vpclattice.TargetGroupSummary
 	)
 
-	BeforeEach(func() {
-		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{
-			Name:      "target-deregistration-test",
+	BeforeAll(func() {
+		deployments[0], services[0] = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:      "target-deregistration-test-1",
+			Namespace: k8snamespace,
+		})
+		deployments[1], services[1] = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:      "target-deregistration-test-2",
 			Namespace: k8snamespace,
 		})
 		pathMatchHttpRoute = testFramework.NewPathMatchHttpRoute(
-			testGateway, []client.Object{service}, "http", "", k8snamespace)
+			testGateway, []client.Object{services[0], services[1]}, "http", "", k8snamespace)
 		testFramework.ExpectCreated(
 			ctx,
 			pathMatchHttpRoute,
-			service,
-			deployment,
+			services[0],
+			deployments[0],
+			services[1],
+			deployments[1],
 		)
 		route, _ := core.NewRoute(pathMatchHttpRoute)
 		_ = testFramework.GetVpcLatticeService(ctx, route)
 
-		// Verify VPC Lattice Target Group exists
-		targetGroup = testFramework.GetTargetGroup(ctx, service)
-		Expect(*targetGroup.VpcIdentifier).To(Equal(test.CurrentClusterVpcId))
-		Expect(*targetGroup.Protocol).To(Equal("HTTP"))
+		for i, service := range services {
+			// Verify VPC Lattice Target Group exists
+			targetGroups[i] = testFramework.GetTargetGroup(ctx, service)
+			Expect(*targetGroups[i]).To(Not(BeNil()))
 
-		// Verify VPC Lattice Targets exist
-		targets := testFramework.GetTargets(ctx, targetGroup, deployment)
-		Expect(*targetGroup.Port).To(BeEquivalentTo(80))
-		for _, target := range targets {
-			Expect(*target.Port).To(BeEquivalentTo(service.Spec.Ports[0].TargetPort.IntVal))
-			Expect(*target.Status).To(Or(
-				Equal(vpclattice.TargetStatusInitial),
-				Equal(vpclattice.TargetStatusHealthy),
-			))
+			// Verify VPC Lattice Targets exist
+			targets := testFramework.GetTargets(ctx, targetGroups[i], deployments[i])
+			Expect(*targetGroups[i].Port).To(BeEquivalentTo(80))
+			for _, target := range targets {
+				Expect(*target.Port).To(BeEquivalentTo(service.Spec.Ports[0].TargetPort.IntVal))
+				Expect(*target.Status).To(Or(
+					Equal(vpclattice.TargetStatusInitial),
+					Equal(vpclattice.TargetStatusHealthy),
+				))
+			}
 		}
 	})
 
-	AfterEach(func() {
-		// Lattice targets draining time for test cases in this file is actually unavoidable,
-		//because these test cases logic themselves test lattice targets de-registering before delete the httproute
-		testFramework.ExpectDeletedThenNotFound(ctx,
-			pathMatchHttpRoute,
-			service,
-			deployment,
-		)
+	It("Kubernetes Service deletion deregisters targets", func() {
+		testFramework.ExpectDeleted(ctx, services[0])
+		verifyNoTargetsForTargetGroup(targetGroups[0])
 	})
 
-	//It("Kubernetes Service deletion deregisters targets", func() {
-	//	Fail("Currently controller have a bug, service deletion does NOT trigger targets de-registering, need to further investigate the root cause")
-	//	testFramework.ExpectDeleted(ctx, service)
-	//  verifyNoTargetsForTargetGroup(targetGroup)
-	//})
-
 	It("Kubernetes Deployment deletion triggers targets de-registering", func() {
-		testFramework.ExpectDeleted(ctx, deployment)
-		verifyNoTargetsForTargetGroup(targetGroup)
+		testFramework.ExpectDeleted(ctx, services[1])
+		verifyNoTargetsForTargetGroup(targetGroups[1])
+	})
+
+	AfterAll(func() {
+		// Lattice targets draining time for test cases in this file is actually unavoidable,
+		// because these test cases logic themselves test lattice targets de-registering before delete the httproute
+		testFramework.ExpectDeletedThenNotFound(ctx,
+			pathMatchHttpRoute,
+			services[0],
+			deployments[0],
+			services[1],
+			deployments[1],
+		)
 	})
 })
 


### PR DESCRIPTION
…8sService deletion

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: bug fix for #331
It's quite possible that this previous refactoring [service_controller.go](https://github.com/aws/aws-application-networking-k8s/pull/360/files#diff-00e81e75f6d3a8e448c8698e8838e914e508f7bb66e569da6fdd3d394baf96e5), cause a regression that "deleting k8sService do NOT de-registering targets".  Bring back the  `(r *serviceReconciler) reconcileTargetsResource()` logic to handle the k8sService deletion could fix this issue 

**What does this PR do / Why do we need it**: bug fix for #331


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:

newly un-commented e2etest case pass, all test cases pass
```
Ran 29 of 29 Specs in 1876.938 seconds
SUCCESS! -- 29 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (1877.46s)
PASS
```
E2E tests for new revision also pass 

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.