### PR TITLE
Add mapper.policyToTargetRefObj() helper function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ go.work*
 
 # IDE files/directories
 .idea/
+
+# gomock generated prog.go
+pkg/aws/services/gomock_reflect_*

--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -20,9 +20,10 @@ import (
 	"flag"
 	"os"
 
+	"github.com/go-logr/zapr"
+
 	"github.com/aws/aws-application-networking-k8s/pkg/aws"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
-	"github.com/go-logr/zapr"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -34,18 +35,20 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	"github.com/aws/aws-application-networking-k8s/controllers"
-	//+kubebuilder:scaffold:imports
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
-	"github.com/aws/aws-application-networking-k8s/pkg/config"
-	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
-	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/external-dns/endpoint"
 	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gateway_api_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcs_api "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	"github.com/aws/aws-application-networking-k8s/controllers"
+
+	//+kubebuilder:scaffold:imports
+	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/config"
+	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
+	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 )
 
 var (
@@ -70,12 +73,15 @@ func addOptionalCRDs(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(dnsEndpoint, &endpoint.DNSEndpoint{}, &endpoint.DNSEndpointList{})
 	metav1.AddToGroupVersion(scheme, dnsEndpoint)
 
-	targetGroupPolicy := schema.GroupVersion{
-		Group:   "application-networking.k8s.aws",
+	awsGatewayControllerCRDGroupVersion := schema.GroupVersion{
+		Group:   v1alpha1.GroupName,
 		Version: "v1alpha1",
 	}
-	scheme.AddKnownTypes(targetGroupPolicy, &v1alpha1.TargetGroupPolicy{}, &v1alpha1.TargetGroupPolicyList{})
-	metav1.AddToGroupVersion(scheme, targetGroupPolicy)
+	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &v1alpha1.TargetGroupPolicy{}, &v1alpha1.TargetGroupPolicyList{})
+	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
+
+	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &v1alpha1.VpcAssociationPolicy{}, &v1alpha1.VpcAssociationPolicyList{})
+	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
 }
 
 func main() {

--- a/controllers/eventhandlers/vpcAssociationPolicy.go
+++ b/controllers/eventhandlers/vpcAssociationPolicy.go
@@ -1,0 +1,35 @@
+package eventhandlers
+
+import (
+	"context"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type vpcAssociationPolicyEventHandler struct {
+	log    gwlog.Logger
+	client client.Client
+	mapper *resourceMapper
+}
+
+func NewVpcAssociationPolicyEventHandler(log gwlog.Logger, client client.Client) *vpcAssociationPolicyEventHandler {
+	return &vpcAssociationPolicyEventHandler{log: log, client: client,
+		mapper: &resourceMapper{log: log, client: client}}
+}
+
+func (h *vpcAssociationPolicyEventHandler) MapToGateway() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+		if vap, ok := obj.(*v1alpha1.VpcAssociationPolicy); ok {
+			if gw := h.mapper.VpcAssociationPolicyToGateway(context.Background(), vap); gw != nil {
+				return []reconcile.Request{{NamespacedName: k8s.NamespacedName(gw)}}
+			}
+		}
+		return nil
+	})
+}

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -97,12 +97,13 @@ func RegisterGatewayController(
 	builder.Watches(&source.Kind{Type: &gateway_api.GatewayClass{}}, gwClassEventHandler)
 
 	//Watch VpcAssociationPolicy CRD if it is installed
-	if ok, err := k8s.IsGVKSupported(mgr, v1alpha1.GroupVersion.String(), v1alpha1.VpcAssociationPolicyKind); ok {
+	ok, err := k8s.IsGVKSupported(mgr, v1alpha1.GroupVersion.String(), v1alpha1.VpcAssociationPolicyKind)
+	if err != nil {
+		return err
+	}
+	if ok {
 		builder.Watches(&source.Kind{Type: &v1alpha1.VpcAssociationPolicy{}}, vpcAssociationPolicyEventHandler.MapToGateway())
 	} else {
-		if err != nil {
-			return err
-		}
 		log.Infof("VpcAssociationPolicy CRD is not installed, skipping watch")
 	}
 	return builder.Complete(r)

--- a/examples/vpc-association-policy.yaml
+++ b/examples/vpc-association-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: VpcAssociationPolicy
+metadata:
+    name: test-vpc-association-policy
+spec:
+    targetRef:
+        group: "gateway.networking.k8s.io"
+        kind: Gateway
+        name: my-hotel
+    securityGroupIds:
+        - <example-security-group-id-1>
+        - <example-security-group-id-2>
+    associateWithVpc: true


### PR DESCRIPTION
## Changes
- Add a helper `resourceMapper.policyToTargetRefObj()` so that both VpcAssociationPolicyToGateway() and TargetGroupPolicyToService could leverage it
- Mimic #360, Add the `vpcAssociationPolicyEventHandler.MapToGateway()` method
- Make gateway_controller optionally watches the `VpcAssociationPolicy`


**What type of PR is this?**  Prepare for SNVA Security Group Api support #199 


**What does this PR do / Why do we need it**: Prepare for SNVA Security Group Api support


**Testing done on this change**:

- More unit test for `mapper.go` 
- Manual test done: `kubectl apply -f examples/vpc-association-policy.yaml` could enter the `gatewayReconciler.Reconcile()` method if targetRef gateway exists
- E2E test all pass
```
Ran 31 of 31 Specs in 2006.710 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2007.08s)
PASS
```


**Will this PR introduce any new dependencies?**: No 

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:  No

**Does this PR introduce any user-facing change?**: No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.