### PR TITLE
Create VpcAssociationPolicy e2e test

### DIFF
--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/onsi/gomega/format"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,12 +85,15 @@ func addOptionalCRDs(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(dnsEndpoint, &endpoint.DNSEndpoint{}, &endpoint.DNSEndpointList{})
 	metav1.AddToGroupVersion(scheme, dnsEndpoint)
 
-	targetGroupPolicy := schema.GroupVersion{
-		Group:   "application-networking.k8s.aws",
+	awsGatewayControllerCRDGroupVersion := schema.GroupVersion{
+		Group:   v1alpha1.GroupName,
 		Version: "v1alpha1",
 	}
-	scheme.AddKnownTypes(targetGroupPolicy, &v1alpha1.TargetGroupPolicy{}, &v1alpha1.TargetGroupPolicyList{})
-	metav1.AddToGroupVersion(scheme, targetGroupPolicy)
+	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &v1alpha1.TargetGroupPolicy{}, &v1alpha1.TargetGroupPolicyList{})
+	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
+
+	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &v1alpha1.VpcAssociationPolicy{}, &v1alpha1.VpcAssociationPolicyList{})
+	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
 }
 
 type Framework struct {
@@ -100,6 +104,7 @@ type Framework struct {
 	namespace               string
 	controllerRuntimeConfig *rest.Config
 	LatticeClient           services.Lattice
+	Ec2Client               *ec2.EC2
 	GrpcurlRunner           *v1.Pod
 }
 
@@ -111,6 +116,7 @@ func NewFramework(ctx context.Context, log gwlog.Logger, testNamespace string) *
 	framework := &Framework{
 		Client:                  lo.Must(client.New(controllerRuntimeConfig, client.Options{Scheme: testScheme})),
 		LatticeClient:           services.NewDefaultLattice(session.Must(session.NewSession()), config.Region), // region is currently hardcoded
+		Ec2Client:               ec2.New(session.Must(session.NewSession(&aws.Config{Region: aws.String(config.Region)}))),
 		GrpcurlRunner:           &v1.Pod{},
 		ctx:                     ctx,
 		log:                     log,
@@ -362,23 +368,23 @@ func (env *Framework) VerifyTargetGroupNotFound(tg *vpclattice.TargetGroupSummar
 	}).Should(Succeed())
 }
 
