### PR TITLE
Partial bug fix for serviceexport deletion leaking targetgroup issue

### DIFF
--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -125,7 +125,7 @@ func Test_SynthesizeTriggeredServiceExport(t *testing.T) {
 
 			ds := latticestore.NewLatticeDataStore()
 			if !tt.svcExport.DeletionTimestamp.IsZero() {
-				// When test serviceExport deletion, we expect latticeDataStore already has this tg entry
+				// When test serviceExport deletion, we expect latticeDataStore already had this tg entry
 				tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
 				ds.AddTargetGroup(tgName, "vpc-123456789", "123456789", "tg-123", false, "")
 			}
@@ -873,7 +873,7 @@ func Test_SynthesizeTriggeredTargetGroupsCreation_TriggeredByServiceExport(t *te
 
 			ds := latticestore.NewLatticeDataStore()
 			if !tt.svcExport.DeletionTimestamp.IsZero() {
-				// When test serviceExport deletion, we expect latticeDataStore already has this tg entry
+				// When test serviceExport deletion, we expect latticeDataStore already had this tg entry
 				tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
 				ds.AddTargetGroup(tgName, "vpc-123456789", "arn123", "4567", false, "")
 			}

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -275,10 +275,10 @@ func (t *targetGroupModelBuildTask) buildTargetGroupForServiceExportDeletion(ctx
 	})
 	t.datastore.SetTargetGroupByServiceExport(targetGroupName, false, false)
 	dsTG, err := t.datastore.GetTargetGroup(targetGroupName, "", false)
-	t.log.Debugf("TargetGroup cached in datastore: %v", dsTG)
 	if err != nil {
 		return nil, fmt.Errorf("%w: targetGroupName: %s", err, targetGroupName)
 	}
+	t.log.Debugf("TargetGroup cached in datastore: %v", dsTG)
 	if !dsTG.ByBackendRef {
 		// When handling the serviceExport deletion request while having dsTG.ByBackendRef==false,
 		// That means this target group is not in use anymore, i.e., it is not referenced by latticeService rules(aka http/grpc route rules),

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -252,7 +252,7 @@ func (t *targetGroupModelBuildTask) buildTargetGroupForServiceExportCreation(ctx
 		},
 	})
 
-	t.log.Infow("stackTG:",
+	t.log.Debugw("stackTG:",
 		"targetGroupName", stackTG.Spec.Name,
 		"K8SServiceName", stackTG.Spec.Config.K8SServiceName,
 		"K8SServiceNamespace", stackTG.Spec.Config.K8SServiceNamespace,

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -226,7 +226,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 
 			ds := latticestore.NewLatticeDataStore()
 			if !tt.svcExport.DeletionTimestamp.IsZero() {
-				// When test serviceExport deletion, we expect latticeDataStore already has this tg entry
+				// When test serviceExport deletion, we expect latticeDataStore already had this tg entry
 				tgName := latticestore.TargetGroupName(tt.svcExport.Name, tt.svcExport.Namespace)
 				ds.AddTargetGroup(tgName, "vpc-123456789", "123456789", "tg-123", false, "")
 			}

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -388,6 +388,21 @@ func GetTargets(targetGroup *vpclattice.TargetGroupSummary, deployment *appsv1.D
 	return podIps, retrievedTargets
 }
 
+func (env *Framework) VerifyTargetGroupNotFound(tg *vpclattice.TargetGroupSummary) {
+	Eventually(func(g Gomega) {
+		retrievedTargetGroup, err := env.LatticeClient.GetTargetGroup(&vpclattice.GetTargetGroupInput{
+			TargetGroupIdentifier: tg.Id,
+		})
+		g.Expect(retrievedTargetGroup.Id).To(BeNil())
+		g.Expect(err).To(Not(BeNil()))
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				g.Expect(aerr.Code()).To(Equal(vpclattice.ErrCodeResourceNotFoundException))
+			}
+		}
+	}).Should(Succeed())
+}
+
 func (env *Framework) IsVpcAssociatedWithServiceNetwork(ctx context.Context, vpcId string, serviceNetwork *vpclattice.ServiceNetworkSummary) (bool, error) {
 	env.log.Infof("IsVpcAssociatedWithServiceNetwork vpcId:%v serviceNetwork: %v \n", vpcId, serviceNetwork)
 	vpcAssociations, err := env.LatticeClient.ListServiceNetworkVpcAssociationsAsList(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{

--- a/test/suites/integration/serviceexport_mutation_test.go
+++ b/test/suites/integration/serviceexport_mutation_test.go
@@ -1,0 +1,85 @@
+package integration
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+)
+
+var _ = Describe("ServiceExport Mutation Test", func() {
+	Context("Test ServiceExport Deletion", func() {
+		var (
+			deployment    *appsv1.Deployment
+			service       *v1.Service
+			serviceExport *v1alpha1.ServiceExport
+			targetGroup   *vpclattice.TargetGroupSummary
+		)
+
+		BeforeEach(func() {
+			deployment, service = testFramework.NewNginxApp(test.ElasticSearchOptions{
+				Name:      "http",
+				Port:      8080,
+				Port2:     8081,
+				Namespace: k8snamespace,
+			})
+			serviceExport = testFramework.CreateServiceExport(service)
+			numOfServiceExportAnnotationsDefinedPorts := 1
+			testFramework.ExpectCreated(ctx, serviceExport, service, deployment)
+			targetGroup = testFramework.GetTargetGroup(ctx, service)
+			Expect(targetGroup).To(Not(BeNil()))
+			Expect(*targetGroup.VpcIdentifier).To(Equal(test.CurrentClusterVpcId))
+			Expect(*targetGroup.Protocol).To(Equal("HTTP"))
+			Eventually(func(g Gomega) {
+				_, retrievedTargets := testFramework.GetAllTargets(ctx, targetGroup, deployment)
+				g.Expect(len(retrievedTargets)).To(Equal(numOfServiceExportAnnotationsDefinedPorts * int(*deployment.Spec.Replicas)))
+			}).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			testFramework.ExpectDeletedThenNotFound(ctx,
+				serviceExport,
+				deployment,
+				service,
+			)
+		})
+
+		When("Delete ServiceExport, while corresponding K8sService exists", func() {
+			It("Expect targetGroup not found", func() {
+				testFramework.ExpectDeletedThenNotFound(ctx, serviceExport)
+				verifyTargetGroupNotFound(targetGroup)
+			})
+		})
+
+		When("Delete ServiceExport, while corresponding K8sService do NOT exists", func() {
+			It("Expect targetGroup not found", func() {
+				testFramework.ExpectDeletedThenNotFound(ctx, service)
+				time.Sleep(5 * time.Second)
+				testFramework.ExpectDeletedThenNotFound(ctx, serviceExport)
+				verifyTargetGroupNotFound(targetGroup)
+			})
+		})
+	})
+})
+
+func verifyTargetGroupNotFound(tg *vpclattice.TargetGroupSummary) {
+	Eventually(func(g Gomega) {
+		retrievedTargetGroup, err := testFramework.LatticeClient.GetTargetGroup(&vpclattice.GetTargetGroupInput{
+			TargetGroupIdentifier: tg.Id,
+		})
+		g.Expect(retrievedTargetGroup.Id).To(BeNil())
+		g.Expect(err).To(Not(BeNil()))
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				g.Expect(aerr.Code()).To(Equal(vpclattice.ErrCodeResourceNotFoundException))
+			}
+		}
+	}).Should(Succeed())
+}


