### PR TITLE
fix: create lattice resources when no endpoints in K8s services (#386)

### DIFF
--- a/pkg/deploy/lattice/targets_manager.go
+++ b/pkg/deploy/lattice/targets_manager.go
@@ -3,6 +3,7 @@ package lattice
 import (
 	"context"
 	"errors"
+
 	"github.com/golang/glog"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -94,6 +95,11 @@ func (s *defaultTargetsManager) Create(ctx context.Context, targets *latticemode
 			Port: &port,
 		}
 		targetList = append(targetList, &t)
+	}
+
+	// No targets to register
+	if len(targetList) == 0 {
+		return nil
 	}
 
 	registerRouteInput := vpclattice.RegisterTargetsInput{

--- a/pkg/deploy/lattice/targets_synthesizer.go
+++ b/pkg/deploy/lattice/targets_synthesizer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/golang/glog"
 
 	lattice_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
@@ -49,6 +50,7 @@ func (t *targetsSynthesizer) SynthesizeTargets(ctx context.Context, resTargets [
 			return errors.New(errmsg)
 
 		}
+
 		tgName := latticestore.TargetGroupName(targets.Spec.Name, targets.Spec.Namespace)
 
 		var targetList []latticestore.Target

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -109,6 +109,7 @@ func (t *latticeTargetsModelBuildTask) buildLatticeTargets(ctx context.Context) 
 	}
 
 	definedPorts := make(map[int32]struct{})
+
 	if tg.ByServiceExport {
 		serviceExport := &mcs_api.ServiceExport{}
 		err = t.client.Get(ctx, namespacedName, serviceExport)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

#386 


**What does this PR do / Why do we need it**:

This PR allows the controller to continue to create Lattice service, and listeners, and rules when there are no targets to register

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:

Added unit tests, and e2e tests.

`make e2e-test` output:

```
Ran 32 of 32 Specs in 2332.975 seconds
SUCCESS! -- 32 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2334.12s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   2334.147s
```

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:

Added test case `httproute_creation_test.go`
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No

**Does this PR introduce any user-facing change?**: No
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.