### PR TITLE
Read VpcAssociationPolicy value in the model_build_servicenetwork

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -74,7 +74,7 @@ func RegisterGatewayController(
 	scheme := mgr.GetScheme()
 	evtRec := mgr.GetEventRecorderFor("gateway")
 
-	modelBuilder := gateway.NewServiceNetworkModelBuilder()
+	modelBuilder := gateway.NewServiceNetworkModelBuilder(mgrClient)
 	stackDeployer := deploy.NewServiceNetworkStackDeployer(cloud, mgrClient)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -3,8 +3,10 @@ package lattice
 import (
 	"context"
 	"errors"
-	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+
 	"github.com/golang/glog"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"

--- a/pkg/deploy/lattice/service_network_synthesizer_test.go
+++ b/pkg/deploy/lattice/service_network_synthesizer_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -87,6 +86,11 @@ func Test_SynthesizeTriggeredGateways(t *testing.T) {
 		},
 	}
 
+	c := gomock.NewController(t)
+	defer c.Finish()
+	k8sClient := mock_client.NewMockClient(c)
+	k8sClient.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 	for _, tt := range tests {
 
 		fmt.Printf("Testing >>>>> %v\n", tt.name)
@@ -94,7 +98,7 @@ func Test_SynthesizeTriggeredGateways(t *testing.T) {
 		defer c.Finish()
 		ctx := context.TODO()
 
-		builder := gateway.NewServiceNetworkModelBuilder()
+		builder := gateway.NewServiceNetworkModelBuilder(k8sClient)
 
 		stack, mesh, _ := builder.Build(context.Background(), tt.gw)
 

--- a/pkg/gateway/model_build_service_network_test.go
+++ b/pkg/gateway/model_build_service_network_test.go
@@ -5,25 +5,46 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 )
 
 func Test_MeshModelBuild(t *testing.T) {
 	now := metav1.Now()
+	trueBool := true
+	falseBool := false
+	notRelatedVpcAssociationPolicy := v1alpha1.VpcAssociationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "another-vpc-association-policy",
+		},
+		Spec: v1alpha1.VpcAssociationPolicySpec{
+			TargetRef: &v1alpha2.PolicyTargetReference{
+				Group: gateway_api.GroupName,
+				Kind:  "Gateway",
+				Name:  "another-mesh",
+			},
+			AssociateWithVpc: &falseBool,
+		},
+	}
 	tests := []struct {
-		name           string
-		gw             *gateway_api.Gateway
-		wantErr        error
-		wantName       string
-		wantNamespace  string
-		wantIsDeleted  bool
-		associateToVPC bool
+		name                 string
+		gw                   *gateway_api.Gateway
+		vpcAssociationPolicy *v1alpha1.VpcAssociationPolicy
+		wantErr              error
+		wantName             string
+		wantNamespace        string
+		wantIsDeleted        bool
+		associateToVPC       bool
 	}{
 		{
-			name: "Adding Mesh in default namespace, no annotation on VPC association",
+			name: "Adding Mesh in default namespace, no annotation on VPC association, associate to VPC by default",
 			gw: &gateway_api.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mesh1",
@@ -92,13 +113,106 @@ func Test_MeshModelBuild(t *testing.T) {
 			wantIsDeleted:  true,
 			associateToVPC: true,
 		},
+		{
+			name: "Gateway has attached VpcAssociationPolicy found, VpcAssociationPolicy SecurityGroupIds are not empty",
+			gw: &gateway_api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "mesh1",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
+				},
+			},
+			vpcAssociationPolicy: &v1alpha1.VpcAssociationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vpc-association-policy",
+				},
+				Spec: v1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &v1alpha2.PolicyTargetReference{
+						Group: gateway_api.GroupName,
+						Kind:  "Gateway",
+						Name:  "mesh1",
+					},
+					SecurityGroupIds: []v1alpha1.SecurityGroupId{"sg-123456", "sg-654321"},
+				},
+			},
+			wantErr:        nil,
+			wantName:       "mesh1",
+			wantNamespace:  "",
+			wantIsDeleted:  false,
+			associateToVPC: true,
+		},
+		{
+			name: "Gateway does not have LatticeVPCAssociationAnnotation, it has attached VpcAssociationPolicy found, which AssociateWithVpc field set to true",
+			gw: &gateway_api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "mesh1",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
+				},
+			},
+			vpcAssociationPolicy: &v1alpha1.VpcAssociationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vpc-association-policy",
+				},
+				Spec: v1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &v1alpha2.PolicyTargetReference{
+						Group: gateway_api.GroupName,
+						Kind:  "Gateway",
+						Name:  "mesh1",
+					},
+					AssociateWithVpc: &trueBool,
+				},
+			},
+			wantErr:        nil,
+			wantName:       "mesh1",
+			wantNamespace:  "",
+			wantIsDeleted:  false,
+			associateToVPC: true,
+		},
+		{
+			name: "Gateway does not have LatticeVPCAssociationAnnotation, it has attached VpcAssociationPolicy found, which AssociateWithVpc field set to false",
+			gw: &gateway_api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "mesh1",
+					Finalizers: []string{"gateway.k8s.aws/resources"},
+				},
+			},
+			vpcAssociationPolicy: &v1alpha1.VpcAssociationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-vpc-association-policy",
+				},
+				Spec: v1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &v1alpha2.PolicyTargetReference{
+						Group: gateway_api.GroupName,
+						Kind:  "Gateway",
+						Name:  "mesh1",
+					},
+					AssociateWithVpc: &falseBool,
+				},
+			},
+			wantErr:        nil,
+			wantName:       "mesh1",
+			wantNamespace:  "",
+			wantIsDeleted:  false,
+			associateToVPC: false,
+		},
 	}