### PR DESCRIPTION
**Which issue does this PR fix**:  Partial bug fix for #269

This is the **Partial** bug fix for serviceexport deletion leaking targetgroup issue, just fixed serviceexport's serviceImport not being referenced by Route scenario. _To fix the serviceImport being referenced by Route scenario, it need to change dataStore in many various places, That change is hard to trace and review, we need to do it in a separate PR, or do the dataStore refactoring first._ 






**Testing done on this change**:
-  Used `inventory-ver2.yaml `  and`inventory-ver2-export.yaml` did the  different order k8s resource creation/deletion  manual tests. Traced all related code path by single-step debugger, it works as expected
- Added new e2etest cases, new test cases and whole test suite can pass
```
Ran 31 of 31 Specs in 2064.938 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 0 Skipped
```
- Changed according unit tests


**Will this PR introduce any new dependencies?**: No


**Does this PR introduce any user-facing change?**:  No


----

Reasons for why *old* code have bug for deleting serviceExport leaking TG:
https://github.com/aws/aws-application-networking-k8s/blob/f5b903321a1fc226e5bda3e2a0c2bfc06dd1343d/pkg/gateway/model_build_targetgroup.go#L193-L273

- Reason1: old model_build_targetgroup.go code [line 200 ](https://github.com/aws/aws-application-networking-k8s/blob/f5b903321a1fc226e5bda3e2a0c2bfc06dd1343d/pkg/gateway/model_build_targetgroup.go#L200)did `return err`  too early
- Reason2: old model_build_targetgroup.go code [line 206](https://github.com/aws/aws-application-networking-k8s/blob/f5b903321a1fc226e5bda3e2a0c2bfc06dd1343d/pkg/gateway/model_build_targetgroup.go#L206) did `return err`  too early
- Reason3: old model_build_targetgroup.go code [line 250](https://github.com/aws/aws-application-networking-k8s/blob/f5b903321a1fc226e5bda3e2a0c2bfc06dd1343d/pkg/gateway/model_build_targetgroup.go#L250) wrongly (unintentionally) overrides a old targetGroup dataStore entry to the `dsTG.ID==""`.  So that when handling ServiceExport deletion request, [line 261](https://github.com/aws/aws-application-networking-k8s/blob/f5b903321a1fc226e5bda3e2a0c2bfc06dd1343d/pkg/gateway/model_build_targetgroup.go#L261) always get the `dsTG.ID== ""`, so that [line 267](https://github.com/aws/aws-application-networking-k8s/blob/f5b903321a1fc226e5bda3e2a0c2bfc06dd1343d/pkg/gateway/model_build_targetgroup.go#L267) always assign `tg.Spec.LatticeID = ` , in that case, the later [target_group_manager.Delete()](https://github.com/aws/aws-application-networking-k8s/blob/242241fb9a2cb8a73422e27633085d7f92e74ae8/pkg/deploy/lattice/target_group_manager.go#L177) always fail to delete this targetGroup.

Considering above 3 reasons, I did a really small refactoring for `(t *targetGroupModelBuildTask) BuildTargetGroup()` to separate code path for `buildTargetGroupForServiceExportCreation` and `buildTargetGroupForServiceExportDeletion`. New code is more clear and easier to understand.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.