-func (env *Framework) IsVpcAssociatedWithServiceNetwork(ctx context.Context, vpcId string, serviceNetwork *vpclattice.ServiceNetworkSummary) (bool, error) {
+func (env *Framework) IsVpcAssociatedWithServiceNetwork(ctx context.Context, vpcId string, serviceNetwork *vpclattice.ServiceNetworkSummary) (bool, string, error) {
 	env.log.Infof("IsVpcAssociatedWithServiceNetwork vpcId:%v serviceNetwork: %v \n", vpcId, serviceNetwork)
 	vpcAssociations, err := env.LatticeClient.ListServiceNetworkVpcAssociationsAsList(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{
 		ServiceNetworkIdentifier: serviceNetwork.Id,
 		VpcIdentifier:            &vpcId,
 	})
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	if len(vpcAssociations) != 1 {
-		return false, fmt.Errorf("Expect to have one VpcServiceNetworkAssociation len(vpcAssociations): %d", len(vpcAssociations))
+		return false, "", fmt.Errorf("Expect to have one VpcServiceNetworkAssociation len(vpcAssociations): %d", len(vpcAssociations))
 	}
 	association := vpcAssociations[0]
 	if *association.Status != vpclattice.ServiceNetworkVpcAssociationStatusActive {
-		return false, fmt.Errorf("Current cluster should have one Active status association *association.Status: %s, err: %w", *association.Status, err)
+		return false, "", fmt.Errorf("Current cluster should have one Active status association *association.Status: %s, err: %w", *association.Status, err)
 	}
-	return true, nil
+	return true, *association.Id, nil
 }
 
 func (env *Framework) AreAllLatticeTargetsHealthy(ctx context.Context, tg *vpclattice.TargetGroupSummary) (bool, error) {

--- a/test/suites/integration/vpc_association_policy_test.go
+++ b/test/suites/integration/vpc_association_policy_test.go
@@ -1,0 +1,144 @@
+package integration
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+)
+
+var _ = Describe("Test vpc association policy", Ordered, func() {
+	var (
+		vpcAssociationPolicy *v1alpha1.VpcAssociationPolicy
+		sgId                 v1alpha1.SecurityGroupId
+	)
+
+	BeforeAll(func() {
+		// Create security group
+		describeVpcOutput, err := testFramework.Ec2Client.DescribeVpcs(&ec2.DescribeVpcsInput{
+			VpcIds: []*string{aws.String(test.CurrentClusterVpcId)},
+		})
+		Expect(err).To(BeNil())
+		sourceVPC := describeVpcOutput.Vpcs[0]
+		createSgOutput, err := testFramework.Ec2Client.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
+			Description: aws.String("k8s-test-lattice-snva-sg"),
+			GroupName:   aws.String("k8s-test-lattice-snva-sg"),
+			VpcId:       aws.String(test.CurrentClusterVpcId),
+		})
+		Expect(err).To(BeNil())
+		sgId = v1alpha1.SecurityGroupId(*createSgOutput.GroupId)
+
+		// Create security group inbound rules
+		_, err = testFramework.Ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId: createSgOutput.GroupId,
+			IpPermissions: []*ec2.IpPermission{
+				{ // SG Rule to allow HTTP
+					IpProtocol: aws.String("tcp"),
+					IpRanges: []*ec2.IpRange{
+						{
+							CidrIp: sourceVPC.CidrBlock,
+						},
+					},
+					FromPort: aws.Int64(80),
+					ToPort:   aws.Int64(80),
+				},
+				{ // SG Rule to allow HTTPS
+					IpProtocol: aws.String("tcp"),
+					IpRanges: []*ec2.IpRange{
+						{
+							CidrIp: sourceVPC.CidrBlock,
+						},
+					},
+					FromPort: aws.Int64(443),
+					ToPort:   aws.Int64(443),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+	})
+
+	It("Create a VpcAssociationPolicy that set associateWithVpc to false, expecting do not create ServiceNetworkVpcAssociation", func() {
+		vpcAssociationPolicy = &v1alpha1.VpcAssociationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-vpc-association-policy",
+				Namespace: k8snamespace,
+			},
+			Spec: v1alpha1.VpcAssociationPolicySpec{
+				TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
+					Group:     gateway_api.GroupName,
+					Kind:      "Gateway",
+					Name:      gateway_api_v1alpha2.ObjectName(testGateway.Name),
+					Namespace: lo.ToPtr(gateway_api_v1alpha2.Namespace(k8snamespace)),
+				},
+				AssociateWithVpc: lo.ToPtr(false),
+			},
+		}
+		testFramework.ExpectCreated(ctx, vpcAssociationPolicy)
+		Eventually(func(g Gomega) {
+			//Expect no SNVA for testGateway
+			associated, _, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(err).To(Not(BeNil()))
+			g.Expect(associated).To(BeFalse())
+		}).Should(Succeed())
+	})
+
+	It("Update the VpcAssociationPolicy that set associateWithVpc to true with a SecurityGroupId, expecting the ServiceNetworkVpcAssociation with a security group created", func() {
+		testFramework.Get(ctx, types.NamespacedName{
+			Namespace: vpcAssociationPolicy.Namespace,
+			Name:      vpcAssociationPolicy.Name,
+		}, vpcAssociationPolicy)
+		vpcAssociationPolicy.Spec.AssociateWithVpc = lo.ToPtr(true)
+		vpcAssociationPolicy.Spec.SecurityGroupIds = []v1alpha1.SecurityGroupId{sgId}
+		testFramework.ExpectUpdated(ctx, vpcAssociationPolicy)
+
+		Eventually(func(g Gomega) {
+			associated, snvaId, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(err).To(BeNil())
+			g.Expect(associated).To(BeTrue())
+			output, err := testFramework.LatticeClient.GetServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: &snvaId,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(output.SecurityGroupIds).To(HaveLen(1))
+			g.Expect(*output.SecurityGroupIds[0]).To(Equal(string(sgId)))
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		// Re-create SNVA to clean up the SNVA security group by setting associateWithVpc to false and then true with no security group
+		vpcAssociationPolicy.Spec.AssociateWithVpc = lo.ToPtr(false)
+		vpcAssociationPolicy.Spec.SecurityGroupIds = nil
+		testFramework.ExpectUpdated(ctx, vpcAssociationPolicy)
+		Eventually(func(g Gomega) {
+			//Expect no SNVA for testGateway
+			associated, _, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(associated).To(BeFalse())
+		}).Should(Succeed())
+		vpcAssociationPolicy.Spec.AssociateWithVpc = lo.ToPtr(true)
+		testFramework.ExpectUpdated(ctx, vpcAssociationPolicy)
+		Eventually(func(g Gomega) {
+			// Expect SNVA re-created for testGateway
+			associated, _, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(err).To(BeNil())
+			g.Expect(associated).To(BeTrue())
+		}).Should(Succeed())
+
+		// Clean up the vpc association policy
+		testFramework.ExpectDeletedThenNotFound(ctx, vpcAssociationPolicy)
+
+		// Clean up the security group
+		_, err := testFramework.Ec2Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+			GroupId: aws.String(string(sgId)),
+		})
+		Expect(err).To(BeNil())
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** e2e test cases for the security group api feature #199 

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**What does this PR do / Why do we need it**: e2e test cases for the security group api feature #199 


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**: Add VpcAssociationPolicy e2e test cases, whole test suite pass
```
Ran 34 of 34 Specs in 2230.206 seconds
SUCCESS! -- 34 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2230.52s)
PASS

```
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.