+	c := gomock.NewController(t)
+	defer c.Finish()
+	mock_client := mock_client.NewMockClient(c)
+	ctx := context.Background()
 
 	for _, tt := range tests {
 		fmt.Printf("Testing >>> %v\n", tt.name)
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewServiceNetworkModelBuilder()
-
+			mock_client.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, policyList *v1alpha1.VpcAssociationPolicyList, arg3 ...interface{}) error {
+					policyList.Items = append(policyList.Items, notRelatedVpcAssociationPolicy)
+					if tt.vpcAssociationPolicy != nil {
+						policyList.Items = append(policyList.Items, *tt.vpcAssociationPolicy)
+					}
+					return nil
+				},
+			)
+			builder := NewServiceNetworkModelBuilder(mock_client)
 			_, got, err := builder.Build(context.Background(), tt.gw)
 
 			if tt.wantErr != nil {
@@ -108,6 +222,9 @@ func Test_MeshModelBuild(t *testing.T) {
 				assert.Equal(t, tt.wantNamespace, got.Spec.Namespace)
 				assert.Equal(t, tt.wantIsDeleted, got.Spec.IsDeleted)
 				assert.Equal(t, tt.associateToVPC, got.Spec.AssociateToVPC)
+				if tt.vpcAssociationPolicy != nil {
+					assert.Equal(t, securityGroupIdsToStringPointersSlice(tt.vpcAssociationPolicy.Spec.SecurityGroupIds), got.Spec.SecurityGroupIds)
+				}
 			}
 
 		})

--- a/pkg/gateway/model_build_servicenetwork.go
+++ b/pkg/gateway/model_build_servicenetwork.go
@@ -50,7 +50,7 @@ func (b *serviceNetworkModelBuilder) Build(ctx context.Context, gw *gateway_api.
 		return nil, nil, corev1.ErrIntOverflowGenerated
 	}
 
-	return task.stack, task.mesh, nil
+	return task.stack, task.serviceNetwork, nil
 }
 
 func (t *serviceNetworkModelBuildTask) run(ctx context.Context) error {
@@ -79,11 +79,7 @@ func (t *serviceNetworkModelBuildTask) buildServiceNetwork(ctx context.Context) 
 	associateToVPC := true
 	if len(t.gateway.ObjectMeta.Annotations) > 0 {
 		if value, exist := t.gateway.Annotations[LatticeVPCAssociationAnnotation]; exist {
-			if value == "true" {
-				associateToVPC = true
-			} else {
-				associateToVPC = false
-			}
+			associateToVPC = value == "true"
 		}
 	}
 
@@ -110,7 +106,7 @@ func (t *serviceNetworkModelBuildTask) buildServiceNetwork(ctx context.Context) 
 		spec.IsDeleted = false
 	}
 
-	t.mesh = latticemodel.NewServiceNetwork(t.stack, ResourceIDServiceNetwork, spec)
+	t.serviceNetwork = latticemodel.NewServiceNetwork(t.stack, ResourceIDServiceNetwork, spec)
 
 	return nil
 }
@@ -118,7 +114,7 @@ func (t *serviceNetworkModelBuildTask) buildServiceNetwork(ctx context.Context) 
 type serviceNetworkModelBuildTask struct {
 	gateway              *gateway_api.Gateway
 	vpcAssociationPolicy *v1alpha1.VpcAssociationPolicy
-	mesh                 *latticemodel.ServiceNetwork
+	serviceNetwork       *latticemodel.ServiceNetwork
 
 	stack core.Stack
 }

--- a/pkg/gateway/model_build_servicenetwork.go
+++ b/pkg/gateway/model_build_servicenetwork.go
@@ -77,10 +77,8 @@ func (t *serviceNetworkModelBuildTask) buildServiceNetwork(ctx context.Context) 
 
 	// default associateToVPC is true
 	associateToVPC := true
-	if len(t.gateway.ObjectMeta.Annotations) > 0 {
-		if value, exist := t.gateway.Annotations[LatticeVPCAssociationAnnotation]; exist {
-			associateToVPC = value == "true"
-		}
+	if value, exist := t.gateway.Annotations[LatticeVPCAssociationAnnotation]; exist {
+		associateToVPC = value == "true"
 	}
 
 	if t.vpcAssociationPolicy != nil {

--- a/pkg/model/lattice/servicenetwork.go
+++ b/pkg/model/lattice/servicenetwork.go
@@ -21,11 +21,12 @@ type ServiceNetwork struct {
 
 type ServiceNetworkSpec struct {
 	// The name of the ServiceNetwork
-	Name           string `json:"name"`
-	Namespace      string `json:"namespace"`
-	Account        string `json:"account"`
-	AssociateToVPC bool
-	IsDeleted      bool
+	Name             string    `json:"name"`
+	Namespace        string    `json:"namespace"`
+	Account          string    `json:"account"`
+	SecurityGroupIds []*string `json:"securityGroupIds"`
+	AssociateToVPC   bool
+	IsDeleted        bool
 }
 
 type ServiceNetworkStatus struct {


### PR DESCRIPTION
**What type of PR is this?** feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: #199  part of security group api support, this PR don't include targets_synthesizer.go changes, so this PR  will not pass security groups ids to the aws vpc lattice sdk, will do that in a next seperate PR




**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
- Add extra unit tests
- e2etest all pass
```
Ran 31 of 31 Specs in 2239.955 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2240.27s)
PASS
```


**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.