### PR TITLE
Test cleanup - should not include functional changes

### DIFF
--- a/controllers/eventhandlers/mapper_test.go
+++ b/controllers/eventhandlers/mapper_test.go
@@ -14,7 +14,7 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
@@ -95,7 +95,7 @@ func TestServiceToRoutes(t *testing.T) {
 		"valid-explicit-namespace",
 	}
 
-	mockClient := mockclient.NewMockClient(c)
+	mockClient := mock_client.NewMockClient(c)
 	mockClient.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, routeList *gwv1beta1.HTTPRouteList, _ ...interface{}) error {
 			for _, route := range routes {
@@ -170,7 +170,7 @@ func TestTargetGroupPolicyToService(t *testing.T) {
 
 	for i, tt := range testCases {
 		t.Run(fmt.Sprintf("TGPolicyToService_%d", i), func(t *testing.T) {
-			mockClient := mockclient.NewMockClient(c)
+			mockClient := mock_client.NewMockClient(c)
 			mapper := &resourceMapper{log: gwlog.FallbackLogger, client: mockClient}
 			if tt.serviceFound {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -264,7 +264,7 @@ func TestVpcAssociationPolicyToGateway(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.testCaseName, func(t *testing.T) {
-			mockClient := mockclient.NewMockClient(c)
+			mockClient := mock_client.NewMockClient(c)
 			mapper := &resourceMapper{log: gwlog.FallbackLogger, client: mockClient}
 			if tt.gatewayFound {
 				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)

--- a/controllers/eventhandlers/mapper_test.go
+++ b/controllers/eventhandlers/mapper_test.go
@@ -3,6 +3,7 @@ package eventhandlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -10,27 +11,27 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 )
 
-func createHTTPRoute(name, namespace string, backendRef gateway_api.BackendObjectReference) gateway_api.HTTPRoute {
-	return gateway_api.HTTPRoute{
+func createHTTPRoute(name, namespace string, backendRef gwv1beta1.BackendObjectReference) gwv1beta1.HTTPRoute {
+	return gwv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: gateway_api.HTTPRouteSpec{
-			Rules: []gateway_api.HTTPRouteRule{
+		Spec: gwv1beta1.HTTPRouteSpec{
+			Rules: []gwv1beta1.HTTPRouteRule{
 				{
-					BackendRefs: []gateway_api.HTTPBackendRef{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{
-							BackendRef: gateway_api.BackendRef{
+							BackendRef: gwv1beta1.BackendRef{
 								BackendObjectReference: backendRef,
 							},
 						},
@@ -45,47 +46,47 @@ func TestServiceToRoutes(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()
 
-	routes := []gateway_api.HTTPRoute{
-		createHTTPRoute("invalid-kind", "ns1", gateway_api.BackendObjectReference{
-			Kind: (*gateway_api.Kind)(pointer.String("NotService")),
+	routes := []gwv1beta1.HTTPRoute{
+		createHTTPRoute("invalid-kind", "ns1", gwv1beta1.BackendObjectReference{
+			Kind: (*gwv1beta1.Kind)(pointer.String("NotService")),
 			Name: "test-service",
 		}),
-		createHTTPRoute("invalid-nil-kind", "ns1", gateway_api.BackendObjectReference{
+		createHTTPRoute("invalid-nil-kind", "ns1", gwv1beta1.BackendObjectReference{
 			Kind:      nil,
 			Namespace: nil,
 			Name:      "test-service",
 		}),
-		createHTTPRoute("invalid-nil-group", "ns1", gateway_api.BackendObjectReference{
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
+		createHTTPRoute("invalid-nil-group", "ns1", gwv1beta1.BackendObjectReference{
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
 			Namespace: nil,
 			Name:      "test-service",
 		}),
-		createHTTPRoute("invalid-group", "ns1", gateway_api.BackendObjectReference{
-			Group:     (*gateway_api.Group)(pointer.String("not-core")),
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
+		createHTTPRoute("invalid-group", "ns1", gwv1beta1.BackendObjectReference{
+			Group:     (*gwv1beta1.Group)(pointer.String("not-core")),
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
 			Namespace: nil,
 			Name:      "test-service",
 		}),
-		createHTTPRoute("valid-inferred-namespace", "ns1", gateway_api.BackendObjectReference{
-			Group:     (*gateway_api.Group)(pointer.String("")),
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
+		createHTTPRoute("valid-inferred-namespace", "ns1", gwv1beta1.BackendObjectReference{
+			Group:     (*gwv1beta1.Group)(pointer.String("")),
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
 			Namespace: nil,
 			Name:      "test-service",
 		}),
-		createHTTPRoute("valid-explicit-namespace", "ns1", gateway_api.BackendObjectReference{
-			Group:     (*gateway_api.Group)(pointer.String("")),
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
-			Namespace: (*gateway_api.Namespace)(pointer.String("ns1")),
+		createHTTPRoute("valid-explicit-namespace", "ns1", gwv1beta1.BackendObjectReference{
+			Group:     (*gwv1beta1.Group)(pointer.String("")),
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
+			Namespace: (*gwv1beta1.Namespace)(pointer.String("ns1")),
 			Name:      "test-service",
 		}),
-		createHTTPRoute("invalid-different-namespace", "ns1", gateway_api.BackendObjectReference{
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
-			Namespace: (*gateway_api.Namespace)(pointer.String("ns2")),
+		createHTTPRoute("invalid-different-namespace", "ns1", gwv1beta1.BackendObjectReference{
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
+			Namespace: (*gwv1beta1.Namespace)(pointer.String("ns2")),
 			Name:      "test-service",
 		}),
-		createHTTPRoute("invalid-different-name", "ns1", gateway_api.BackendObjectReference{
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
-			Namespace: (*gateway_api.Namespace)(pointer.String("ns1")),
+		createHTTPRoute("invalid-different-name", "ns1", gwv1beta1.BackendObjectReference{
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
+			Namespace: (*gwv1beta1.Namespace)(pointer.String("ns1")),
 			Name:      "not-test-service",
 		}),
 	}
@@ -94,9 +95,9 @@ func TestServiceToRoutes(t *testing.T) {
 		"valid-explicit-namespace",
 	}
 
-	mockClient := mock_client.NewMockClient(c)
+	mockClient := mockclient.NewMockClient(c)
 	mockClient.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, routeList *gateway_api.HTTPRouteList, _ ...interface{}) error {
+		func(ctx context.Context, routeList *gwv1beta1.HTTPRouteList, _ ...interface{}) error {
 			for _, route := range routes {
 				routeList.Items = append(routeList.Items, route)
 			}
@@ -127,34 +128,34 @@ func TestTargetGroupPolicyToService(t *testing.T) {
 
 	testCases := []struct {
 		namespace       string
-		targetKind      gateway_api.Kind
-		targetNamespace *gateway_api.Namespace
+		targetKind      gwv1beta1.Kind
+		targetNamespace *gwv1beta1.Namespace
 		serviceFound    bool
 		success         bool
 	}{
 		{
 			namespace:       ns1,
 			targetKind:      "Service",
-			targetNamespace: (*gateway_api.Namespace)(&ns2),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns2),
 			success:         false,
 		},
 		{
 			namespace:       ns1,
 			targetKind:      "NotService",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			success:         false,
 		},
 		{
 			namespace:       ns1,
 			targetKind:      "Service",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			serviceFound:    false,
 			success:         false,
 		},
 		{
 			namespace:       ns1,
 			targetKind:      "Service",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			serviceFound:    true,
 			success:         true,
 		},
@@ -167,33 +168,35 @@ func TestTargetGroupPolicyToService(t *testing.T) {
 		},
 	}
 
-	for _, tt := range testCases {
-		mockClient := mock_client.NewMockClient(c)
-		mapper := &resourceMapper{log: gwlog.FallbackLogger, client: mockClient}
-		if tt.serviceFound {
-			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		} else {
-			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("fail")).AnyTimes()
-		}
-		svc := mapper.TargetGroupPolicyToService(context.Background(), &v1alpha1.TargetGroupPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-policy",
-				Namespace: tt.namespace,
-			},
-			Spec: v1alpha1.TargetGroupPolicySpec{
-				TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
-					Group:     "",
-					Kind:      tt.targetKind,
-					Name:      "test-service",
-					Namespace: tt.targetNamespace,
+	for i, tt := range testCases {
+		t.Run(fmt.Sprintf("TGPolicyToService_%d", i), func(t *testing.T) {
+			mockClient := mockclient.NewMockClient(c)
+			mapper := &resourceMapper{log: gwlog.FallbackLogger, client: mockClient}
+			if tt.serviceFound {
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			} else {
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("fail")).AnyTimes()
+			}
+			svc := mapper.TargetGroupPolicyToService(context.Background(), &anv1alpha1.TargetGroupPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy",
+					Namespace: tt.namespace,
 				},
-			},
+				Spec: anv1alpha1.TargetGroupPolicySpec{
+					TargetRef: &gwv1alpha2.PolicyTargetReference{
+						Group:     "",
+						Kind:      tt.targetKind,
+						Name:      "test-service",
+						Namespace: tt.targetNamespace,
+					},
+				},
+			})
+			if tt.success {
+				assert.NotNil(t, svc)
+			} else {
+				assert.Nil(t, svc)
+			}
 		})
-		if tt.success {
-			assert.NotNil(t, svc)
-		} else {
-			assert.Nil(t, svc)
-		}
 	}
 }
 
@@ -207,8 +210,8 @@ func TestVpcAssociationPolicyToGateway(t *testing.T) {
 	testCases := []struct {
 		testCaseName    string
 		namespace       string
-		targetKind      gateway_api.Kind
-		targetNamespace *gateway_api.Namespace
+		targetKind      gwv1beta1.Kind
+		targetNamespace *gwv1beta1.Namespace
 		gatewayFound    bool
 		expectSuccess   bool
 	}{
@@ -216,28 +219,28 @@ func TestVpcAssociationPolicyToGateway(t *testing.T) {
 			testCaseName:    "namespace not match",
 			namespace:       ns1,
 			targetKind:      "Gateway",
-			targetNamespace: (*gateway_api.Namespace)(&ns2),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns2),
 			expectSuccess:   false,
 		},
 		{
 			testCaseName:    "targetKind not match scenario 1",
 			namespace:       ns1,
 			targetKind:      "NotGateway",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			expectSuccess:   false,
 		},
 		{
 			testCaseName:    "targetKind not match scenario 2",
 			namespace:       ns1,
 			targetKind:      "Service",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			expectSuccess:   false,
 		},
 		{
 			testCaseName:    "gateway not found",
 			namespace:       ns1,
 			targetKind:      "Gateway",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			gatewayFound:    false,
 			expectSuccess:   false,
 		},
@@ -245,7 +248,7 @@ func TestVpcAssociationPolicyToGateway(t *testing.T) {
 			testCaseName:    "gateway found, targetRef namespace match",
 			namespace:       ns1,
 			targetKind:      "Gateway",
-			targetNamespace: (*gateway_api.Namespace)(&ns1),
+			targetNamespace: (*gwv1beta1.Namespace)(&ns1),
 			gatewayFound:    true,
 			expectSuccess:   true,
 		},
@@ -260,39 +263,41 @@ func TestVpcAssociationPolicyToGateway(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		mockClient := mock_client.NewMockClient(c)
-		mapper := &resourceMapper{log: gwlog.FallbackLogger, client: mockClient}
-		if tt.gatewayFound {
-			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		} else {
-			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("fail")).AnyTimes()
-		}
-		var targetRefGroupName string
-		if tt.targetKind == "Gateway" {
-			targetRefGroupName = gateway_api.GroupName
-		} else if tt.targetKind == "Service" {
-			targetRefGroupName = corev1.GroupName
-		}
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			mockClient := mockclient.NewMockClient(c)
+			mapper := &resourceMapper{log: gwlog.FallbackLogger, client: mockClient}
+			if tt.gatewayFound {
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			} else {
+				mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("fail")).AnyTimes()
+			}
+			var targetRefGroupName string
+			if tt.targetKind == "Gateway" {
+				targetRefGroupName = gwv1beta1.GroupName
+			} else if tt.targetKind == "Service" {
+				targetRefGroupName = corev1.GroupName
+			}
 
-		gw := mapper.VpcAssociationPolicyToGateway(context.Background(), &v1alpha1.VpcAssociationPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test--vpc-association-policy",
-				Namespace: tt.namespace,
-			},
-
-			Spec: v1alpha1.VpcAssociationPolicySpec{
-				TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
-					Group:     gateway_api.Group(targetRefGroupName),
-					Kind:      tt.targetKind,
-					Name:      "test-gw",
-					Namespace: tt.targetNamespace,
+			gw := mapper.VpcAssociationPolicyToGateway(context.Background(), &anv1alpha1.VpcAssociationPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test--vpc-association-policy",
+					Namespace: tt.namespace,
 				},
-			},
+
+				Spec: anv1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &gwv1alpha2.PolicyTargetReference{
+						Group:     gwv1beta1.Group(targetRefGroupName),
+						Kind:      tt.targetKind,
+						Name:      "test-gw",
+						Namespace: tt.targetNamespace,
+					},
+				},
+			})
+			if tt.expectSuccess {
+				assert.NotNil(t, gw)
+			} else {
+				assert.Nil(t, gw)
+			}
 		})
-		if tt.expectSuccess {
-			assert.NotNil(t, gw)
-		} else {
-			assert.Nil(t, gw)
-		}
 	}
 }

--- a/controllers/eventhandlers/service_test.go
+++ b/controllers/eventhandlers/service_test.go
@@ -2,7 +2,7 @@ package eventhandlers
 
 import (
 	"context"
-	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
@@ -30,7 +30,7 @@ func TestServiceEventHandler_MapToRoute(t *testing.T) {
 			Name:      "test-service",
 		}),
 	}
-	mockClient := mockclient.NewMockClient(c)
+	mockClient := mock_client.NewMockClient(c)
 	h := NewServiceEventHandler(gwlog.FallbackLogger, mockClient)
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, name types.NamespacedName, svc client.Object, _ ...interface{}) error {
@@ -86,7 +86,7 @@ func TestServiceEventHandler_MapToServiceExport(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()
 
-	mockClient := mockclient.NewMockClient(c)
+	mockClient := mock_client.NewMockClient(c)
 	h := NewServiceEventHandler(gwlog.FallbackLogger, mockClient)
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, name types.NamespacedName, svcOrSvcExport client.Object, _ ...interface{}) error {

--- a/controllers/eventhandlers/service_test.go
+++ b/controllers/eventhandlers/service_test.go
@@ -2,8 +2,8 @@ package eventhandlers
 
 import (
 	"context"
-	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/golang/mock/gomock"
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"testing"
 )
 
@@ -22,15 +22,15 @@ func TestServiceEventHandler_MapToRoute(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()
 
-	routes := []gateway_api.HTTPRoute{
-		createHTTPRoute("valid-route", "ns1", gateway_api.BackendObjectReference{
-			Group:     (*gateway_api.Group)(pointer.String("")),
-			Kind:      (*gateway_api.Kind)(pointer.String("Service")),
-			Namespace: (*gateway_api.Namespace)(pointer.String("ns1")),
+	routes := []gwv1beta1.HTTPRoute{
+		createHTTPRoute("valid-route", "ns1", gwv1beta1.BackendObjectReference{
+			Group:     (*gwv1beta1.Group)(pointer.String("")),
+			Kind:      (*gwv1beta1.Kind)(pointer.String("Service")),
+			Namespace: (*gwv1beta1.Namespace)(pointer.String("ns1")),
 			Name:      "test-service",
 		}),
 	}
-	mockClient := mock_client.NewMockClient(c)
+	mockClient := mockclient.NewMockClient(c)
 	h := NewServiceEventHandler(gwlog.FallbackLogger, mockClient)
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, name types.NamespacedName, svc client.Object, _ ...interface{}) error {
@@ -40,7 +40,7 @@ func TestServiceEventHandler_MapToRoute(t *testing.T) {
 		},
 	).AnyTimes()
 	mockClient.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, routeList *gateway_api.HTTPRouteList, _ ...interface{}) error {
+		func(ctx context.Context, routeList *gwv1beta1.HTTPRouteList, _ ...interface{}) error {
 			for _, route := range routes {
 				routeList.Items = append(routeList.Items, route)
 			}
@@ -49,13 +49,13 @@ func TestServiceEventHandler_MapToRoute(t *testing.T) {
 	).AnyTimes()
 
 	objs := []client.Object{
-		&v1alpha1.TargetGroupPolicy{
+		&anv1alpha1.TargetGroupPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-policy",
 				Namespace: "ns1",
 			},
-			Spec: v1alpha1.TargetGroupPolicySpec{
-				TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
+			Spec: anv1alpha1.TargetGroupPolicySpec{
+				TargetRef: &gwv1alpha2.PolicyTargetReference{
 					Group: "",
 					Kind:  "Service",
 					Name:  "test-service",
@@ -86,7 +86,7 @@ func TestServiceEventHandler_MapToServiceExport(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()
 
-	mockClient := mock_client.NewMockClient(c)
+	mockClient := mockclient.NewMockClient(c)
 	h := NewServiceEventHandler(gwlog.FallbackLogger, mockClient)
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, name types.NamespacedName, svcOrSvcExport client.Object, _ ...interface{}) error {
@@ -97,13 +97,13 @@ func TestServiceEventHandler_MapToServiceExport(t *testing.T) {
 	).AnyTimes()
 
 	objs := []client.Object{
-		&v1alpha1.TargetGroupPolicy{
+		&anv1alpha1.TargetGroupPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-policy",
 				Namespace: "ns1",
 			},
-			Spec: v1alpha1.TargetGroupPolicySpec{
-				TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
+			Spec: anv1alpha1.TargetGroupPolicySpec{
+				TargetRef: &gwv1alpha2.PolicyTargetReference{
 					Group: "",
 					Kind:  "Service",
 					Name:  "test-service",

--- a/controllers/eventhandlers/serviceimport_test.go
+++ b/controllers/eventhandlers/serviceimport_test.go
@@ -2,7 +2,7 @@ package eventhandlers
 
 import (
 	"context"
-	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/golang/mock/gomock"
@@ -26,7 +26,7 @@ func TestServiceImportEventHandler_MapToRoute(t *testing.T) {
 			Name:      "test-service",
 		}),
 	}
-	mockClient := mockclient.NewMockClient(c)
+	mockClient := mock_client.NewMockClient(c)
 	h := NewServiceImportEventHandler(gwlog.FallbackLogger, mockClient)
 	mockClient.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, routeList *gwv1beta1.HTTPRouteList, _ ...interface{}) error {

--- a/controllers/eventhandlers/serviceimport_test.go
+++ b/controllers/eventhandlers/serviceimport_test.go
@@ -2,15 +2,15 @@ package eventhandlers
 
 import (
 	"context"
-	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
-	mcs_api "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 	"testing"
 )
 
@@ -18,18 +18,18 @@ func TestServiceImportEventHandler_MapToRoute(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()
 
-	routes := []gateway_api.HTTPRoute{
-		createHTTPRoute("valid-route", "ns1", gateway_api.BackendObjectReference{
-			Group:     (*gateway_api.Group)(pointer.String("multicluster.x-k8s.io")),
-			Kind:      (*gateway_api.Kind)(pointer.String("ServiceImport")),
-			Namespace: (*gateway_api.Namespace)(pointer.String("ns1")),
+	routes := []gwv1beta1.HTTPRoute{
+		createHTTPRoute("valid-route", "ns1", gwv1beta1.BackendObjectReference{
+			Group:     (*gwv1beta1.Group)(pointer.String("multicluster.x-k8s.io")),
+			Kind:      (*gwv1beta1.Kind)(pointer.String("ServiceImport")),
+			Namespace: (*gwv1beta1.Namespace)(pointer.String("ns1")),
 			Name:      "test-service",
 		}),
 	}
-	mockClient := mock_client.NewMockClient(c)
+	mockClient := mockclient.NewMockClient(c)
 	h := NewServiceImportEventHandler(gwlog.FallbackLogger, mockClient)
 	mockClient.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, routeList *gateway_api.HTTPRouteList, _ ...interface{}) error {
+		func(ctx context.Context, routeList *gwv1beta1.HTTPRouteList, _ ...interface{}) error {
 			for _, route := range routes {
 				routeList.Items = append(routeList.Items, route)
 			}
@@ -37,7 +37,7 @@ func TestServiceImportEventHandler_MapToRoute(t *testing.T) {
 		},
 	).AnyTimes()
 
-	reqs := h.mapToRoute(&mcs_api.ServiceImport{
+	reqs := h.mapToRoute(&mcsv1alpha1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-service",
 			Namespace: "ns1",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,14 +27,10 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	//"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
 var k8sClient client.Client

--- a/docs/developer-cheat-sheet.md
+++ b/docs/developer-cheat-sheet.md
@@ -43,6 +43,15 @@ import (
 )
 ```
 
+For unit tests, this changes slightly for more readability when using the imports strictly for mocking
+```go
+import (
+  mocks_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+  mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+  mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+)
+```
+
 ### Service, Service, or Service?
 Similarly, because there is overlap between the Gateway API spec, model types, and Lattice API nouns, it is important to use differentiating names between the types in components where the name could be ambiguous. The safest approach is to use a prefix:
 

--- a/pkg/aws/cloud_test.go
+++ b/pkg/aws/cloud_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,13 +38,13 @@ func TestIsArnManaged(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()
 
-	lat := services.NewMockLattice(c)
+	mockLattice := services.NewMockLattice(c)
 	cfg := CloudConfig{VpcId: "vpc-id", AccountId: "account-id"}
-	cl := NewDefaultCloud(lat, cfg)
+	cl := NewDefaultCloud(mockLattice, cfg)
 
 	t.Run("arn sent", func(t *testing.T) {
 		arn := "arn"
-		lat.EXPECT().ListTagsForResource(gomock.Any()).
+		mockLattice.EXPECT().ListTagsForResource(gomock.Any()).
 			DoAndReturn(
 				func(req *vpclattice.ListTagsForResourceInput) (*vpclattice.ListTagsForResourceOutput, error) {
 					assert.Equal(t, arn, *req.ResourceArn)
@@ -55,7 +55,7 @@ func TestIsArnManaged(t *testing.T) {
 
 	t.Run("is managed", func(t *testing.T) {
 		arn := "arn"
-		lat.EXPECT().ListTagsForResource(gomock.Any()).
+		mockLattice.EXPECT().ListTagsForResource(gomock.Any()).
 			Return(&vpclattice.ListTagsForResourceOutput{
 				Tags: cl.DefaultTags(),
 			}, nil)
@@ -65,7 +65,7 @@ func TestIsArnManaged(t *testing.T) {
 	})
 
 	t.Run("not managed", func(t *testing.T) {
-		lat.EXPECT().ListTagsForResource(gomock.Any()).
+		mockLattice.EXPECT().ListTagsForResource(gomock.Any()).
 			Return(&vpclattice.ListTagsForResourceOutput{}, nil)
 		managed, err := cl.IsArnManaged("arn")
 		assert.Nil(t, err)
@@ -73,7 +73,7 @@ func TestIsArnManaged(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		lat.EXPECT().ListTagsForResource(gomock.Any()).
+		mockLattice.EXPECT().ListTagsForResource(gomock.Any()).
 			Return(nil, errors.New(":("))
 		managed, err := cl.IsArnManaged("arn")
 		assert.Nil(t, err)

--- a/pkg/aws/services/vpclattice_test.go
+++ b/pkg/aws/services/vpclattice_test.go
@@ -46,50 +46,52 @@ func Test_defaultLattice_ListServiceNetworksAsList(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		mockLattice := NewMockLattice(c)
+		t.Run(tt.testName, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			mockLattice := NewMockLattice(c)
 
-		d := &defaultLattice{
-			VPCLatticeAPI: mockLattice,
-		}
+			d := &defaultLattice{
+				VPCLatticeAPI: mockLattice,
+			}
 
-		input := &vpclattice.ListServiceNetworksInput{
-			MaxResults: &tt.maxResults,
-			NextToken:  nil,
-		}
-		sn := &vpclattice.ServiceNetworkSummary{
-			Arn:  &tt.testArn,
-			Id:   &tt.testId,
-			Name: &tt.testName,
-		}
-		listOutput1 := &vpclattice.ListServiceNetworksOutput{
-			Items:     []*vpclattice.ServiceNetworkSummary{sn, sn},
-			NextToken: &tt.nextToken,
-		}
-		listOutput2 := &vpclattice.ListServiceNetworksOutput{
-			Items:     []*vpclattice.ServiceNetworkSummary{sn, sn},
-			NextToken: &tt.nextToken,
-		}
-		listOutput3 := &vpclattice.ListServiceNetworksOutput{
-			Items:     []*vpclattice.ServiceNetworkSummary{sn},
-			NextToken: nil,
-		}
-		mockLattice.EXPECT().ListServiceNetworksPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
-			func(ctx aws.Context, input *vpclattice.ListServiceNetworksInput, f func(*vpclattice.ListServiceNetworksOutput, bool) bool, opts ...request.Option) error {
-				cont := f(listOutput1, false)
-				if cont {
-					cont = f(listOutput2, false)
-				}
-				if cont {
-					f(listOutput3, true)
-				}
-				return nil
-			}).Times(1)
+			input := &vpclattice.ListServiceNetworksInput{
+				MaxResults: &tt.maxResults,
+				NextToken:  nil,
+			}
+			sn := &vpclattice.ServiceNetworkSummary{
+				Arn:  &tt.testArn,
+				Id:   &tt.testId,
+				Name: &tt.testName,
+			}
+			listOutput1 := &vpclattice.ListServiceNetworksOutput{
+				Items:     []*vpclattice.ServiceNetworkSummary{sn, sn},
+				NextToken: &tt.nextToken,
+			}
+			listOutput2 := &vpclattice.ListServiceNetworksOutput{
+				Items:     []*vpclattice.ServiceNetworkSummary{sn, sn},
+				NextToken: &tt.nextToken,
+			}
+			listOutput3 := &vpclattice.ListServiceNetworksOutput{
+				Items:     []*vpclattice.ServiceNetworkSummary{sn},
+				NextToken: nil,
+			}
+			mockLattice.EXPECT().ListServiceNetworksPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
+				func(ctx aws.Context, input *vpclattice.ListServiceNetworksInput, f func(*vpclattice.ListServiceNetworksOutput, bool) bool, opts ...request.Option) error {
+					cont := f(listOutput1, false)
+					if cont {
+						cont = f(listOutput2, false)
+					}
+					if cont {
+						f(listOutput3, true)
+					}
+					return nil
+				}).Times(1)
 
-		got, err := d.ListServiceNetworksAsList(tt.ctx, input)
-		assert.Nil(t, err)
-		assert.Equal(t, got, []*vpclattice.ServiceNetworkSummary{sn, sn, sn, sn, sn})
+			got, err := d.ListServiceNetworksAsList(tt.ctx, input)
+			assert.Nil(t, err)
+			assert.Equal(t, got, []*vpclattice.ServiceNetworkSummary{sn, sn, sn, sn, sn})
+		})
 	}
 }
 
@@ -108,42 +110,44 @@ func Test_defaultLattice_ListServicesAsList(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		mockLattice := NewMockLattice(c)
+		t.Run(tt.testName, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			mockLattice := NewMockLattice(c)
 
-		d := &defaultLattice{
-			VPCLatticeAPI: mockLattice,
-		}
+			d := &defaultLattice{
+				VPCLatticeAPI: mockLattice,
+			}
 
-		input := &vpclattice.ListServicesInput{
-			MaxResults: &tt.maxResults,
-			NextToken:  nil,
-		}
-		sampleService := &vpclattice.ServiceSummary{
-			Name: &tt.testName,
-		}
-		listOutput1 := &vpclattice.ListServicesOutput{
-			Items:     []*vpclattice.ServiceSummary{sampleService},
-			NextToken: &tt.nextToken,
-		}
-		listOutput2 := &vpclattice.ListServicesOutput{
-			Items:     []*vpclattice.ServiceSummary{sampleService},
-			NextToken: nil,
-		}
+			input := &vpclattice.ListServicesInput{
+				MaxResults: &tt.maxResults,
+				NextToken:  nil,
+			}
+			sampleService := &vpclattice.ServiceSummary{
+				Name: &tt.testName,
+			}
+			listOutput1 := &vpclattice.ListServicesOutput{
+				Items:     []*vpclattice.ServiceSummary{sampleService},
+				NextToken: &tt.nextToken,
+			}
+			listOutput2 := &vpclattice.ListServicesOutput{
+				Items:     []*vpclattice.ServiceSummary{sampleService},
+				NextToken: nil,
+			}
 
-		mockLattice.EXPECT().ListServicesPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
-			func(ctx aws.Context, input *vpclattice.ListServicesInput, f func(*vpclattice.ListServicesOutput, bool) bool, opts ...request.Option) error {
-				cont := f(listOutput1, false)
-				if cont {
-					f(listOutput2, true)
-				}
-				return nil
-			}).Times(1)
+			mockLattice.EXPECT().ListServicesPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
+				func(ctx aws.Context, input *vpclattice.ListServicesInput, f func(*vpclattice.ListServicesOutput, bool) bool, opts ...request.Option) error {
+					cont := f(listOutput1, false)
+					if cont {
+						f(listOutput2, true)
+					}
+					return nil
+				}).Times(1)
 
-		got, err := d.ListServicesAsList(tt.ctx, input)
-		assert.Nil(t, err)
-		assert.Equal(t, got, []*vpclattice.ServiceSummary{sampleService, sampleService})
+			got, err := d.ListServicesAsList(tt.ctx, input)
+			assert.Nil(t, err)
+			assert.Equal(t, got, []*vpclattice.ServiceSummary{sampleService, sampleService})
+		})
 	}
 }
 
@@ -162,36 +166,38 @@ func Test_defaultLattice_ListTGsAsList(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		mockLattice := NewMockLattice(c)
+		t.Run(tt.testName, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			mockLattice := NewMockLattice(c)
 
-		d := &defaultLattice{
-			VPCLatticeAPI: mockLattice,
-		}
+			d := &defaultLattice{
+				VPCLatticeAPI: mockLattice,
+			}
 
-		input := &vpclattice.ListTargetGroupsInput{
-			MaxResults: &tt.maxResults,
-			NextToken:  nil,
-		}
-		sample := &vpclattice.TargetGroupSummary{
-			Name: &tt.testName,
-		}
+			input := &vpclattice.ListTargetGroupsInput{
+				MaxResults: &tt.maxResults,
+				NextToken:  nil,
+			}
+			sample := &vpclattice.TargetGroupSummary{
+				Name: &tt.testName,
+			}
 
-		listOutput1 := &vpclattice.ListTargetGroupsOutput{
-			Items:     []*vpclattice.TargetGroupSummary{sample},
-			NextToken: nil,
-		}
+			listOutput1 := &vpclattice.ListTargetGroupsOutput{
+				Items:     []*vpclattice.TargetGroupSummary{sample},
+				NextToken: nil,
+			}
 
-		mockLattice.EXPECT().ListTargetGroupsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
-			func(ctx aws.Context, input *vpclattice.ListTargetGroupsInput, f func(*vpclattice.ListTargetGroupsOutput, bool) bool, opts ...request.Option) error {
-				f(listOutput1, true)
-				return nil
-			}).Times(1)
+			mockLattice.EXPECT().ListTargetGroupsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
+				func(ctx aws.Context, input *vpclattice.ListTargetGroupsInput, f func(*vpclattice.ListTargetGroupsOutput, bool) bool, opts ...request.Option) error {
+					f(listOutput1, true)
+					return nil
+				}).Times(1)
 
-		got, err := d.ListTargetGroupsAsList(tt.ctx, input)
-		assert.Nil(t, err)
-		assert.Equal(t, got, []*vpclattice.TargetGroupSummary{sample})
+			got, err := d.ListTargetGroupsAsList(tt.ctx, input)
+			assert.Nil(t, err)
+			assert.Equal(t, got, []*vpclattice.TargetGroupSummary{sample})
+		})
 	}
 }
 
@@ -210,34 +216,36 @@ func Test_defaultLattice_ListTargetsAsList(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		mockLattice := NewMockLattice(c)
+		t.Run(tt.testName, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			mockLattice := NewMockLattice(c)
 
-		d := &defaultLattice{
-			VPCLatticeAPI: mockLattice,
-		}
+			d := &defaultLattice{
+				VPCLatticeAPI: mockLattice,
+			}
 
-		input := &vpclattice.ListTargetsInput{
-			MaxResults: &tt.maxResults,
-			NextToken:  nil,
-		}
-		sample := &vpclattice.TargetSummary{
-			Id: &tt.testName,
-		}
-		listOutput1 := &vpclattice.ListTargetsOutput{
-			Items:     []*vpclattice.TargetSummary{sample, sample},
-			NextToken: nil,
-		}
-		mockLattice.EXPECT().ListTargetsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
-			func(ctx aws.Context, input *vpclattice.ListTargetsInput, f func(*vpclattice.ListTargetsOutput, bool) bool, opts ...request.Option) error {
-				f(listOutput1, true)
-				return nil
-			}).Times(1)
+			input := &vpclattice.ListTargetsInput{
+				MaxResults: &tt.maxResults,
+				NextToken:  nil,
+			}
+			sample := &vpclattice.TargetSummary{
+				Id: &tt.testName,
+			}
+			listOutput1 := &vpclattice.ListTargetsOutput{
+				Items:     []*vpclattice.TargetSummary{sample, sample},
+				NextToken: nil,
+			}
+			mockLattice.EXPECT().ListTargetsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
+				func(ctx aws.Context, input *vpclattice.ListTargetsInput, f func(*vpclattice.ListTargetsOutput, bool) bool, opts ...request.Option) error {
+					f(listOutput1, true)
+					return nil
+				}).Times(1)
 
-		got, err := d.ListTargetsAsList(tt.ctx, input)
-		assert.Nil(t, err)
-		assert.Equal(t, got, []*vpclattice.TargetSummary{sample, sample})
+			got, err := d.ListTargetsAsList(tt.ctx, input)
+			assert.Nil(t, err)
+			assert.Equal(t, got, []*vpclattice.TargetSummary{sample, sample})
+		})
 	}
 }
 
@@ -256,34 +264,36 @@ func Test_defaultLattice_ListServiceNetworkVpcAssociationsAsList(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		mockLattice := NewMockLattice(c)
+		t.Run(tt.testName, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			mockLattice := NewMockLattice(c)
 
-		d := &defaultLattice{
-			VPCLatticeAPI: mockLattice,
-		}
+			d := &defaultLattice{
+				VPCLatticeAPI: mockLattice,
+			}
 
-		input := &vpclattice.ListServiceNetworkVpcAssociationsInput{
-			MaxResults: &tt.maxResults,
-			NextToken:  nil,
-		}
-		sample := &vpclattice.ServiceNetworkVpcAssociationSummary{
-			ServiceNetworkName: &tt.testName,
-		}
-		listOutput1 := &vpclattice.ListServiceNetworkVpcAssociationsOutput{
-			Items:     []*vpclattice.ServiceNetworkVpcAssociationSummary{sample},
-			NextToken: nil,
-		}
-		mockLattice.EXPECT().ListServiceNetworkVpcAssociationsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
-			func(ctx aws.Context, input *vpclattice.ListServiceNetworkVpcAssociationsInput, f func(*vpclattice.ListServiceNetworkVpcAssociationsOutput, bool) bool, opts ...request.Option) error {
-				f(listOutput1, true)
-				return nil
-			}).Times(1)
+			input := &vpclattice.ListServiceNetworkVpcAssociationsInput{
+				MaxResults: &tt.maxResults,
+				NextToken:  nil,
+			}
+			sample := &vpclattice.ServiceNetworkVpcAssociationSummary{
+				ServiceNetworkName: &tt.testName,
+			}
+			listOutput1 := &vpclattice.ListServiceNetworkVpcAssociationsOutput{
+				Items:     []*vpclattice.ServiceNetworkVpcAssociationSummary{sample},
+				NextToken: nil,
+			}
+			mockLattice.EXPECT().ListServiceNetworkVpcAssociationsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
+				func(ctx aws.Context, input *vpclattice.ListServiceNetworkVpcAssociationsInput, f func(*vpclattice.ListServiceNetworkVpcAssociationsOutput, bool) bool, opts ...request.Option) error {
+					f(listOutput1, true)
+					return nil
+				}).Times(1)
 
-		got, err := d.ListServiceNetworkVpcAssociationsAsList(tt.ctx, input)
-		assert.Nil(t, err)
-		assert.Equal(t, got, []*vpclattice.ServiceNetworkVpcAssociationSummary{sample})
+			got, err := d.ListServiceNetworkVpcAssociationsAsList(tt.ctx, input)
+			assert.Nil(t, err)
+			assert.Equal(t, got, []*vpclattice.ServiceNetworkVpcAssociationSummary{sample})
+		})
 	}
 }
 
@@ -302,32 +312,34 @@ func Test_defaultLattice_ListServiceNetworkServiceAssociationsAsList(t *testing.
 		},
 	}
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		mockLattice := NewMockLattice(c)
+		t.Run(tt.testName, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			mockLattice := NewMockLattice(c)
 
-		d := &defaultLattice{
-			VPCLatticeAPI: mockLattice,
-		}
+			d := &defaultLattice{
+				VPCLatticeAPI: mockLattice,
+			}
 
-		input := &vpclattice.ListServiceNetworkServiceAssociationsInput{
-			MaxResults: &tt.maxResults,
-			NextToken:  nil,
-		}
+			input := &vpclattice.ListServiceNetworkServiceAssociationsInput{
+				MaxResults: &tt.maxResults,
+				NextToken:  nil,
+			}
 
-		listOutput1 := &vpclattice.ListServiceNetworkServiceAssociationsOutput{
-			Items:     []*vpclattice.ServiceNetworkServiceAssociationSummary{},
-			NextToken: nil,
-		}
-		mockLattice.EXPECT().ListServiceNetworkServiceAssociationsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
-			func(ctx aws.Context, input *vpclattice.ListServiceNetworkServiceAssociationsInput, f func(*vpclattice.ListServiceNetworkServiceAssociationsOutput, bool) bool, opts ...request.Option) error {
-				f(listOutput1, true)
-				return nil
-			}).Times(1)
+			listOutput1 := &vpclattice.ListServiceNetworkServiceAssociationsOutput{
+				Items:     []*vpclattice.ServiceNetworkServiceAssociationSummary{},
+				NextToken: nil,
+			}
+			mockLattice.EXPECT().ListServiceNetworkServiceAssociationsPagesWithContext(tt.ctx, input, gomock.Any()).DoAndReturn(
+				func(ctx aws.Context, input *vpclattice.ListServiceNetworkServiceAssociationsInput, f func(*vpclattice.ListServiceNetworkServiceAssociationsOutput, bool) bool, opts ...request.Option) error {
+					f(listOutput1, true)
+					return nil
+				}).Times(1)
 
-		got, err := d.ListServiceNetworkServiceAssociationsAsList(tt.ctx, input)
-		assert.Nil(t, err)
-		assert.Equal(t, got, []*vpclattice.ServiceNetworkServiceAssociationSummary{})
+			got, err := d.ListServiceNetworkServiceAssociationsAsList(tt.ctx, input)
+			assert.Nil(t, err)
+			assert.Equal(t, got, []*vpclattice.ServiceNetworkServiceAssociationSummary{})
+		})
 	}
 }
 

--- a/pkg/deploy/externaldns/dnsendpoint_manager_test.go
+++ b/pkg/deploy/externaldns/dnsendpoint_manager_test.go
@@ -3,11 +3,10 @@ package externaldns
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
 	"github.com/golang/mock/gomock"
@@ -26,7 +25,7 @@ func TestCreateDnsEndpoint(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		service          latticemodel.Service
+		service          model.Service
 		existingEndpoint endpoint.DNSEndpoint
 		routeGetErr      error
 		dnsGetErr        error
@@ -38,13 +37,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 	}{
 		{
 			name: "No customer domain name - skips creation",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -52,13 +51,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "No service dns - skips creation",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "",
 				},
 			},
@@ -66,13 +65,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "No parent route - skips creation",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -81,13 +80,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "Create new DNSEndpoint if not existing already",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -97,13 +96,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "Return error on creation failure",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -114,13 +113,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "Update DNSEndpoint if existing already",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -141,13 +140,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "DNSEndpoint existing already, but skip if it is the same",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -168,13 +167,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "Return error on update failure",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -196,13 +195,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "Skips creation when DNSEndpoint CRD is not found",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -214,13 +213,13 @@ func TestCreateDnsEndpoint(t *testing.T) {
 		},
 		{
 			name: "Return error on unexpected lookup failure",
-			service: latticemodel.Service{
-				Spec: latticemodel.ServiceSpec{
+			service: model.Service{
+				Spec: model.ServiceSpec{
 					Name:               "service",
 					Namespace:          "default",
 					CustomerDomainName: "custom-domain",
 				},
-				Status: &latticemodel.ServiceStatus{
+				Status: &model.ServiceStatus{
 					Dns: "lattice-internal-domain",
 				},
 			},
@@ -230,43 +229,44 @@ func TestCreateDnsEndpoint(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Printf("Testing >>>>> %v\n", tt.name)
-		client := mock_client.NewMockClient(c)
-		mgr := NewDnsEndpointManager(gwlog.FallbackLogger, client)
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := mock_client.NewMockClient(c)
+			mgr := NewDnsEndpointManager(gwlog.FallbackLogger, mockClient)
 
-		client.EXPECT().Scheme().Return(runtime.NewScheme()).AnyTimes()
+			mockClient.EXPECT().Scheme().Return(runtime.NewScheme()).AnyTimes()
 
-		client.EXPECT().Get(gomock.Any(), gomock.Eq(types.NamespacedName{
-			Namespace: tt.service.Spec.Namespace,
-			Name:      tt.service.Spec.Name,
-		}), gomock.Any()).Return(tt.routeGetErr).AnyTimes()
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Eq(types.NamespacedName{
+				Namespace: tt.service.Spec.Namespace,
+				Name:      tt.service.Spec.Name,
+			}), gomock.Any()).Return(tt.routeGetErr).AnyTimes()
 
-		client.EXPECT().Get(gomock.Any(), gomock.Eq(types.NamespacedName{
-			Namespace: tt.service.Spec.Namespace,
-			Name:      tt.service.Spec.Name + "-dns",
-		}), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, ep *endpoint.DNSEndpoint, _ ...interface{}) error {
-			tt.existingEndpoint.DeepCopyInto(ep)
-			return tt.dnsGetErr
-		}).AnyTimes()
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Eq(types.NamespacedName{
+				Namespace: tt.service.Spec.Namespace,
+				Name:      tt.service.Spec.Name + "-dns",
+			}), gomock.Any()).DoAndReturn(func(ctx context.Context, name types.NamespacedName, ep *endpoint.DNSEndpoint, _ ...interface{}) error {
+				tt.existingEndpoint.DeepCopyInto(ep)
+				return tt.dnsGetErr
+			}).AnyTimes()
 
-		createCall := client.EXPECT().Create(gomock.Any(), gomock.Any()).Return(tt.dnsCreateErr)
-		if tt.created {
-			createCall.Times(1)
-		} else {
-			createCall.Times(0)
-		}
-		patchCall := client.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.dnsUpdateErr)
-		if tt.updated {
-			patchCall.Times(1)
-		} else {
-			patchCall.Times(0)
-		}
+			createCall := mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(tt.dnsCreateErr)
+			if tt.created {
+				createCall.Times(1)
+			} else {
+				createCall.Times(0)
+			}
+			patchCall := mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.dnsUpdateErr)
+			if tt.updated {
+				patchCall.Times(1)
+			} else {
+				patchCall.Times(0)
+			}
 
-		err := mgr.Create(context.Background(), &tt.service)
-		if tt.errIsNil {
-			assert.Nil(t, err)
-		} else {
-			assert.Error(t, err)
-		}
+			err := mgr.Create(context.Background(), &tt.service)
+			if tt.errIsNil {
+				assert.Nil(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
 	}
 }

--- a/pkg/deploy/lattice/rule_manager_test.go
+++ b/pkg/deploy/lattice/rule_manager_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
-var rulelist = []struct {
+var ruleList = []struct {
 	Arn       string
 	Id        string
 	IsDefault bool
@@ -44,16 +44,16 @@ var rulelist = []struct {
 	},
 }
 
-var rules = []*latticemodel.Rule{
+var rules = []*model.Rule{
 	{
-		Spec: latticemodel.RuleSpec{
+		Spec: model.RuleSpec{
 			ServiceName:      "svc-1",
 			ServiceNamespace: "default",
 			ListenerPort:     int64(80),
 			ListenerProtocol: "HTTP",
 			RuleID:           "rule-1", //TODO, maybe rename this field to RuleName
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			ServiceID:  "serviceID1",
 			ListenerID: "listenerID1",
 			RuleID:     "rule-ID-1",
@@ -61,14 +61,14 @@ var rules = []*latticemodel.Rule{
 	},
 
 	{
-		Spec: latticemodel.RuleSpec{
+		Spec: model.RuleSpec{
 			ServiceName:      "svc-1",
 			ServiceNamespace: "default",
 			ListenerPort:     int64(80),
 			ListenerProtocol: "HTTP",
 			RuleID:           "rule-2", //TODO, maybe rename this field to RuleName
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			ServiceID:  "serviceID1",
 			ListenerID: "listenerID1",
 			RuleID:     "rule-ID-2",
@@ -94,36 +94,36 @@ func Test_CreateRule(t *testing.T) {
 	var weight2 = int64(10)
 	weightRulePriority := 1
 	weightRuleID := fmt.Sprintf("rule-%d", weightRulePriority)
-	WeigthedAction_1 := latticemodel.RuleTargetGroup{
+	WeightedAction_1 := model.RuleTargetGroup{
 		Name:            "TestCreateWeighted1",
 		Namespace:       "default",
 		IsServiceImport: false,
 		Weight:          weight1,
 	}
 
-	WeightedAction_11 := latticemodel.RuleTargetGroup{
+	WeightedAction_11 := model.RuleTargetGroup{
 		Name:            "TestCreateWeighted1",
 		Namespace:       "default",
 		IsServiceImport: false,
 		Weight:          weight2,
 	}
 
-	WeigthedAction_2 := latticemodel.RuleTargetGroup{
+	WeightedAction_2 := model.RuleTargetGroup{
 		Name:            "TestCreateWeighte2",
 		Namespace:       "default",
 		IsServiceImport: false,
 		Weight:          weight2,
 	}
 
-	WeigthedAction_22 := latticemodel.RuleTargetGroup{
+	WeightedAction_22 := model.RuleTargetGroup{
 		Name:            "TestCreateWeighte2",
 		Namespace:       "default",
 		IsServiceImport: false,
 		Weight:          weight1,
 	}
 
-	WeightedRule_1 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	WeightedRule_1 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:      ServiceName,
 			ServiceNamespace: ServiceNameSpace,
 			ListenerPort:     ListenerPort,
@@ -131,13 +131,13 @@ func Test_CreateRule(t *testing.T) {
 			PathMatchPrefix:  true,
 			PathMatchValue:   "",
 			RuleID:           weightRuleID,
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_1,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_1,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-1",
 			ListenerID: ListenerID,
@@ -145,8 +145,8 @@ func Test_CreateRule(t *testing.T) {
 		},
 	}
 
-	WeightedRule_1_2 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	WeightedRule_1_2 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:      ServiceName,
 			ServiceNamespace: ServiceNameSpace,
 			ListenerPort:     ListenerPort,
@@ -154,14 +154,14 @@ func Test_CreateRule(t *testing.T) {
 			PathMatchValue:   "",
 			PathMatchPrefix:  true,
 			RuleID:           weightRuleID,
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_1,
-					&WeigthedAction_2,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_1,
+					&WeightedAction_2,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-1-2",
 			ListenerID: ListenerID,
@@ -169,8 +169,8 @@ func Test_CreateRule(t *testing.T) {
 		},
 	}
 
-	WeightedRule_2_1 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	WeightedRule_2_1 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:      ServiceName,
 			ServiceNamespace: ServiceNameSpace,
 			ListenerPort:     ListenerPort,
@@ -178,14 +178,14 @@ func Test_CreateRule(t *testing.T) {
 			PathMatchValue:   "",
 			PathMatchPrefix:  true,
 			RuleID:           weightRuleID,
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
 					&WeightedAction_11,
-					&WeigthedAction_22,
+					&WeightedAction_22,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-2-1",
 			ListenerID: ListenerID,
@@ -193,8 +193,8 @@ func Test_CreateRule(t *testing.T) {
 		},
 	}
 
-	pathRule_1 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	pathRule_1 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:      ServiceName,
 			ServiceNamespace: ServiceNameSpace,
 			ListenerPort:     ListenerPort,
@@ -202,13 +202,13 @@ func Test_CreateRule(t *testing.T) {
 			RuleID:           weightRuleID,
 			PathMatchPrefix:  true,
 			PathMatchValue:   "/ver-1",
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_1,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_1,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-2-1",
 			ListenerID: ListenerID,
@@ -216,8 +216,8 @@ func Test_CreateRule(t *testing.T) {
 		},
 	}
 
-	pathRule_11 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	pathRule_11 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:      ServiceName,
 			ServiceNamespace: ServiceNameSpace,
 			ListenerPort:     ListenerPort,
@@ -225,13 +225,13 @@ func Test_CreateRule(t *testing.T) {
 			RuleID:           weightRuleID,
 			PathMatchPrefix:  true,
 			PathMatchValue:   "/ver-1",
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_2,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_2,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-2-1",
 			ListenerID: ListenerID,
@@ -239,8 +239,8 @@ func Test_CreateRule(t *testing.T) {
 		},
 	}
 
-	pathRule_2 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	pathRule_2 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:      ServiceName,
 			ServiceNamespace: ServiceNameSpace,
 			ListenerPort:     ListenerPort,
@@ -248,13 +248,13 @@ func Test_CreateRule(t *testing.T) {
 			RuleID:           weightRuleID,
 			PathMatchPrefix:  true,
 			PathMatchValue:   "/ver-2",
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_1,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_1,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-2-1",
 			ListenerID: ListenerID,
@@ -262,8 +262,8 @@ func Test_CreateRule(t *testing.T) {
 		},
 	}
 
-	headerRule_1 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	headerRule_1 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:        ServiceName,
 			ServiceNamespace:   ServiceNameSpace,
 			ListenerPort:       ListenerPort,
@@ -289,13 +289,13 @@ func Test_CreateRule(t *testing.T) {
 				{},
 				{},
 			},
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_1,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_1,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-2-1",
 			ListenerID: ListenerID,
@@ -306,8 +306,8 @@ func Test_CreateRule(t *testing.T) {
 	headerRule_1_path_exact.Spec.PathMatchPrefix = false
 	headerRule_1_path_exact.Spec.PathMatchExact = true
 
-	headerRule_1_2 := latticemodel.Rule{
-		Spec: latticemodel.RuleSpec{
+	headerRule_1_2 := model.Rule{
+		Spec: model.RuleSpec{
 			ServiceName:        ServiceName,
 			ServiceNamespace:   ServiceNameSpace,
 			ListenerPort:       ListenerPort,
@@ -333,14 +333,14 @@ func Test_CreateRule(t *testing.T) {
 				{},
 				{},
 			},
-			Action: latticemodel.RuleAction{
-				TargetGroups: []*latticemodel.RuleTargetGroup{
-					&WeigthedAction_1,
-					&WeigthedAction_2,
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					&WeightedAction_1,
+					&WeightedAction_2,
 				},
 			},
 		},
-		Status: &latticemodel.RuleStatus{
+		Status: &model.RuleStatus{
 			RuleARN:    "ruleARn",
 			RuleID:     "rule-id-2-1",
 			ListenerID: ListenerID,
@@ -353,9 +353,9 @@ func Test_CreateRule(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		oldRule              *latticemodel.Rule
-		newRule              *latticemodel.Rule
-		listRuleOuput        []*latticemodel.Rule
+		oldRule              *model.Rule
+		newRule              *model.Rule
+		listRuleOuput        []*model.Rule
 		createRule           bool
 		updateRule           bool
 		noServiceID          bool
@@ -522,81 +522,120 @@ func Test_CreateRule(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Printf("testing >>> tt.name: %v\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		mockLattice := mocks.NewMockLattice(c)
-		mockCloud := mocks_aws.NewMockCloud(c)
-		mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+			mockLattice := mocks.NewMockLattice(c)
+			mockCloud := mocks_aws.NewMockCloud(c)
+			mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
-		latticeDataStore := latticestore.NewLatticeDataStore()
+			latticeDataStore := latticestore.NewLatticeDataStore()
 
-		ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+			ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
 
-		if !tt.noServiceID {
-			mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
-				&vpclattice.ServiceSummary{
-					Name: aws.String((&RuleLSNProvider{tt.newRule}).LatticeServiceName()),
-					Arn:  aws.String("serviceARN"),
-					Id:   aws.String(tt.newRule.Status.ServiceID),
-					DnsEntry: &vpclattice.DnsEntry{
-						DomainName:   aws.String("test-dns"),
-						HostedZoneId: aws.String("my-favourite-zone"),
-					},
-				}, nil).Times(1)
-		} else {
-			mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(nil, &mocks.NotFoundError{}).Times(1)
-		}
-
-		if !tt.noListenerID {
-			latticeDataStore.AddListener(tt.newRule.Spec.ServiceName, tt.newRule.Spec.ServiceNamespace,
-				tt.newRule.Spec.ListenerPort, "HTTP",
-				"listernerARN", tt.newRule.Status.ListenerID)
-		}
-
-		if !tt.noTargetGroupID {
-			for _, tg := range tt.newRule.Spec.Action.TargetGroups {
-				tgName := latticestore.TargetGroupName(tg.Name, tg.Namespace)
-				latticeDataStore.AddTargetGroup(tgName, "vpc", "arn", "tg-id", tg.IsServiceImport, "")
+			if !tt.noServiceID {
+				mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
+					&vpclattice.ServiceSummary{
+						Name: aws.String((&RuleLSNProvider{tt.newRule}).LatticeServiceName()),
+						Arn:  aws.String("serviceARN"),
+						Id:   aws.String(tt.newRule.Status.ServiceID),
+						DnsEntry: &vpclattice.DnsEntry{
+							DomainName:   aws.String("test-dns"),
+							HostedZoneId: aws.String("my-favourite-zone"),
+						},
+					}, nil).Times(1)
+			} else {
+				mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(nil, &mocks.NotFoundError{}).Times(1)
 			}
 
-		}
-
-		if !tt.noListenerID && !tt.noServiceID {
-			ruleInput := vpclattice.ListRulesInput{
-				ListenerIdentifier: aws.String(tt.newRule.Status.ListenerID),
-				ServiceIdentifier:  aws.String(tt.newRule.Status.ServiceID),
+			if !tt.noListenerID {
+				latticeDataStore.AddListener(tt.newRule.Spec.ServiceName, tt.newRule.Spec.ServiceNamespace,
+					tt.newRule.Spec.ListenerPort, "HTTP",
+					"listernerARN", tt.newRule.Status.ListenerID)
 			}
 
-			ruleOutput := vpclattice.ListRulesOutput{}
-
-			if tt.oldRule != nil {
-				items := []*vpclattice.RuleSummary{}
-
-				items = append(items, &vpclattice.RuleSummary{
-					Id: aws.String(tt.oldRule.Spec.RuleID),
-				})
-				ruleOutput = vpclattice.ListRulesOutput{
-					Items: items,
-				}
-			}
-			mockLattice.EXPECT().ListRules(&ruleInput).Return(&ruleOutput, nil)
-
-			if tt.oldRule != nil {
-				ruleGetInput := vpclattice.GetRuleInput{
-					ListenerIdentifier: aws.String(ListenerID),
-					ServiceIdentifier:  aws.String(ServiceID),
-					RuleIdentifier:     aws.String(tt.oldRule.Spec.RuleID),
+			if !tt.noTargetGroupID {
+				for _, tg := range tt.newRule.Spec.Action.TargetGroups {
+					tgName := latticestore.TargetGroupName(tg.Name, tg.Namespace)
+					latticeDataStore.AddTargetGroup(tgName, "vpc", "arn", "tg-id", tg.IsServiceImport, "")
 				}
 
-				//				listenerID := tt.oldRule.Status.ListenerID
+			}
+
+			if !tt.noListenerID && !tt.noServiceID {
+				ruleInput := vpclattice.ListRulesInput{
+					ListenerIdentifier: aws.String(tt.newRule.Status.ListenerID),
+					ServiceIdentifier:  aws.String(tt.newRule.Status.ServiceID),
+				}
+
+				ruleOutput := vpclattice.ListRulesOutput{}
+
+				if tt.oldRule != nil {
+					items := []*vpclattice.RuleSummary{}
+
+					items = append(items, &vpclattice.RuleSummary{
+						Id: aws.String(tt.oldRule.Spec.RuleID),
+					})
+					ruleOutput = vpclattice.ListRulesOutput{
+						Items: items,
+					}
+				}
+				mockLattice.EXPECT().ListRules(&ruleInput).Return(&ruleOutput, nil)
+
+				if tt.oldRule != nil {
+					ruleGetInput := vpclattice.GetRuleInput{
+						ListenerIdentifier: aws.String(ListenerID),
+						ServiceIdentifier:  aws.String(ServiceID),
+						RuleIdentifier:     aws.String(tt.oldRule.Spec.RuleID),
+					}
+
+					//				listenerID := tt.oldRule.Status.ListenerID
+					latticeTGs := []*vpclattice.WeightedTargetGroup{}
+					//	ruleName := fmt.Sprintf("rule-%d-%s", tt.oldRule.Spec.CreateTime.Unix(), tt.oldRule.Spec.RuleID)
+					priority, _ := ruleID2Priority(tt.oldRule.Spec.RuleID)
+
+					for _, tg := range tt.oldRule.Spec.Action.TargetGroups {
+						latticeTG := vpclattice.WeightedTargetGroup{
+							TargetGroupIdentifier: aws.String("tg-id"),
+							Weight:                aws.Int64(tg.Weight),
+						}
+						latticeTGs = append(latticeTGs, &latticeTG)
+					}
+
+					httpMatch := vpclattice.HttpMatch{}
+					updateSDKhttpMatch(&httpMatch, tt.oldRule)
+					ruleGetOutput := vpclattice.GetRuleOutput{
+						Id:       aws.String(tt.oldRule.Spec.RuleID),
+						Priority: aws.Int64(priority),
+						Action: &vpclattice.RuleAction{
+							Forward: &vpclattice.ForwardAction{
+								TargetGroups: latticeTGs,
+							},
+						},
+						Match: &vpclattice.RuleMatch{
+							HttpMatch: &httpMatch,
+						},
+					}
+
+					mockLattice.EXPECT().GetRule(&ruleGetInput).Return(&ruleGetOutput, nil)
+
+				}
+			}
+
+			if tt.createRule || tt.updateRule {
+				listenerID := tt.newRule.Status.ListenerID
 				latticeTGs := []*vpclattice.WeightedTargetGroup{}
-				//	ruleName := fmt.Sprintf("rule-%d-%s", tt.oldRule.Spec.CreateTime.Unix(), tt.oldRule.Spec.RuleID)
-				priority, _ := ruleID2Priority(tt.oldRule.Spec.RuleID)
+				ruleName := fmt.Sprintf("k8s-%d-%s", tt.newRule.Spec.CreateTime.Unix(), tt.newRule.Spec.RuleID)
+				priority, _ := ruleID2Priority(tt.newRule.Spec.RuleID)
 
-				for _, tg := range tt.oldRule.Spec.Action.TargetGroups {
+				if tt.updatePriorityNeeded {
+					priority, _ = ruleID2Priority(tt.oldRule.Spec.RuleID)
+					priority++
+				}
+
+				for _, tg := range tt.newRule.Spec.Action.TargetGroups {
 					latticeTG := vpclattice.WeightedTargetGroup{
 						TargetGroupIdentifier: aws.String("tg-id"),
 						Weight:                aws.Int64(tg.Weight),
@@ -604,122 +643,83 @@ func Test_CreateRule(t *testing.T) {
 					latticeTGs = append(latticeTGs, &latticeTG)
 				}
 
-				httpMatch := vpclattice.HttpMatch{}
-				updateSDKhttpMatch(&httpMatch, tt.oldRule)
-				ruleGetOutput := vpclattice.GetRuleOutput{
-					Id:       aws.String(tt.oldRule.Spec.RuleID),
-					Priority: aws.Int64(priority),
-					Action: &vpclattice.RuleAction{
-						Forward: &vpclattice.ForwardAction{
-							TargetGroups: latticeTGs,
+				if tt.createRule {
+					httpMatch := vpclattice.HttpMatch{}
+					updateSDKhttpMatch(&httpMatch, tt.newRule)
+					ruleInput := vpclattice.CreateRuleInput{
+						Action: &vpclattice.RuleAction{
+							Forward: &vpclattice.ForwardAction{
+								TargetGroups: latticeTGs,
+							},
 						},
-					},
-					Match: &vpclattice.RuleMatch{
-						HttpMatch: &httpMatch,
-					},
-				}
 
-				mockLattice.EXPECT().GetRule(&ruleGetInput).Return(&ruleGetOutput, nil)
-
-			}
-		}
-
-		if tt.createRule || tt.updateRule {
-			listenerID := tt.newRule.Status.ListenerID
-			latticeTGs := []*vpclattice.WeightedTargetGroup{}
-			ruleName := fmt.Sprintf("k8s-%d-%s", tt.newRule.Spec.CreateTime.Unix(), tt.newRule.Spec.RuleID)
-			priority, _ := ruleID2Priority(tt.newRule.Spec.RuleID)
-
-			if tt.updatePriorityNeeded {
-				priority, _ = ruleID2Priority(tt.oldRule.Spec.RuleID)
-				priority++
-			}
-
-			for _, tg := range tt.newRule.Spec.Action.TargetGroups {
-				latticeTG := vpclattice.WeightedTargetGroup{
-					TargetGroupIdentifier: aws.String("tg-id"),
-					Weight:                aws.Int64(tg.Weight),
-				}
-				latticeTGs = append(latticeTGs, &latticeTG)
-			}
-
-			if tt.createRule {
-				httpMatch := vpclattice.HttpMatch{}
-				updateSDKhttpMatch(&httpMatch, tt.newRule)
-				ruleInput := vpclattice.CreateRuleInput{
-					Action: &vpclattice.RuleAction{
-						Forward: &vpclattice.ForwardAction{
-							TargetGroups: latticeTGs,
-						},
-					},
-
-					ListenerIdentifier: aws.String(listenerID),
-					Name:               aws.String(ruleName),
-					Priority:           aws.Int64(priority),
-					ServiceIdentifier:  aws.String(ServiceID),
-					Match: &vpclattice.RuleMatch{
-						HttpMatch: &httpMatch,
-					},
-				}
-				ruleOutput := vpclattice.CreateRuleOutput{
-					Id: aws.String(ruleID),
-				}
-				mockLattice.EXPECT().CreateRule(&ruleInput).Return(&ruleOutput, nil)
-			}
-
-			if tt.updateRule {
-				httpMatch := vpclattice.HttpMatch{}
-				updateSDKhttpMatch(&httpMatch, tt.newRule)
-				ruleInput := vpclattice.UpdateRuleInput{
-					Action: &vpclattice.RuleAction{
-						Forward: &vpclattice.ForwardAction{
-							TargetGroups: latticeTGs,
-						},
-					},
-
-					ListenerIdentifier: aws.String(listenerID),
-					//Name:               aws.String(ruleName),
-					RuleIdentifier:    aws.String(tt.newRule.Spec.RuleID),
-					Priority:          aws.Int64(priority),
-					ServiceIdentifier: aws.String(ServiceID),
-					Match: &vpclattice.RuleMatch{
-						HttpMatch: &httpMatch,
-					},
-					/*
+						ListenerIdentifier: aws.String(listenerID),
+						Name:               aws.String(ruleName),
+						Priority:           aws.Int64(priority),
+						ServiceIdentifier:  aws.String(ServiceID),
 						Match: &vpclattice.RuleMatch{
-							HttpMatch: &vpclattice.HttpMatch{
-								// TODO, what if not specfied this
-								//Method: aws.String(vpclattice.HttpMethodGet),
-								PathMatch: &vpclattice.PathMatch{
-									CaseSensitive: nil,
-									Match: &vpclattice.PathMatchType{
-										Exact:  nil,
-										Prefix: aws.String(tt.newRule.Spec.PathMatchValue),
+							HttpMatch: &httpMatch,
+						},
+					}
+					ruleOutput := vpclattice.CreateRuleOutput{
+						Id: aws.String(ruleID),
+					}
+					mockLattice.EXPECT().CreateRule(&ruleInput).Return(&ruleOutput, nil)
+				}
+
+				if tt.updateRule {
+					httpMatch := vpclattice.HttpMatch{}
+					updateSDKhttpMatch(&httpMatch, tt.newRule)
+					ruleInput := vpclattice.UpdateRuleInput{
+						Action: &vpclattice.RuleAction{
+							Forward: &vpclattice.ForwardAction{
+								TargetGroups: latticeTGs,
+							},
+						},
+
+						ListenerIdentifier: aws.String(listenerID),
+						//Name:               aws.String(ruleName),
+						RuleIdentifier:    aws.String(tt.newRule.Spec.RuleID),
+						Priority:          aws.Int64(priority),
+						ServiceIdentifier: aws.String(ServiceID),
+						Match: &vpclattice.RuleMatch{
+							HttpMatch: &httpMatch,
+						},
+						/*
+							Match: &vpclattice.RuleMatch{
+								HttpMatch: &vpclattice.HttpMatch{
+									// TODO, what if not specfied this
+									//Method: aws.String(vpclattice.HttpMethodGet),
+									PathMatch: &vpclattice.PathMatch{
+										CaseSensitive: nil,
+										Match: &vpclattice.PathMatchType{
+											Exact:  nil,
+											Prefix: aws.String(tt.newRule.Spec.PathMatchValue),
+										},
 									},
 								},
 							},
-						},
-					*/
+						*/
+					}
+					ruleOutput := vpclattice.UpdateRuleOutput{
+						Id: aws.String(ruleID),
+					}
+					mockLattice.EXPECT().UpdateRule(&ruleInput).Return(&ruleOutput, nil)
 				}
-				ruleOutput := vpclattice.UpdateRuleOutput{
-					Id: aws.String(ruleID),
-				}
-				mockLattice.EXPECT().UpdateRule(&ruleInput).Return(&ruleOutput, nil)
 			}
-		}
 
-		resp, err := ruleManager.Create(ctx, tt.newRule)
+			resp, err := ruleManager.Create(ctx, tt.newRule)
 
-		if !tt.noListenerID && !tt.noServiceID && !tt.noTargetGroupID {
-			assert.NoError(t, err)
+			if !tt.noListenerID && !tt.noServiceID && !tt.noTargetGroupID {
+				assert.NoError(t, err)
 
-			assert.Equal(t, resp.ListenerID, ListenerID)
-			assert.Equal(t, resp.ServiceID, ServiceID)
-			assert.Equal(t, resp.RuleID, ruleID)
-		}
+				assert.Equal(t, resp.ListenerID, ListenerID)
+				assert.Equal(t, resp.ServiceID, ServiceID)
+				assert.Equal(t, resp.RuleID, ruleID)
+			}
 
-		fmt.Printf(" rulemanager.Create :%v, err %d\n", resp, err)
-
+			fmt.Printf(" rulemanager.Create :%v, err %d\n", resp, err)
+		})
 	}
 }
 
@@ -748,73 +748,74 @@ func Test_UpdateRule(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		mockLattice := mocks.NewMockLattice(c)
-		mockCloud := mocks_aws.NewMockCloud(c)
-		mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+			mockLattice := mocks.NewMockLattice(c)
+			mockCloud := mocks_aws.NewMockCloud(c)
+			mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
-		latticeDataStore := latticestore.NewLatticeDataStore()
+			latticeDataStore := latticestore.NewLatticeDataStore()
 
-		ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+			ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
 
-		var i = 0
-		if !tt.noServiceID {
-			mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
-				&vpclattice.ServiceSummary{
-					Name: aws.String((&RuleLSNProvider{rules[i]}).LatticeServiceName()),
-					Arn:  aws.String("serviceARN"),
-					Id:   aws.String(rules[i].Status.ServiceID),
-					DnsEntry: &vpclattice.DnsEntry{
-						DomainName:   aws.String("test-dns"),
-						HostedZoneId: aws.String("my-favourite-zone"),
-					},
-				}, nil).Times(1)
-		} else {
-			mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(nil, &mocks.NotFoundError{}).Times(1)
-		}
-
-		if !tt.noListenerID {
-			latticeDataStore.AddListener(rules[i].Spec.ServiceName, rules[i].Spec.ServiceNamespace,
-				rules[i].Spec.ListenerPort, "HTTP",
-				"listenerARN", rules[i].Status.ListenerID)
-		}
-
-		var ruleUpdateList []*vpclattice.RuleUpdate
-
-		for _, rule := range rules {
-			priority, _ := ruleID2Priority(rule.Spec.RuleID)
-			ruleupdate := vpclattice.RuleUpdate{
-				RuleIdentifier: aws.String(rule.Status.RuleID),
-				Priority:       aws.Int64(priority),
+			var i = 0
+			if !tt.noServiceID {
+				mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
+					&vpclattice.ServiceSummary{
+						Name: aws.String((&RuleLSNProvider{rules[i]}).LatticeServiceName()),
+						Arn:  aws.String("serviceARN"),
+						Id:   aws.String(rules[i].Status.ServiceID),
+						DnsEntry: &vpclattice.DnsEntry{
+							DomainName:   aws.String("test-dns"),
+							HostedZoneId: aws.String("my-favourite-zone"),
+						},
+					}, nil).Times(1)
+			} else {
+				mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(nil, &mocks.NotFoundError{}).Times(1)
 			}
 
-			ruleUpdateList = append(ruleUpdateList, &ruleupdate)
+			if !tt.noListenerID {
+				latticeDataStore.AddListener(rules[i].Spec.ServiceName, rules[i].Spec.ServiceNamespace,
+					rules[i].Spec.ListenerPort, "HTTP",
+					"listenerARN", rules[i].Status.ListenerID)
+			}
 
-		}
+			var ruleUpdateList []*vpclattice.RuleUpdate
 
-		batchRuleInput := vpclattice.BatchUpdateRuleInput{
-			ListenerIdentifier: aws.String(rules[0].Status.ListenerID),
-			ServiceIdentifier:  aws.String(rules[0].Status.ServiceID),
-			Rules:              ruleUpdateList,
-		}
+			for _, rule := range rules {
+				priority, _ := ruleID2Priority(rule.Spec.RuleID)
+				ruleupdate := vpclattice.RuleUpdate{
+					RuleIdentifier: aws.String(rule.Status.RuleID),
+					Priority:       aws.Int64(priority),
+				}
 
-		if !tt.noListenerID && !tt.noServiceID {
-			var batchRuleOutput vpclattice.BatchUpdateRuleOutput
-			mockLattice.EXPECT().BatchUpdateRule(&batchRuleInput).Return(&batchRuleOutput, nil)
-		}
+				ruleUpdateList = append(ruleUpdateList, &ruleupdate)
 
-		err := ruleManager.Update(ctx, rules)
+			}
 
-		if !tt.noListenerID && !tt.noServiceID {
-			assert.NoError(t, err)
-		} else {
-			assert.NotNil(t, err)
-		}
+			batchRuleInput := vpclattice.BatchUpdateRuleInput{
+				ListenerIdentifier: aws.String(rules[0].Status.ListenerID),
+				ServiceIdentifier:  aws.String(rules[0].Status.ServiceID),
+				Rules:              ruleUpdateList,
+			}
+
+			if !tt.noListenerID && !tt.noServiceID {
+				var batchRuleOutput vpclattice.BatchUpdateRuleOutput
+				mockLattice.EXPECT().BatchUpdateRule(&batchRuleInput).Return(&batchRuleOutput, nil)
+			}
+
+			err := ruleManager.Update(ctx, rules)
+
+			if !tt.noListenerID && !tt.noServiceID {
+				assert.NoError(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+		})
 	}
-
 }
 
 func Test_List(t *testing.T) {
@@ -822,8 +823,7 @@ func Test_List(t *testing.T) {
 	defer c.Finish()
 	ctx := context.TODO()
 
-	mockVpcLatticeSess := mocks.NewMockLattice(c)
-
+	mockLattice := mocks.NewMockLattice(c)
 	mockCloud := mocks_aws.NewMockCloud(c)
 
 	serviceID := "service1-ID"
@@ -836,22 +836,22 @@ func Test_List(t *testing.T) {
 	ruleOutput := vpclattice.ListRulesOutput{
 		Items: []*vpclattice.RuleSummary{
 			{
-				Arn:       &rulelist[0].Arn,
-				Id:        &rulelist[0].Id,
-				IsDefault: &rulelist[0].IsDefault,
+				Arn:       &ruleList[0].Arn,
+				Id:        &ruleList[0].Id,
+				IsDefault: &ruleList[0].IsDefault,
 			},
 			{
-				Arn:       &rulelist[1].Arn,
-				Id:        &rulelist[1].Id,
-				IsDefault: &rulelist[1].IsDefault,
+				Arn:       &ruleList[1].Arn,
+				Id:        &ruleList[1].Id,
+				IsDefault: &ruleList[1].IsDefault,
 			},
 		},
 	}
 
 	latticeDataStore := latticestore.NewLatticeDataStore()
 
-	mockVpcLatticeSess.EXPECT().ListRules(&ruleInput).Return(&ruleOutput, nil)
-	mockCloud.EXPECT().Lattice().Return(mockVpcLatticeSess).AnyTimes()
+	mockLattice.EXPECT().ListRules(&ruleInput).Return(&ruleOutput, nil)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
 	ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
 
@@ -861,7 +861,7 @@ func Test_List(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		assert.Equal(t, resp[i].ListenerID, listenerID)
-		assert.Equal(t, resp[i].RuleID, rulelist[i].Id)
+		assert.Equal(t, resp[i].RuleID, ruleList[i].Id)
 		assert.Equal(t, resp[i].ServiceID, serviceID)
 	}
 	fmt.Printf("rule Manager List resp %v\n", resp)
@@ -873,8 +873,7 @@ func Test_GetRule(t *testing.T) {
 	defer c.Finish()
 	ctx := context.TODO()
 
-	mockVpcLatticeSess := mocks.NewMockLattice(c)
-
+	mockLattice := mocks.NewMockLattice(c)
 	mockCloud := mocks_aws.NewMockCloud(c)
 
 	serviceID := "service1-ID"
@@ -897,8 +896,8 @@ func Test_GetRule(t *testing.T) {
 		Priority: aws.Int64(int64(rulePriority)),
 	}
 
-	mockVpcLatticeSess.EXPECT().GetRule(&ruleGetInput).Return(&ruleGetOutput, nil)
-	mockCloud.EXPECT().Lattice().Return(mockVpcLatticeSess).AnyTimes()
+	mockLattice.EXPECT().GetRule(&ruleGetInput).Return(&ruleGetOutput, nil)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
 	ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
 
@@ -916,8 +915,7 @@ func Test_DeleteRule(t *testing.T) {
 	defer c.Finish()
 	ctx := context.TODO()
 
-	mockVpcLatticeSess := mocks.NewMockLattice(c)
-
+	mockLattice := mocks.NewMockLattice(c)
 	mockCloud := mocks_aws.NewMockCloud(c)
 
 	serviceID := "service1-ID"
@@ -933,8 +931,8 @@ func Test_DeleteRule(t *testing.T) {
 	latticeDataStore := latticestore.NewLatticeDataStore()
 
 	ruleDeleteOuput := vpclattice.DeleteRuleOutput{}
-	mockVpcLatticeSess.EXPECT().DeleteRule(&ruleDeleteInput).Return(&ruleDeleteOuput, nil)
-	mockCloud.EXPECT().Lattice().Return(mockVpcLatticeSess).AnyTimes()
+	mockLattice.EXPECT().DeleteRule(&ruleDeleteInput).Return(&ruleDeleteOuput, nil)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
 	ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
 
@@ -952,14 +950,14 @@ func Test_isRulesSame(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		k8sRule     *latticemodel.Rule
+		k8sRule     *model.Rule
 		sdkRule     *vpclattice.GetRuleOutput
 		ruleMatched bool
 	}{
 		{
 			name: "PathMatchEaxt Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchExact: true,
 					PathMatchValue: path1,
 				},
@@ -979,8 +977,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "PathMatchPrefix Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchPrefix: true,
 					PathMatchValue:  path1,
 				},
@@ -1000,8 +998,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "2 headers + PathPrefix Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchPrefix:    true,
 					PathMatchValue:     path1,
 					NumOfHeaderMatches: 2,
@@ -1052,8 +1050,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "2 headers + path exact Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchExact:     true,
 					PathMatchValue:     path1,
 					NumOfHeaderMatches: 2,
@@ -1104,8 +1102,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "2 headers + header mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					NumOfHeaderMatches: 2,
 					MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1140,8 +1138,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "2 headers + value mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					NumOfHeaderMatches: 2,
 					MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1176,8 +1174,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "PathMatchEaxt MisMatch",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchExact: true,
 					PathMatchValue: path1,
 				},
@@ -1197,8 +1195,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "PathMatchEaxt PathPrefix MisMatch",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchPrefix: true,
 					PathMatchValue:  path1,
 				},
@@ -1218,8 +1216,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "2 headers + path exact Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchExact:     true,
 					PathMatchValue:     path1,
 					NumOfHeaderMatches: 2,
@@ -1270,8 +1268,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "number of header mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					NumOfHeaderMatches: 1,
 					MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1310,8 +1308,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "2nd header value mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					NumOfHeaderMatches: 2,
 					MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1359,8 +1357,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "header match, but one has pathexat -- mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					NumOfHeaderMatches: 2,
 					MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1408,8 +1406,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "header match, but one has pathprefix -- mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					NumOfHeaderMatches: 2,
 					MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1457,8 +1455,8 @@ func Test_isRulesSame(t *testing.T) {
 		},
 		{
 			name: "header match, but one has pathprefix -- mis Match",
-			k8sRule: &latticemodel.Rule{
-				Spec: latticemodel.RuleSpec{
+			k8sRule: &model.Rule{
+				Spec: model.RuleSpec{
 					PathMatchPrefix:    true,
 					PathMatchValue:     path1,
 					NumOfHeaderMatches: 2,
@@ -1504,16 +1502,14 @@ func Test_isRulesSame(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Printf("Testing >>>>> %v \n", tt.name)
+		t.Run(tt.name, func(t *testing.T) {
+			sameRule := isRulesSame(gwlog.FallbackLogger, tt.k8sRule, tt.sdkRule)
 
-		sameRule := isRulesSame(gwlog.FallbackLogger, tt.k8sRule, tt.sdkRule)
-
-		if tt.ruleMatched {
-			assert.True(t, sameRule)
-		} else {
-			assert.False(t, sameRule)
-		}
-
+			if tt.ruleMatched {
+				assert.True(t, sameRule)
+			} else {
+				assert.False(t, sameRule)
+			}
+		})
 	}
-
 }

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -58,7 +58,7 @@ type defaultServiceNetworkManager struct {
 //
 // return errors.New(LATTICE_RETRY) when:
 //
-//	CreateServiceNetworkVpcAssociationInput returns ServiceNetworkVpcAssociationStatusFailed/ServiceNetworkVpcAssociationStatusCreateInProgress/MeshVpcAssociationStatusDeleteInProgress
+//	CreateServiceNetworkVpcAssociationInput returns ServiceNetworkVpcAssociationStatusFailed/ServiceNetworkVpcAssociationStatusCreateInProgress/ServiceNetworkVpcAssociationStatusDeleteInProgress
 
 func (m *defaultServiceNetworkManager) CreateOrUpdate(ctx context.Context, serviceNetwork *model.ServiceNetwork) (model.ServiceNetworkStatus, error) {
 	// check if exists
@@ -266,13 +266,13 @@ func (m *defaultServiceNetworkManager) isServiceNetworkAlreadyAssociatedWithVPC(
 			if err == nil {
 				switch associationStatus {
 				case vpclattice.ServiceNetworkVpcAssociationStatusActive:
-					m.log.Debugf("Mesh and Vpc association is active.")
+					m.log.Debugf("ServiceNetwork and Vpc association is active.")
 					return true, r, resp, nil
 				case vpclattice.ServiceNetworkVpcAssociationStatusCreateFailed:
-					m.log.Debugf("Mesh and Vpc association does not exists, start creating service_network and vpc association")
+					m.log.Debugf("ServiceNetwork and Vpc association does not exists, start creating service_network and vpc association")
 					return false, r, resp, nil
 				case vpclattice.ServiceNetworkVpcAssociationStatusDeleteFailed:
-					m.log.Debugf("Mesh and Vpc association failed to delete")
+					m.log.Debugf("ServiceNetwork and Vpc association failed to delete")
 					return true, r, resp, nil
 				case vpclattice.ServiceNetworkVpcAssociationStatusDeleteInProgress:
 					m.log.Debugf("ServiceNetwork and Vpc association is being deleted, retry later")

--- a/pkg/deploy/lattice/service_network_synthesizer_test.go
+++ b/pkg/deploy/lattice/service_network_synthesizer_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
 	"github.com/aws/aws-application-networking-k8s/pkg/gateway"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 )
 
@@ -21,68 +21,68 @@ func Test_SynthesizeTriggeredGateways(t *testing.T) {
 	now := metav1.Now()
 	tests := []struct {
 		name               string
-		gw                 *gateway_api.Gateway
+		gw                 *gwv1beta1.Gateway
 		gwUsedByOtherNS    bool
-		meshManagerErr     error
+		snMgrErr           error
 		wantSynthesizerErr error
 	}{
 		{
-			name: "Adding a new Mesh successfully",
-			gw: &gateway_api.Gateway{
+			name: "Adding a new SN successfully",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "mesh1",
+					Name: "sn-1",
 				},
 			},
-			meshManagerErr:     nil,
+			snMgrErr:           nil,
 			wantSynthesizerErr: nil,
 		},
 		{
-			name: "Adding a new Mesh associating in progress",
-			gw: &gateway_api.Gateway{
+			name: "Adding a new SN associating in progress",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "mesh2",
+					Name: "sn-2",
 				},
 			},
-			meshManagerErr:     errors.New(LATTICE_RETRY),
+			snMgrErr:           errors.New(LATTICE_RETRY),
 			wantSynthesizerErr: errors.New(LATTICE_RETRY),
 		},
 
 		{
-			name: "Deleting Mesh Successfully",
-			gw: &gateway_api.Gateway{
+			name: "Deleting SN Successfully",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "mesh3",
+					Name:              "sn-3",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
 			},
-			meshManagerErr:     nil,
+			snMgrErr:           nil,
 			gwUsedByOtherNS:    false,
 			wantSynthesizerErr: nil,
 		},
 		{
-			name: "Deleting Mesh Skipped due to other NS still uses it",
-			gw: &gateway_api.Gateway{
+			name: "Deleting SN Skipped due to other NS still uses it",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "mesh3",
+					Name:              "sn-3",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
 			},
-			meshManagerErr:     nil,
+			snMgrErr:           nil,
 			gwUsedByOtherNS:    true,
 			wantSynthesizerErr: nil,
 		},
 		{
-			name: "Deleting Mesh Successfully in progress",
-			gw: &gateway_api.Gateway{
+			name: "Deleting SN Successfully in progress",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "mesh4",
+					Name:              "sn-4",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
 			},
-			meshManagerErr:     errors.New(LATTICE_RETRY),
+			snMgrErr:           errors.New(LATTICE_RETRY),
 			wantSynthesizerErr: errors.New(LATTICE_RETRY),
 		},
 	}
@@ -93,107 +93,106 @@ func Test_SynthesizeTriggeredGateways(t *testing.T) {
 	k8sClient.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		fmt.Printf("Testing >>>>> %v\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+			builder := gateway.NewServiceNetworkModelBuilder(k8sClient)
+			stack, sn, _ := builder.Build(context.Background(), tt.gw)
 
-		builder := gateway.NewServiceNetworkModelBuilder(k8sClient)
+			var status model.ServiceNetworkStatus
+			mockSvcNetworkMgr := NewMockServiceNetworkManager(c)
 
-		stack, mesh, _ := builder.Build(context.Background(), tt.gw)
+			// testing deleting staled sn (gateway)
+			mockClient := mock_client.NewMockClient(c)
 
-		var meshStatus latticemodel.ServiceNetworkStatus
-		mockMeshManager := NewMockServiceNetworkManager(c)
+			// testing add or delete of triggered gateway(sn)
+			if !tt.gw.DeletionTimestamp.IsZero() {
+				// testing delete
 
-		// testing deleting staled mesh (gateway)
-		mock_client := mock_client.NewMockClient(c)
+				gwList := &gwv1beta1.GatewayList{}
 
-		// testing add or delete of triggered gateway(mesh)
-		if !tt.gw.DeletionTimestamp.IsZero() {
-			// testing delete
-
-			gwList := &gateway_api.GatewayList{}
-
-			gwList.Items = append(gwList.Items,
-				gateway_api.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: tt.gw.GetObjectMeta().GetName(),
-					},
-				})
-			if tt.gwUsedByOtherNS {
 				gwList.Items = append(gwList.Items,
-					gateway_api.Gateway{
+					gwv1beta1.Gateway{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      tt.gw.GetObjectMeta().GetName(),
-							Namespace: "non-default",
+							Name: tt.gw.GetObjectMeta().GetName(),
 						},
+					})
+				if tt.gwUsedByOtherNS {
+					gwList.Items = append(gwList.Items,
+						gwv1beta1.Gateway{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      tt.gw.GetObjectMeta().GetName(),
+								Namespace: "non-default",
+							},
+						},
+					)
+				}
+
+				mockClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, retGWList *gwv1beta1.GatewayList, arg3 ...interface{}) error {
+						// return empty gatway
+						for _, gw := range gwList.Items {
+							retGWList.Items = append(retGWList.Items, gw)
+						}
+						return nil
+
 					},
 				)
+
+				if !tt.gwUsedByOtherNS {
+					mockSvcNetworkMgr.EXPECT().Delete(ctx, tt.gw.Name).Return(tt.snMgrErr)
+				}
+			} else {
+				status = model.ServiceNetworkStatus{ServiceNetworkARN: "testing arn", ServiceNetworkID: "87654321"}
+				mockSvcNetworkMgr.EXPECT().CreateOrUpdate(ctx, sn).Return(status, tt.snMgrErr)
 			}
 
-			mock_client.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, retGWList *gateway_api.GatewayList, arg3 ...interface{}) error {
-					// return empty gatway
-					for _, gw := range gwList.Items {
-						retGWList.Items = append(retGWList.Items, gw)
-					}
-					return nil
-
-				},
-			)
-
-			if !tt.gwUsedByOtherNS {
-				mockMeshManager.EXPECT().Delete(ctx, tt.gw.Name).Return(tt.meshManagerErr)
-			}
-		} else {
-			meshStatus = latticemodel.ServiceNetworkStatus{ServiceNetworkARN: "testing arn", ServiceNetworkID: "87654321"}
-			mockMeshManager.EXPECT().CreateOrUpdate(ctx, mesh).Return(meshStatus, tt.meshManagerErr)
-		}
-
-		meshMeshSynthesizer := NewServiceNetworkSynthesizer(gwlog.FallbackLogger, mock_client, mockMeshManager, stack)
-		err := meshMeshSynthesizer.synthesizeTriggeredGateways(ctx)
-		assert.Equal(t, tt.wantSynthesizerErr, err)
+			snSynthesizer := NewServiceNetworkSynthesizer(gwlog.FallbackLogger, mockClient, mockSvcNetworkMgr, stack)
+			err := snSynthesizer.synthesizeTriggeredGateways(ctx)
+			assert.Equal(t, tt.wantSynthesizerErr, err)
+		})
 	}
 }
 
-type sdkMeshDef struct {
-	name           string
-	isStale        bool
-	meshManagerErr error
+type sdkSvcNetworkDef struct {
+	name         string
+	isStale      bool
+	snManagerErr error
 }
 
-func Test_SythesizeSDKMeshs(t *testing.T) {
+func Test_SynthesizeSDKSvcNetworks(t *testing.T) {
 	tests := []struct {
 		name                string
-		sdkMeshes           []sdkMeshDef
+		sdkSvcNetworks      []sdkSvcNetworkDef
 		wantSynthesizerErr  error
 		wantDataStoreErr    error
 		wantDataStoreStatus string
 	}{
 		{
-			name:                "Deleting SDK Mesh Successfully",
-			sdkMeshes:           []sdkMeshDef{{name: "sdkMesh1", isStale: true, meshManagerErr: nil}},
+			name:                "Deleting SDK SN Successfully",
+			sdkSvcNetworks:      []sdkSvcNetworkDef{{name: "sdkSvcNetwork1", isStale: true, snManagerErr: nil}},
 			wantSynthesizerErr:  nil,
 			wantDataStoreErr:    nil,
 			wantDataStoreStatus: "",
 		},
 		{
-			name: "Deleting one stale SDKMesh Successfully and keep rest",
-			sdkMeshes: []sdkMeshDef{
-				{name: "sdkMesh21", isStale: false, meshManagerErr: nil},
-				{name: "sdkMesh22", isStale: true, meshManagerErr: nil},
-				{name: "sdkMesh23", isStale: false, meshManagerErr: nil}},
+			name: "Deleting one stale SDK SN Successfully and keep rest",
+			sdkSvcNetworks: []sdkSvcNetworkDef{
+				{name: "sdkSvcNetwork21", isStale: false, snManagerErr: nil},
+				{name: "sdkSvcNetwork22", isStale: true, snManagerErr: nil},
+				{name: "sdkSvcNetwork23", isStale: false, snManagerErr: nil}},
 			wantSynthesizerErr:  nil,
 			wantDataStoreErr:    nil,
 			wantDataStoreStatus: "",
 		},
 		{
-			name: "Deleting one stale SDKMesh work-in-progress and keep rest",
-			sdkMeshes: []sdkMeshDef{
-				{name: "sdkMesh21", isStale: false, meshManagerErr: nil},
-				{name: "sdkMesh22", isStale: true, meshManagerErr: errors.New("delete-in-progress")},
-				{name: "sdkMesh23", isStale: false, meshManagerErr: nil}},
+			name: "Deleting one stale SDK SN work-in-progress and keep rest",
+			sdkSvcNetworks: []sdkSvcNetworkDef{
+				{name: "sdkSvcNetwork21", isStale: false, snManagerErr: nil},
+				{name: "sdkSvcNetwork22", isStale: true, snManagerErr: errors.New("delete-in-progress")},
+				{name: "sdkSvcNetwork23", isStale: false, snManagerErr: nil}},
 			wantSynthesizerErr:  errors.New(LATTICE_RETRY),
 			wantDataStoreErr:    nil,
 			wantDataStoreStatus: "",
@@ -201,61 +200,61 @@ func Test_SythesizeSDKMeshs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Printf("Testing >>>>> %v\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		mockMeshManager := NewMockServiceNetworkManager(c)
+			mockSnMgr := NewMockServiceNetworkManager(c)
 
-		// testing deleting staled mesh (gateway)
-		mock_client := mock_client.NewMockClient(c)
-		sdkMeshsReturned := []string{}
+			mockClient := mock_client.NewMockClient(c)
+			sdkItemsReturned := []string{}
 
-		if len(tt.sdkMeshes) > 0 {
-			fmt.Printf("Testing deleting non-existing SDK mesh")
+			if len(tt.sdkSvcNetworks) > 0 {
+				fmt.Printf("Testing deleting non-existing SDK SN")
 
-			gwList := &gateway_api.GatewayList{}
+				gwList := &gwv1beta1.GatewayList{}
 
-			for _, sdkMesh := range tt.sdkMeshes {
-				fmt.Printf("sdkMesh %v\n", sdkMesh)
-				sdkMeshsReturned = append(sdkMeshsReturned, sdkMesh.name)
-				fmt.Printf("sdkMeshsReturned --loop %v\n", sdkMeshsReturned)
+				for _, sdkSvcNetwork := range tt.sdkSvcNetworks {
+					fmt.Printf("sdkSvcNetwork %v\n", sdkSvcNetwork)
+					sdkItemsReturned = append(sdkItemsReturned, sdkSvcNetwork.name)
+					fmt.Printf("sdkSvcNetworksReturned --loop %v\n", sdkItemsReturned)
 
-				if !sdkMesh.isStale {
-					gwList.Items = append(gwList.Items,
-						gateway_api.Gateway{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: sdkMesh.name,
-							},
-						})
-
-				}
-			}
-
-			mock_client.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, retGWList *gateway_api.GatewayList, arg3 ...interface{}) error {
-					for _, gw := range gwList.Items {
-						retGWList.Items = append(retGWList.Items, gw)
+					if !sdkSvcNetwork.isStale {
+						gwList.Items = append(gwList.Items,
+							gwv1beta1.Gateway{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: sdkSvcNetwork.name,
+								},
+							})
 
 					}
-					return nil
+				}
 
-				},
-			)
+				mockClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, retGWList *gwv1beta1.GatewayList, arg3 ...interface{}) error {
+						for _, gw := range gwList.Items {
+							retGWList.Items = append(retGWList.Items, gw)
 
-			for _, sdkMesh := range tt.sdkMeshes {
-				if sdkMesh.isStale {
-					// first add this datastore and see if it can be deleted byy business logic
-					mockMeshManager.EXPECT().Delete(ctx, sdkMesh.name).Return(sdkMesh.meshManagerErr)
+						}
+						return nil
 
+					},
+				)
+
+				for _, sdkSvcNetwork := range tt.sdkSvcNetworks {
+					if sdkSvcNetwork.isStale {
+						// first add this datastore and see if it can be deleted byy business logic
+						mockSnMgr.EXPECT().Delete(ctx, sdkSvcNetwork.name).Return(sdkSvcNetwork.snManagerErr)
+
+					}
 				}
 			}
-		}
 
-		mockMeshManager.EXPECT().List(ctx).Return(sdkMeshsReturned, nil)
-		meshMeshSynthesizer := NewServiceNetworkSynthesizer(gwlog.FallbackLogger, mock_client, mockMeshManager, nil)
-		err := meshMeshSynthesizer.synthesizeSDKServiceNetworks(ctx)
-		assert.Equal(t, tt.wantSynthesizerErr, err)
+			mockSnMgr.EXPECT().List(ctx).Return(sdkItemsReturned, nil)
+			snSynthesizer := NewServiceNetworkSynthesizer(gwlog.FallbackLogger, mockClient, mockSnMgr, nil)
+			err := snSynthesizer.synthesizeSDKServiceNetworks(ctx)
+			assert.Equal(t, tt.wantSynthesizerErr, err)
+		})
 	}
 }

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -59,11 +59,12 @@ func getLatticeTGName(targetGroup *model.TargetGroup) string {
 //
 // return errors.New(LATTICE_RETRY) when:
 //
-//	CreateTargetGroupWithContext returns
-//		TG is TargetGroupStatusUpdateInProgress
-//		TG is MeshVpcAssociationStatusFailed
-//		TG is TargetGroupStatusCreateInProgress
-//		TG is TargetGroupStatusFailed
+//		CreateTargetGroupWithContext returns
+//			TG is TargetGroupStatusUpdateInProgress
+//			TG is TargetGroupStatusCreateFailed
+//			TG is TargetGroupStatusCreateInProgress
+//			TG is TargetGroupStatusDeleteFailed
+//	        TG is TargetGroupStatusDeleteInProgress
 //
 // return nil when:
 //

--- a/pkg/deploy/stack_deployer_test.go
+++ b/pkg/deploy/stack_deployer_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/aws-application-networking-k8s/pkg/deploy/externaldns"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
 func Test_latticeServiceStackDeployer_createAllResources(t *testing.T) {
@@ -43,11 +43,11 @@ func Test_latticeServiceStackDeployer_createAllResources(t *testing.T) {
 
 	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
 
-	stackService := latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{})
-	latticemodel.NewTargetGroup(s, "fake-targetGroup", latticemodel.TargetGroupSpec{})
-	latticemodel.NewTargets(s, "fake-target", latticemodel.TargetsSpec{})
-	latticemodel.NewListener(s, "fake-listener", 8080, "HTTP", "service1", "default", latticemodel.DefaultAction{})
-	latticemodel.NewRule(s, "fake-rule", "fake-rule", "default", 80, "HTTP", latticemodel.RuleAction{}, latticemodel.RuleSpec{})
+	stackService := model.NewLatticeService(s, "fake-service", model.ServiceSpec{})
+	model.NewTargetGroup(s, "fake-targetGroup", model.TargetGroupSpec{})
+	model.NewTargets(s, "fake-target", model.TargetsSpec{})
+	model.NewListener(s, "fake-listener", 8080, "HTTP", "service1", "default", model.DefaultAction{})
+	model.NewRule(s, "fake-rule", "fake-rule", "default", 80, "HTTP", model.RuleAction{}, model.RuleSpec{})
 
 	mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
 		&vpclattice.ServiceSummary{
@@ -112,7 +112,7 @@ func Test_latticeServiceStackDeployer_CreateJustService(t *testing.T) {
 
 	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
 
-	stackService := latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{})
+	stackService := model.NewLatticeService(s, "fake-service", model.ServiceSpec{})
 
 	mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
 		&vpclattice.ServiceSummary{
@@ -160,7 +160,7 @@ func Test_latticeServiceStackDeployer_DeleteService(t *testing.T) {
 
 	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
 
-	stackService := latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{
+	stackService := model.NewLatticeService(s, "fake-service", model.ServiceSpec{
 		IsDeleted: true,
 	})
 
@@ -214,10 +214,10 @@ func Test_latticeServiceStackDeployer_DeleteAllResources(t *testing.T) {
 
 	s := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "tt", Name: "name"}))
 
-	stackService := latticemodel.NewLatticeService(s, "fake-service", latticemodel.ServiceSpec{
+	stackService := model.NewLatticeService(s, "fake-service", model.ServiceSpec{
 		IsDeleted: true,
 	})
-	latticemodel.NewTargetGroup(s, "fake-targetGroup", latticemodel.TargetGroupSpec{
+	model.NewTargetGroup(s, "fake-targetGroup", model.TargetGroupSpec{
 		IsDeleted: true,
 	})
 

--- a/pkg/gateway/model_build_lattice_service_test.go
+++ b/pkg/gateway/model_build_lattice_service_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -20,29 +20,29 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
-	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func Test_LatticeServiceModelBuild(t *testing.T) {
 	now := metav1.Now()
-	var httpSectionName gateway_api.SectionName = "http"
-	var serviceKind gateway_api.Kind = "Service"
-	var serviceimportKind gateway_api.Kind = "ServiceImport"
+	var httpSectionName gwv1beta1.SectionName = "http"
+	var serviceKind gwv1beta1.Kind = "Service"
+	var serviceimportKind gwv1beta1.Kind = "ServiceImport"
 	var weight1 = int32(10)
 	var weight2 = int32(90)
-	var namespace = gateway_api.Namespace("default")
+	var namespace = gwv1beta1.Namespace("default")
 
-	var backendRef1 = gateway_api.BackendRef{
-		BackendObjectReference: gateway_api.BackendObjectReference{
+	var backendRef1 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name:      "targetgroup1",
 			Namespace: &namespace,
 			Kind:      &serviceKind,
 		},
 		Weight: &weight1,
 	}
-	var backendRef2 = gateway_api.BackendRef{
-		BackendObjectReference: gateway_api.BackendObjectReference{
+	var backendRef2 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name:      "targetgroup2",
 			Namespace: &namespace,
 			Kind:      &serviceimportKind,
@@ -61,19 +61,19 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService with hostname",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Hostnames: []gateway_api.Hostname{
+					Hostnames: []gwv1beta1.Hostname{
 						"test1.test.com",
 						"test2.test.com",
 					},
@@ -88,13 +88,13 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
@@ -111,13 +111,13 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService with GRPCRoute",
-			route: core.NewGRPCRoute(gateway_api_v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
-				Spec: gateway_api_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
@@ -133,24 +133,24 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "gateway2",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -191,7 +191,7 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 				route:     tt.route,
 				stack:     stack,
 				client:    k8sClient,
-				tgByResID: make(map[string]*latticemodel.TargetGroup),
+				tgByResID: make(map[string]*model.TargetGroup),
 				datastore: ds,
 			}
 
@@ -202,11 +202,11 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 			if tt.wantIsDeleted {
 				assert.Equal(t, true, task.latticeService.Spec.IsDeleted)
 				// make sure no rules and listener are built
-				var resRules []*latticemodel.Rule
+				var resRules []*model.Rule
 				stack.ListResources(&resRules)
 				assert.Equal(t, len(resRules), 0)
 
-				var resListener []*latticemodel.Listener
+				var resListener []*model.Listener
 				stack.ListResources(&resListener)
 				assert.Equal(t, len(resListener), 0)
 
@@ -228,7 +228,6 @@ func Test_LatticeServiceModelBuild(t *testing.T) {
 			} else {
 				assert.NotNil(t, err)
 			}
-
 		})
 	}
 }

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -76,7 +76,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
@@ -110,7 +110,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
@@ -144,7 +144,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
@@ -178,7 +178,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
@@ -210,7 +210,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
@@ -268,7 +268,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
@@ -300,7 +300,7 @@ func Test_ListenerModelBuild(t *testing.T) {
 					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
 						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &missingSectionName,
 							},
 						},

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -21,28 +21,28 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
 // PortNumberPtr translates an int to a *PortNumber
-func PortNumberPtr(p int) *gateway_api.PortNumber {
-	result := gateway_api.PortNumber(p)
+func PortNumberPtr(p int) *gwv1beta1.PortNumber {
+	result := gwv1beta1.PortNumber(p)
 	return &result
 }
 
 func Test_ListenerModelBuild(t *testing.T) {
-	var httpSectionName gateway_api.SectionName = "http"
-	var missingSectionName gateway_api.SectionName = "miss"
-	var serviceKind gateway_api.Kind = "Service"
-	var serviceimportKind gateway_api.Kind = "ServiceImport"
-	var backendRef = gateway_api.BackendRef{
-		BackendObjectReference: gateway_api.BackendObjectReference{
+	var httpSectionName gwv1beta1.SectionName = "http"
+	var missingSectionName gwv1beta1.SectionName = "miss"
+	var serviceKind gwv1beta1.Kind = "Service"
+	var serviceimportKind gwv1beta1.Kind = "ServiceImport"
+	var backendRef = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name: "targetgroup1",
 			Kind: &serviceKind,
 		},
 	}
-	var backendServiceImportRef = gateway_api.BackendRef{
-		BackendObjectReference: gateway_api.BackendObjectReference{
+	var backendServiceImportRef = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name: "targetgroup1",
 			Kind: &serviceimportKind,
 		},
@@ -50,8 +50,8 @@ func Test_ListenerModelBuild(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		gwListenerPort     gateway_api.PortNumber
-		gwListenerProtocol gateway_api.ProtocolType
+		gwListenerPort     gwv1beta1.PortNumber
+		gwListenerProtocol gwv1beta1.ProtocolType
 		route              core.Route
 		wantErrIsNil       bool
 		k8sGetGatewayCall  bool
@@ -67,23 +67,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -101,23 +101,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       true,
 			certARN:            "test-cert-ARN",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -135,23 +135,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       false,
 			certARN:            "test-cert-ARN",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -169,23 +169,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			k8sGatewayReturnOK: true,
 			tlsTerminate:       false,
 			certARN:            "test-cert-ARN",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -201,23 +201,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendServiceImportRef,
 								},
@@ -232,18 +232,18 @@ func Test_ListenerModelBuild(t *testing.T) {
 			gwListenerPort:    *PortNumberPtr(80),
 			wantErrIsNil:      false,
 			k8sGetGatewayCall: false,
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{},
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -259,23 +259,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: false,
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -291,23 +291,23 @@ func Test_ListenerModelBuild(t *testing.T) {
 			wantErrIsNil:       false,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name:        "mesh1",
 								SectionName: &missingSectionName,
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef,
 								},
@@ -320,115 +320,115 @@ func Test_ListenerModelBuild(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Printf("testing >>>>> %s =============\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		k8sClient := mock_client.NewMockClient(c)
+			mockK8sClient := mock_client.NewMockClient(c)
 
-		if tt.k8sGetGatewayCall {
+			if tt.k8sGetGatewayCall {
 
-			k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, gwName types.NamespacedName, gw *gateway_api.Gateway, arg3 ...interface{}) error {
+				mockK8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, gwName types.NamespacedName, gw *gwv1beta1.Gateway, arg3 ...interface{}) error {
 
-					if tt.k8sGatewayReturnOK {
-						listener := gateway_api.Listener{
-							Port:     tt.gwListenerPort,
-							Protocol: "HTTP",
-							Name:     *tt.route.Spec().ParentRefs()[0].SectionName,
-						}
+						if tt.k8sGatewayReturnOK {
+							listener := gwv1beta1.Listener{
+								Port:     tt.gwListenerPort,
+								Protocol: "HTTP",
+								Name:     *tt.route.Spec().ParentRefs()[0].SectionName,
+							}
 
-						if tt.tlsTerminate {
-							mode := gateway_api.TLSModeTerminate
-							var tlsConfig gateway_api.GatewayTLSConfig
+							if tt.tlsTerminate {
+								mode := gwv1beta1.TLSModeTerminate
+								var tlsConfig gwv1beta1.GatewayTLSConfig
 
-							if tt.noTLSOption {
-								tlsConfig = gateway_api.GatewayTLSConfig{
-									Mode: &mode,
-								}
-
-							} else {
-
-								tlsConfig = gateway_api.GatewayTLSConfig{
-									Mode:    &mode,
-									Options: make(map[gateway_api.AnnotationKey]gateway_api.AnnotationValue),
-								}
-
-								if tt.wrongTLSOption {
-									tlsConfig.Options["wrong-annotation"] = gateway_api.AnnotationValue(tt.certARN)
+								if tt.noTLSOption {
+									tlsConfig = gwv1beta1.GatewayTLSConfig{
+										Mode: &mode,
+									}
 
 								} else {
-									tlsConfig.Options[awsCustomCertARN] = gateway_api.AnnotationValue(tt.certARN)
+
+									tlsConfig = gwv1beta1.GatewayTLSConfig{
+										Mode:    &mode,
+										Options: make(map[gwv1beta1.AnnotationKey]gwv1beta1.AnnotationValue),
+									}
+
+									if tt.wrongTLSOption {
+										tlsConfig.Options["wrong-annotation"] = gwv1beta1.AnnotationValue(tt.certARN)
+
+									} else {
+										tlsConfig.Options[awsCustomCertARN] = gwv1beta1.AnnotationValue(tt.certARN)
+									}
 								}
+								listener.TLS = &tlsConfig
+
 							}
-							listener.TLS = &tlsConfig
-
+							gw.Spec.Listeners = append(gw.Spec.Listeners, listener)
+							return nil
+						} else {
+							return errors.New("unknown k8s object")
 						}
-						gw.Spec.Listeners = append(gw.Spec.Listeners, listener)
-						return nil
-					} else {
-						return errors.New("unknown k8s object")
-					}
-				},
-			)
-		}
+					},
+				)
+			}
 
-		ds := latticestore.NewLatticeDataStore()
+			ds := latticestore.NewLatticeDataStore()
 
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
-		task := &latticeServiceModelBuildTask{
-			log:             gwlog.FallbackLogger,
-			route:           tt.route,
-			stack:           stack,
-			client:          k8sClient,
-			listenerByResID: make(map[string]*latticemodel.Listener),
-			datastore:       ds,
-		}
+			task := &latticeServiceModelBuildTask{
+				log:             gwlog.FallbackLogger,
+				route:           tt.route,
+				stack:           stack,
+				client:          mockK8sClient,
+				listenerByResID: make(map[string]*model.Listener),
+				datastore:       ds,
+			}
 
-		service := latticemodel.Service{}
-		task.latticeService = &service
+			service := model.Service{}
+			task.latticeService = &service
 
-		err := task.buildListeners(ctx)
+			err := task.buildListeners(ctx)
 
-		fmt.Printf("task.buildListeners err: %v \n", err)
+			fmt.Printf("task.buildListeners err: %v \n", err)
 
-		if !tt.wantErrIsNil {
-			// TODO why following is failing????
-			//assert.Equal(t, err!=nil, true)
-			//assert.Error(t, err)
-			fmt.Printf("task.buildListeners tt : %v err: %v %v\n", tt.name, err, err != nil)
-			continue
-		} else {
-			assert.NoError(t, err)
-		}
+			if !tt.wantErrIsNil {
+				// TODO why following is failing????
+				//assert.Equal(t, err!=nil, true)
+				//assert.Error(t, err)
+				fmt.Printf("task.buildListeners tt : %v err: %v %v\n", tt.name, err, err != nil)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
 
-		fmt.Printf("listeners %v\n", task.listenerByResID)
-		fmt.Printf("task : %v stack %v\n", task, stack)
-		var resListener []*latticemodel.Listener
+			fmt.Printf("listeners %v\n", task.listenerByResID)
+			fmt.Printf("task : %v stack %v\n", task, stack)
+			var resListener []*model.Listener
 
-		stack.ListResources(&resListener)
+			stack.ListResources(&resListener)
 
-		fmt.Printf("resListener :%v \n", resListener)
-		assert.Equal(t, resListener[0].Spec.Port, int64(tt.gwListenerPort))
-		assert.Equal(t, resListener[0].Spec.Name, tt.route.Name())
-		assert.Equal(t, resListener[0].Spec.Namespace, tt.route.Namespace())
-		assert.Equal(t, resListener[0].Spec.Protocol, "HTTP")
+			fmt.Printf("resListener :%v \n", resListener)
+			assert.Equal(t, resListener[0].Spec.Port, int64(tt.gwListenerPort))
+			assert.Equal(t, resListener[0].Spec.Name, tt.route.Name())
+			assert.Equal(t, resListener[0].Spec.Namespace, tt.route.Namespace())
+			assert.Equal(t, resListener[0].Spec.Protocol, "HTTP")
 
-		assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceName,
-			string(tt.route.Spec().Rules()[0].BackendRefs()[0].Name()))
-		if ns := tt.route.Spec().Rules()[0].BackendRefs()[0].Namespace(); ns != nil {
-			assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, *ns)
-		} else {
-			assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, tt.route.Namespace())
-		}
+			assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceName,
+				string(tt.route.Spec().Rules()[0].BackendRefs()[0].Name()))
+			if ns := tt.route.Spec().Rules()[0].BackendRefs()[0].Namespace(); ns != nil {
+				assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, *ns)
+			} else {
+				assert.Equal(t, resListener[0].Spec.DefaultAction.BackendServiceNamespace, tt.route.Namespace())
+			}
 
-		if tt.tlsTerminate && !tt.noTLSOption && !tt.wrongTLSOption {
-			assert.Equal(t, task.latticeService.Spec.CustomerCertARN, tt.certARN)
-		} else {
-			assert.Equal(t, task.latticeService.Spec.CustomerCertARN, "")
-		}
-
+			if tt.tlsTerminate && !tt.noTLSOption && !tt.wrongTLSOption {
+				assert.Equal(t, task.latticeService.Spec.CustomerCertARN, tt.certARN)
+			} else {
+				assert.Equal(t, task.latticeService.Spec.CustomerCertARN, "")
+			}
+		})
 	}
 }

--- a/pkg/gateway/model_build_rule_test.go
+++ b/pkg/gateway/model_build_rule_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -25,56 +25,56 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
 func Test_RuleModelBuild(t *testing.T) {
-	var httpSectionName v1beta1.SectionName = "http"
-	var serviceKind v1beta1.Kind = "Service"
-	var serviceimportKind v1beta1.Kind = "ServiceImport"
+	var httpSectionName gwv1beta1.SectionName = "http"
+	var serviceKind gwv1beta1.Kind = "Service"
+	var serviceimportKind gwv1beta1.Kind = "ServiceImport"
 	var weight1 = int32(10)
 	var weight2 = int32(90)
-	var namespace = v1beta1.Namespace("testnamespace")
-	var namespace2 = v1beta1.Namespace("testnamespace2")
+	var namespace = gwv1beta1.Namespace("testnamespace")
+	var namespace2 = gwv1beta1.Namespace("testnamespace2")
 	var path1 = "/ver1"
 	var path2 = "/ver2"
 	var path3 = "/ver3"
-	var httpGet = v1beta1.HTTPMethodGet
-	var httpPost = v1beta1.HTTPMethodPost
-	var k8sPathMatchExactType = v1beta1.PathMatchExact
-	var k8sMethodMatchExactType = v1alpha2.GRPCMethodMatchExact
-	var backendRef1 = v1beta1.BackendRef{
-		BackendObjectReference: v1beta1.BackendObjectReference{
+	var httpGet = gwv1beta1.HTTPMethodGet
+	var httpPost = gwv1beta1.HTTPMethodPost
+	var k8sPathMatchExactType = gwv1beta1.PathMatchExact
+	var k8sMethodMatchExactType = gwv1alpha2.GRPCMethodMatchExact
+	var backendRef1 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name: "targetgroup1",
 			Kind: &serviceKind,
 		},
 		Weight: &weight1,
 	}
-	var backendRef2 = v1beta1.BackendRef{
-		BackendObjectReference: v1beta1.BackendObjectReference{
+	var backendRef2 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name: "targetgroup2",
 			Kind: &serviceimportKind,
 		},
 		Weight: &weight2,
 	}
-	var backendRef1Namespace1 = v1beta1.BackendRef{
-		BackendObjectReference: v1beta1.BackendObjectReference{
+	var backendRef1Namespace1 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name:      "targetgroup2",
 			Namespace: &namespace,
 			Kind:      &serviceimportKind,
 		},
 		Weight: &weight2,
 	}
-	var backendRef1Namespace2 = v1beta1.BackendRef{
-		BackendObjectReference: v1beta1.BackendObjectReference{
+	var backendRef1Namespace2 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name:      "targetgroup2",
 			Namespace: &namespace2,
 			Kind:      &serviceimportKind,
 		},
 		Weight: &weight2,
 	}
-	var backendServiceImportRef = v1beta1.BackendRef{
-		BackendObjectReference: v1beta1.BackendObjectReference{
+	var backendServiceImportRef = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name: "targetgroup1",
 			Kind: &serviceimportKind,
 		},
@@ -82,7 +82,7 @@ func Test_RuleModelBuild(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		gwListenerPort     v1beta1.PortNumber
+		gwListenerPort     gwv1beta1.PortNumber
 		route              core.Route
 		wantErrIsNil       bool
 		k8sGetGatewayCall  bool
@@ -94,23 +94,23 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -126,23 +126,23 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendServiceImportRef,
 								},
@@ -158,23 +158,23 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -193,48 +193,48 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchExactType,
 										Value: &path1,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
 							},
 						},
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 
 										Value: &path2,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef2,
 								},
@@ -250,40 +250,40 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 									Method: &httpGet,
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
 							},
 						},
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 									Method: &httpPost,
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef2,
 								},
@@ -299,58 +299,58 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "non-default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Value: &path1,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
 							},
 						},
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Value: &path2,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1Namespace1,
 								},
 							},
 						},
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Value: &path3,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1Namespace2,
 								},
@@ -366,23 +366,23 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewGRPCRoute(v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: v1alpha2.CommonRouteSpec{
-						ParentRefs: []v1alpha2.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
+						ParentRefs: []gwv1alpha2.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1alpha2.GRPCRouteRule{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendServiceImportRef,
 								},
@@ -398,64 +398,64 @@ func Test_RuleModelBuild(t *testing.T) {
 			wantErrIsNil:       true,
 			k8sGetGatewayCall:  true,
 			k8sGatewayReturnOK: true,
-			route: core.NewGRPCRoute(v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "non-default",
 				},
-				Spec: v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1alpha2.GRPCRouteRule{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type:    &k8sMethodMatchExactType,
 										Service: pointer.String("service"),
 										Method:  pointer.String("method1"),
 									},
 								},
 							},
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
 							},
 						},
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type:    &k8sMethodMatchExactType,
 										Service: pointer.String("service"),
 										Method:  pointer.String("method2"),
 									},
 								},
 							},
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1Namespace1,
 								},
 							},
 						},
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type:    &k8sMethodMatchExactType,
 										Service: pointer.String("service"),
 										Method:  pointer.String("method3"),
 									},
 								},
 							},
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1Namespace2,
 								},
@@ -467,107 +467,106 @@ func Test_RuleModelBuild(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		fmt.Printf("Testing >>> %v\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		k8sClient := mock_client.NewMockClient(c)
+			mockK8sClient := mock_client.NewMockClient(c)
 
-		if tt.k8sGetGatewayCall {
+			if tt.k8sGetGatewayCall {
 
-			k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, gwName types.NamespacedName, gw *v1beta1.Gateway, arg3 ...interface{}) error {
+				mockK8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, gwName types.NamespacedName, gw *gwv1beta1.Gateway, arg3 ...interface{}) error {
 
-					if tt.k8sGatewayReturnOK {
-						gw.Spec.Listeners = append(gw.Spec.Listeners, v1beta1.Listener{
-							Port: tt.gwListenerPort,
-							Name: *tt.route.Spec().ParentRefs()[0].SectionName,
-						})
-						return nil
-					} else {
-						return errors.New("unknown k8s object")
-					}
-				},
-			)
-		}
-
-		ds := latticestore.NewLatticeDataStore()
-
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
-
-		task := &latticeServiceModelBuildTask{
-			log:             gwlog.FallbackLogger,
-			route:           tt.route,
-			stack:           stack,
-			client:          k8sClient,
-			listenerByResID: make(map[string]*latticemodel.Listener),
-			datastore:       ds,
-		}
-
-		err := task.buildRules(ctx)
-
-		assert.NoError(t, err)
-
-		var resRules []*latticemodel.Rule
-
-		stack.ListResources(&resRules)
-
-		if len(resRules) > 0 {
-			fmt.Printf("resRules :%v \n", *resRules[0])
-		}
-
-		var i = 1
-		for _, resRule := range resRules {
-
-			fmt.Sscanf(resRule.Spec.RuleID, "rule-%d", &i)
-
-			assert.Equal(t, resRule.Spec.ListenerPort, int64(tt.gwListenerPort))
-			// Defer this to dedicate rule check			assert.Equal(t, resRule.Spec.PathMatchValue, tt.route.)
-			assert.Equal(t, resRule.Spec.ServiceName, tt.route.Name())
-			assert.Equal(t, resRule.Spec.ServiceNamespace, tt.route.Namespace())
-
-			var j = 0
-			for _, tg := range resRule.Spec.Action.TargetGroups {
-
-				assert.Equal(t, v1beta1.ObjectName(tg.Name), tt.route.Spec().Rules()[i-1].BackendRefs()[j].Name())
-				if tt.route.Spec().Rules()[i-1].BackendRefs()[j].Namespace() != nil {
-					assert.Equal(t, v1beta1.Namespace(tg.Namespace), *tt.route.Spec().Rules()[i-1].BackendRefs()[j].Namespace())
-				} else {
-					assert.Equal(t, tg.Namespace, tt.route.Namespace())
-				}
-
-				if *tt.route.Spec().Rules()[i-1].BackendRefs()[j].Kind() == "ServiceImport" {
-					assert.Equal(t, tg.IsServiceImport, true)
-				} else {
-					assert.Equal(t, tg.IsServiceImport, false)
-				}
-				j++
+						if tt.k8sGatewayReturnOK {
+							gw.Spec.Listeners = append(gw.Spec.Listeners, gwv1beta1.Listener{
+								Port: tt.gwListenerPort,
+								Name: *tt.route.Spec().ParentRefs()[0].SectionName,
+							})
+							return nil
+						} else {
+							return errors.New("unknown k8s object")
+						}
+					},
+				)
 			}
 
-		}
+			ds := latticestore.NewLatticeDataStore()
 
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
+
+			task := &latticeServiceModelBuildTask{
+				log:             gwlog.FallbackLogger,
+				route:           tt.route,
+				stack:           stack,
+				client:          mockK8sClient,
+				listenerByResID: make(map[string]*model.Listener),
+				datastore:       ds,
+			}
+
+			err := task.buildRules(ctx)
+
+			assert.NoError(t, err)
+
+			var resRules []*model.Rule
+
+			stack.ListResources(&resRules)
+
+			if len(resRules) > 0 {
+				fmt.Printf("resRules :%v \n", *resRules[0])
+			}
+
+			var i = 1
+			for _, resRule := range resRules {
+
+				fmt.Sscanf(resRule.Spec.RuleID, "rule-%d", &i)
+
+				assert.Equal(t, resRule.Spec.ListenerPort, int64(tt.gwListenerPort))
+				// Defer this to dedicate rule check			assert.Equal(t, resRule.Spec.PathMatchValue, tt.route.)
+				assert.Equal(t, resRule.Spec.ServiceName, tt.route.Name())
+				assert.Equal(t, resRule.Spec.ServiceNamespace, tt.route.Namespace())
+
+				var j = 0
+				for _, tg := range resRule.Spec.Action.TargetGroups {
+
+					assert.Equal(t, gwv1beta1.ObjectName(tg.Name), tt.route.Spec().Rules()[i-1].BackendRefs()[j].Name())
+					if tt.route.Spec().Rules()[i-1].BackendRefs()[j].Namespace() != nil {
+						assert.Equal(t, gwv1beta1.Namespace(tg.Namespace), *tt.route.Spec().Rules()[i-1].BackendRefs()[j].Namespace())
+					} else {
+						assert.Equal(t, tg.Namespace, tt.route.Namespace())
+					}
+
+					if *tt.route.Spec().Rules()[i-1].BackendRefs()[j].Kind() == "ServiceImport" {
+						assert.Equal(t, tg.IsServiceImport, true)
+					} else {
+						assert.Equal(t, tg.IsServiceImport, false)
+					}
+					j++
+				}
+			}
+		})
 	}
 }
 
 func Test_HeadersRuleBuild(t *testing.T) {
-	var httpSectionName v1beta1.SectionName = "http"
-	var serviceKind v1beta1.Kind = "Service"
+	var httpSectionName gwv1beta1.SectionName = "http"
+	var serviceKind gwv1beta1.Kind = "Service"
 
-	var namespace = v1beta1.Namespace("default")
+	var namespace = gwv1beta1.Namespace("default")
 	var path1 = "/ver1"
-	var k8sPathMatchExactType = v1beta1.PathMatchExact
-	var k8sPathMatchPrefixType = v1beta1.PathMatchPathPrefix
-	var k8sMethodMatchExactType = v1alpha2.GRPCMethodMatchExact
+	var k8sPathMatchExactType = gwv1beta1.PathMatchExact
+	var k8sPathMatchPrefixType = gwv1beta1.PathMatchPathPrefix
+	var k8sMethodMatchExactType = gwv1alpha2.GRPCMethodMatchExact
 
-	var k8sHeaderExactType = v1beta1.HeaderMatchExact
+	var k8sHeaderExactType = gwv1beta1.HeaderMatchExact
 	var hdr1 = "env1"
 	var hdr1Value = "test1"
 	var hdr2 = "env2"
 	var hdr2Value = "test2"
 
-	var backendRef1 = v1beta1.BackendRef{
-		BackendObjectReference: v1beta1.BackendObjectReference{
+	var backendRef1 = gwv1beta1.BackendRef{
+		BackendObjectReference: gwv1beta1.BackendObjectReference{
 			Name:      "targetgroup1",
 			Namespace: &namespace,
 			Kind:      &serviceKind,
@@ -576,9 +575,9 @@ func Test_HeadersRuleBuild(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		gwListenerPort   v1beta1.PortNumber
+		gwListenerPort   gwv1beta1.PortNumber
 		route            core.Route
-		expectedRuleSpec latticemodel.RuleSpec
+		expectedRuleSpec model.RuleSpec
 		wantErrIsNil     bool
 		samerule         bool
 	}{
@@ -588,32 +587,32 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchExactType,
 										Value: &path1,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -622,7 +621,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				PathMatchExact: true,
 				PathMatchValue: path1,
 			},
@@ -634,32 +633,32 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchPrefixType,
 										Value: &path1,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -668,7 +667,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				PathMatchPrefix: true,
 				PathMatchValue:  path1,
 			},
@@ -679,39 +678,39 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									//	Path: &v1beta1.HTTPPathMatch{
+									//	Path: &gwv1beta1.HTTPPathMatch{
 									//		Type:  &k8sPathMatchPrefixType,
 									//		Value: &path1,
 									//	},
-									Headers: []v1beta1.HTTPHeaderMatch{
+									Headers: []gwv1beta1.HTTPHeaderMatch{
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -720,7 +719,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				NumOfHeaderMatches: 1,
 				MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -743,39 +742,39 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
-									Headers: []v1beta1.HTTPHeaderMatch{
+									Headers: []gwv1beta1.HTTPHeaderMatch{
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -784,7 +783,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				NumOfHeaderMatches: 2,
 				MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -811,44 +810,44 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchExactType,
 										Value: &path1,
 									},
-									Headers: []v1beta1.HTTPHeaderMatch{
+									Headers: []gwv1beta1.HTTPHeaderMatch{
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -857,7 +856,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				PathMatchExact:     true,
 				PathMatchValue:     path1,
 				NumOfHeaderMatches: 2,
@@ -886,44 +885,44 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchPrefixType,
 										Value: &path1,
 									},
-									Headers: []v1beta1.HTTPHeaderMatch{
+									Headers: []gwv1beta1.HTTPHeaderMatch{
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -932,7 +931,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				PathMatchPrefix:    true,
 				PathMatchValue:     path1,
 				NumOfHeaderMatches: 2,
@@ -961,39 +960,39 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
-									Headers: []v1beta1.HTTPHeaderMatch{
+									Headers: []gwv1beta1.HTTPHeaderMatch{
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1002,7 +1001,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				NumOfHeaderMatches: 2,
 				MatchedHeaders: [5]vpclattice.HeaderMatch{
 
@@ -1029,64 +1028,64 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchExactType,
 										Value: &path1,
 									},
-									Headers: []v1beta1.HTTPHeaderMatch{
+									Headers: []gwv1beta1.HTTPHeaderMatch{
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr1),
+											Name:  gwv1beta1.HTTPHeaderName(hdr1),
 											Value: hdr1Value,
 										},
 										{
 											Type:  &k8sHeaderExactType,
-											Name:  v1beta1.HTTPHeaderName(hdr2),
+											Name:  gwv1beta1.HTTPHeaderName(hdr2),
 											Value: hdr2Value,
 										},
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1095,7 +1094,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				PathMatchExact:     true,
 				PathMatchValue:     path1,
 				NumOfHeaderMatches: 2,
@@ -1124,39 +1123,39 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   true,
 			samerule:       true,
 
-			route: core.NewHTTPRoute(v1beta1.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1beta1.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							Matches: []v1beta1.HTTPRouteMatch{
+							Matches: []gwv1beta1.HTTPRouteMatch{
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchExactType,
 										Value: &path1,
 									},
 								},
 								{
 
-									Path: &v1beta1.HTTPPathMatch{
+									Path: &gwv1beta1.HTTPPathMatch{
 										Type:  &k8sPathMatchExactType,
 										Value: &path1,
 									},
 								},
 							},
-							BackendRefs: []v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1165,7 +1164,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				PathMatchExact: true,
 				PathMatchValue: path1,
 			},
@@ -1176,25 +1175,25 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewGRPCRoute(v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1alpha2.GRPCRouteRule{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type:    &k8sMethodMatchExactType,
 										Service: pointer.String("service"),
 										Method:  pointer.String("method"),
@@ -1202,7 +1201,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 								},
 							},
 
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1211,7 +1210,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				Method:             "POST",
 				NumOfHeaderMatches: 0,
 				PathMatchExact:     true,
@@ -1224,32 +1223,32 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewGRPCRoute(v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1alpha2.GRPCRouteRule{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type:    &k8sMethodMatchExactType,
 										Service: pointer.String("service"),
 									},
 								},
 							},
 
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1258,7 +1257,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				Method:             "POST",
 				NumOfHeaderMatches: 0,
 				PathMatchPrefix:    true,
@@ -1271,31 +1270,31 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewGRPCRoute(v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1alpha2.GRPCRouteRule{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type: &k8sMethodMatchExactType,
 									},
 								},
 							},
 
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1304,7 +1303,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				Method:             "POST",
 				NumOfHeaderMatches: 0,
 				PathMatchPrefix:    true,
@@ -1317,29 +1316,29 @@ func Test_HeadersRuleBuild(t *testing.T) {
 			wantErrIsNil:   false,
 			samerule:       true,
 
-			route: core.NewGRPCRoute(v1alpha2.GRPCRoute{
+			route: core.NewGRPCRoute(gwv1alpha2.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service1",
 					Namespace: "default",
 				},
-				Spec: v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: v1beta1.CommonRouteSpec{
-						ParentRefs: []v1beta1.ParentReference{
+				Spec: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
-								Name:        "mesh1",
+								Name:        "gw1",
 								SectionName: &httpSectionName,
 							},
 						},
 					},
-					Rules: []v1alpha2.GRPCRouteRule{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							Matches: []v1alpha2.GRPCRouteMatch{
+							Matches: []gwv1alpha2.GRPCRouteMatch{
 								{
-									Method: &v1alpha2.GRPCMethodMatch{
+									Method: &gwv1alpha2.GRPCMethodMatch{
 										Type:    &k8sMethodMatchExactType,
 										Service: pointer.String("service"),
 									},
-									Headers: []v1alpha2.GRPCHeaderMatch{
+									Headers: []gwv1alpha2.GRPCHeaderMatch{
 										{
 											Name:  "foo1",
 											Value: "bar1",
@@ -1368,7 +1367,7 @@ func Test_HeadersRuleBuild(t *testing.T) {
 									},
 								},
 							},
-							BackendRefs: []v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
 									BackendRef: backendRef1,
 								},
@@ -1377,12 +1376,12 @@ func Test_HeadersRuleBuild(t *testing.T) {
 					},
 				},
 			}),
-			expectedRuleSpec: latticemodel.RuleSpec{
+			expectedRuleSpec: model.RuleSpec{
 				Method:             "POST",
 				NumOfHeaderMatches: 5,
 				PathMatchPrefix:    true,
 				PathMatchValue:     "/service/",
-				MatchedHeaders: [latticemodel.MAX_NUM_OF_MATCHED_HEADERS]vpclattice.HeaderMatch{
+				MatchedHeaders: [model.MAX_NUM_OF_MATCHED_HEADERS]vpclattice.HeaderMatch{
 					{
 						Name: pointer.String("foo1"),
 						Match: &vpclattice.HeaderMatchType{
@@ -1419,75 +1418,74 @@ func Test_HeadersRuleBuild(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
 
-		fmt.Printf("Testing >>> %v\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.TODO()
+			mockK8sClient := mock_client.NewMockClient(c)
 
-		k8sClient := mock_client.NewMockClient(c)
+			mockK8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, gwName types.NamespacedName, gw *gwv1beta1.Gateway, arg3 ...interface{}) error {
 
-		k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, gwName types.NamespacedName, gw *v1beta1.Gateway, arg3 ...interface{}) error {
+					gw.Spec.Listeners = append(gw.Spec.Listeners, gwv1beta1.Listener{
+						Port: tt.gwListenerPort,
+						Name: *tt.route.Spec().ParentRefs()[0].SectionName,
+					})
+					return nil
 
-				gw.Spec.Listeners = append(gw.Spec.Listeners, v1beta1.Listener{
-					Port: tt.gwListenerPort,
-					Name: *tt.route.Spec().ParentRefs()[0].SectionName,
-				})
-				return nil
+				},
+			)
 
-			},
-		)
+			ds := latticestore.NewLatticeDataStore()
 
-		ds := latticestore.NewLatticeDataStore()
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
-
-		task := &latticeServiceModelBuildTask{
-			log:             gwlog.FallbackLogger,
-			route:           tt.route,
-			stack:           stack,
-			client:          k8sClient,
-			listenerByResID: make(map[string]*latticemodel.Listener),
-			datastore:       ds,
-		}
-
-		err := task.buildRules(ctx)
-
-		if tt.wantErrIsNil {
-			assert.Error(t, err)
-			continue
-		}
-		assert.NoError(t, err)
-
-		var resRules []*latticemodel.Rule
-		stack.ListResources(&resRules)
-
-		if len(resRules) > 0 {
-			// for debug fmt.Printf("resRules :%v \n", *resRules[0])
-		}
-
-		// we are unit- testing various combination of one rule for now
-		var i = 1
-		for _, resRule := range resRules {
-
-			// for debugging, fmt.Printf("i = %d resRule :%v \n, expected rule: %v\n", i, resRule, tt.expectedRuleSpec)
-
-			sameRule := isRuleSpecSame(&tt.expectedRuleSpec, &resRule.Spec)
-
-			if tt.samerule {
-				assert.True(t, sameRule)
-			} else {
-				assert.False(t, sameRule)
+			task := &latticeServiceModelBuildTask{
+				log:             gwlog.FallbackLogger,
+				route:           tt.route,
+				stack:           stack,
+				client:          mockK8sClient,
+				listenerByResID: make(map[string]*model.Listener),
+				datastore:       ds,
 			}
-			i++
 
-		}
+			err := task.buildRules(ctx)
 
+			if tt.wantErrIsNil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			var resRules []*model.Rule
+			stack.ListResources(&resRules)
+
+			if len(resRules) > 0 {
+				// for debug fmt.Printf("resRules :%v \n", *resRules[0])
+			}
+
+			// we are unit- testing various combination of one rule for now
+			var i = 1
+			for _, resRule := range resRules {
+
+				// for debugging, fmt.Printf("i = %d resRule :%v \n, expected rule: %v\n", i, resRule, tt.expectedRuleSpec)
+
+				sameRule := isRuleSpecSame(&tt.expectedRuleSpec, &resRule.Spec)
+
+				if tt.samerule {
+					assert.True(t, sameRule)
+				} else {
+					assert.False(t, sameRule)
+				}
+				i++
+
+			}
+		})
 	}
 }
 
-func isRuleSpecSame(rule1 *latticemodel.RuleSpec, rule2 *latticemodel.RuleSpec) bool {
+func isRuleSpecSame(rule1 *model.RuleSpec, rule2 *model.RuleSpec) bool {
 
 	// debug fmt.Printf("rule1 :%v \n", rule1)
 	// debug fmt.Printf("rule2: %v \n", rule2)

--- a/pkg/gateway/model_build_service_network_test.go
+++ b/pkg/gateway/model_build_service_network_test.go
@@ -2,41 +2,40 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 )
 
-func Test_MeshModelBuild(t *testing.T) {
+func Test_SNModelBuild(t *testing.T) {
 	now := metav1.Now()
 	trueBool := true
 	falseBool := false
-	notRelatedVpcAssociationPolicy := v1alpha1.VpcAssociationPolicy{
+	notRelatedVpcAssociationPolicy := anv1alpha1.VpcAssociationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "another-vpc-association-policy",
 		},
-		Spec: v1alpha1.VpcAssociationPolicySpec{
-			TargetRef: &v1alpha2.PolicyTargetReference{
-				Group: gateway_api.GroupName,
+		Spec: anv1alpha1.VpcAssociationPolicySpec{
+			TargetRef: &gwv1alpha2.PolicyTargetReference{
+				Group: gwv1beta1.GroupName,
 				Kind:  "Gateway",
-				Name:  "another-mesh",
+				Name:  "another-gw",
 			},
 			AssociateWithVpc: &falseBool,
 		},
 	}
 	tests := []struct {
 		name                 string
-		gw                   *gateway_api.Gateway
-		vpcAssociationPolicy *v1alpha1.VpcAssociationPolicy
+		gw                   *gwv1beta1.Gateway
+		vpcAssociationPolicy *anv1alpha1.VpcAssociationPolicy
 		wantErr              error
 		wantName             string
 		wantNamespace        string
@@ -44,152 +43,152 @@ func Test_MeshModelBuild(t *testing.T) {
 		associateToVPC       bool
 	}{
 		{
-			name: "Adding Mesh in default namespace, no annotation on VPC association, associate to VPC by default",
-			gw: &gateway_api.Gateway{
+			name: "Adding SN in default namespace, no annotation on VPC association, associate to VPC by default",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "mesh1",
+					Name: "gw1",
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  false,
 			associateToVPC: true,
 		},
 		{
-			name: "Adding Mesh in non-default namespace, no annotation on VPC association",
-			gw: &gateway_api.Gateway{
+			name: "Adding SN in non-default namespace, no annotation on VPC association",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mesh1",
+					Name:      "gw1",
 					Namespace: "non-default",
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "non-default",
 			wantIsDeleted:  false,
 			associateToVPC: true,
 		},
 		{
-			name: "Adding Mesh, and need VPC association",
-			gw: &gateway_api.Gateway{
+			name: "Adding SN, and need VPC association",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "mesh1",
+					Name:        "gw1",
 					Annotations: map[string]string{LatticeVPCAssociationAnnotation: "true"},
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  false,
 			associateToVPC: true,
 		},
 		{
-			name: "Adding Mesh, and need VPC association",
-			gw: &gateway_api.Gateway{
+			name: "Adding SN, and need VPC association",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "mesh1",
+					Name:        "gw1",
 					Annotations: map[string]string{LatticeVPCAssociationAnnotation: "false"},
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  false,
 			associateToVPC: false,
 		},
 		{
-			name: "Deleting Mesh",
-			gw: &gateway_api.Gateway{
+			name: "Deleting SN",
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "mesh1",
+					Name:              "gw1",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  true,
 			associateToVPC: true,
 		},
 		{
 			name: "Gateway has attached VpcAssociationPolicy found, VpcAssociationPolicy SecurityGroupIds are not empty",
-			gw: &gateway_api.Gateway{
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "mesh1",
+					Name:       "gw1",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 			},
-			vpcAssociationPolicy: &v1alpha1.VpcAssociationPolicy{
+			vpcAssociationPolicy: &anv1alpha1.VpcAssociationPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-vpc-association-policy",
 				},
-				Spec: v1alpha1.VpcAssociationPolicySpec{
-					TargetRef: &v1alpha2.PolicyTargetReference{
-						Group: gateway_api.GroupName,
+				Spec: anv1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &gwv1alpha2.PolicyTargetReference{
+						Group: gwv1beta1.GroupName,
 						Kind:  "Gateway",
-						Name:  "mesh1",
+						Name:  "gw1",
 					},
-					SecurityGroupIds: []v1alpha1.SecurityGroupId{"sg-123456", "sg-654321"},
+					SecurityGroupIds: []anv1alpha1.SecurityGroupId{"sg-123456", "sg-654321"},
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  false,
 			associateToVPC: true,
 		},
 		{
 			name: "Gateway does not have LatticeVPCAssociationAnnotation, it has attached VpcAssociationPolicy found, which AssociateWithVpc field set to true",
-			gw: &gateway_api.Gateway{
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "mesh1",
+					Name:       "gw1",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 			},
-			vpcAssociationPolicy: &v1alpha1.VpcAssociationPolicy{
+			vpcAssociationPolicy: &anv1alpha1.VpcAssociationPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-vpc-association-policy",
 				},
-				Spec: v1alpha1.VpcAssociationPolicySpec{
-					TargetRef: &v1alpha2.PolicyTargetReference{
-						Group: gateway_api.GroupName,
+				Spec: anv1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &gwv1alpha2.PolicyTargetReference{
+						Group: gwv1beta1.GroupName,
 						Kind:  "Gateway",
-						Name:  "mesh1",
+						Name:  "gw1",
 					},
 					AssociateWithVpc: &trueBool,
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  false,
 			associateToVPC: true,
 		},
 		{
 			name: "Gateway does not have LatticeVPCAssociationAnnotation, it has attached VpcAssociationPolicy found, which AssociateWithVpc field set to false",
-			gw: &gateway_api.Gateway{
+			gw: &gwv1beta1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "mesh1",
+					Name:       "gw1",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
 			},
-			vpcAssociationPolicy: &v1alpha1.VpcAssociationPolicy{
+			vpcAssociationPolicy: &anv1alpha1.VpcAssociationPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-vpc-association-policy",
 				},
-				Spec: v1alpha1.VpcAssociationPolicySpec{
-					TargetRef: &v1alpha2.PolicyTargetReference{
-						Group: gateway_api.GroupName,
+				Spec: anv1alpha1.VpcAssociationPolicySpec{
+					TargetRef: &gwv1alpha2.PolicyTargetReference{
+						Group: gwv1beta1.GroupName,
 						Kind:  "Gateway",
-						Name:  "mesh1",
+						Name:  "gw1",
 					},
 					AssociateWithVpc: &falseBool,
 				},
 			},
 			wantErr:        nil,
-			wantName:       "mesh1",
+			wantName:       "gw1",
 			wantNamespace:  "",
 			wantIsDeleted:  false,
 			associateToVPC: false,
@@ -197,14 +196,13 @@ func Test_MeshModelBuild(t *testing.T) {
 	}
 	c := gomock.NewController(t)
 	defer c.Finish()
-	mock_client := mock_client.NewMockClient(c)
+	mockClient := mock_client.NewMockClient(c)
 	ctx := context.Background()
 
 	for _, tt := range tests {
-		fmt.Printf("Testing >>> %v\n", tt.name)
 		t.Run(tt.name, func(t *testing.T) {
-			mock_client.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, policyList *v1alpha1.VpcAssociationPolicyList, arg3 ...interface{}) error {
+			mockClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, policyList *anv1alpha1.VpcAssociationPolicyList, arg3 ...interface{}) error {
 					policyList.Items = append(policyList.Items, notRelatedVpcAssociationPolicy)
 					if tt.vpcAssociationPolicy != nil {
 						policyList.Items = append(policyList.Items, *tt.vpcAssociationPolicy)
@@ -212,7 +210,7 @@ func Test_MeshModelBuild(t *testing.T) {
 					return nil
 				},
 			)
-			builder := NewServiceNetworkModelBuilder(mock_client)
+			builder := NewServiceNetworkModelBuilder(mockClient)
 			_, got, err := builder.Build(context.Background(), tt.gw)
 
 			if tt.wantErr != nil {
@@ -226,7 +224,6 @@ func Test_MeshModelBuild(t *testing.T) {
 					assert.Equal(t, securityGroupIdsToStringPointersSlice(tt.vpcAssociationPolicy.Spec.SecurityGroupIds), got.Spec.SecurityGroupIds)
 				}
 			}
-
 		})
 	}
 }

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -17,22 +17,22 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	gateway_api "sigs.k8s.io/gateway-api/apis/v1beta1"
-	mcs_api "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
-	latticemodel "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
 func Test_TGModelByServicexportBuild(t *testing.T) {
 	now := metav1.Now()
 	tests := []struct {
 		name                string
-		svcExport           *mcs_api.ServiceExport
+		svcExport           *mcsv1alpha1.ServiceExport
 		svc                 *corev1.Service
 		endPoints           []corev1.Endpoints
 		wantErrIsNil        bool
@@ -41,7 +41,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 	}{
 		{
 			name: "Adding ServieExport where service object exist",
-			svcExport: &mcs_api.ServiceExport{
+			svcExport: &mcsv1alpha1.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "export1",
 					Namespace: "ns1",
@@ -75,7 +75,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 		},
 		{
 			name: "Adding ServieExport where service object does NOT exist",
-			svcExport: &mcs_api.ServiceExport{
+			svcExport: &mcsv1alpha1.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "export2",
 					Namespace: "ns1",
@@ -88,7 +88,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 		},
 		{
 			name: "Deleting ServiceExport where service object does NOT exist",
-			svcExport: &mcs_api.ServiceExport{
+			svcExport: &mcsv1alpha1.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "export3",
 					Namespace:         "ns1",
@@ -103,7 +103,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 		},
 		{
 			name: "Deleting ServieExport where service object exist",
-			svcExport: &mcs_api.ServiceExport{
+			svcExport: &mcsv1alpha1.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "export4",
 					Namespace:         "ns1",
@@ -139,7 +139,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 		},
 		{
 			name: "Creating IPv6 ServiceExport where service object with IpFamilies IPv6 exists",
-			svcExport: &mcs_api.ServiceExport{
+			svcExport: &mcsv1alpha1.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "export5",
 					Namespace:  "ns1",
@@ -172,7 +172,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 		},
 		{
 			name: "Failed to create IPv6 ServiceExport where service object with dual stack IpFamilies exists",
-			svcExport: &mcs_api.ServiceExport{
+			svcExport: &mcsv1alpha1.ServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "export6",
 					Namespace:  "ns1",
@@ -212,7 +212,7 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 
 			k8sSchema := runtime.NewScheme()
 			clientgoscheme.AddToScheme(k8sSchema)
-			v1alpha1.AddToScheme(k8sSchema)
+			anv1alpha1.AddToScheme(k8sSchema)
 			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
 
 			if tt.svc != nil {
@@ -270,13 +270,13 @@ func Test_TGModelByServicexportBuild(t *testing.T) {
 func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 	now := metav1.Now()
 
-	namespacePtr := func(ns string) *gateway_api.Namespace {
-		p := gateway_api.Namespace(ns)
+	namespacePtr := func(ns string) *gwv1beta1.Namespace {
+		p := gwv1beta1.Namespace(ns)
 		return &p
 	}
 
-	kindPtr := func(k string) *gateway_api.Kind {
-		p := gateway_api.Kind(k)
+	kindPtr := func(k string) *gwv1beta1.Kind {
+		p := gwv1beta1.Kind(k)
 		return &p
 	}
 
@@ -292,24 +292,24 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "service1",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service1-tg1",
 											Namespace: namespacePtr("ns11"),
 											Kind:      kindPtr("Service"),
@@ -330,26 +330,26 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "service2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service2-tg1",
 											Namespace: namespacePtr("ns21"),
 											Kind:      kindPtr("Service"),
@@ -370,25 +370,25 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Create LatticeService where backend K8S service does NOT exist",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service3",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service3-tg1",
 											Namespace: namespacePtr("ns31"),
 											Kind:      kindPtr("Service"),
@@ -409,25 +409,25 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Create LatticeService where backend mcs serviceimport does NOT exist",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service4",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service4-tg1",
 											Namespace: namespacePtr("ns31"),
 											Kind:      kindPtr("ServiceImport"),
@@ -448,25 +448,25 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 		},
 		{
 			name: "Lattice Service with IPv6 Target Group",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "service5",
 					Finalizers: []string{"gateway.k8s.aws/resources"},
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service5-tg1",
 											Namespace: namespacePtr("ns31"),
 											Kind:      kindPtr("Service"),
@@ -494,7 +494,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 
 			k8sSchema := runtime.NewScheme()
 			clientgoscheme.AddToScheme(k8sSchema)
-			v1alpha1.AddToScheme(k8sSchema)
+			anv1alpha1.AddToScheme(k8sSchema)
 			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
 			ds := latticestore.NewLatticeDataStore()
 
@@ -507,7 +507,7 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 				route:     tt.route,
 				stack:     stack,
 				client:    k8sClient,
-				tgByResID: make(map[string]*latticemodel.TargetGroup),
+				tgByResID: make(map[string]*model.TargetGroup),
 				datastore: ds,
 			}
 
@@ -585,22 +585,20 @@ func Test_TGModelByHTTPRouteBuild(t *testing.T) {
 
 					}
 				}
-
 			}
-
 		})
 	}
 }
 
 func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 	now := metav1.Now()
-	namespacePtr := func(ns string) *gateway_api.Namespace {
-		p := gateway_api.Namespace(ns)
+	namespacePtr := func(ns string) *gwv1beta1.Namespace {
+		p := gwv1beta1.Namespace(ns)
 		return &p
 	}
 
-	kindPtr := func(k string) *gateway_api.Kind {
-		p := gateway_api.Kind(k)
+	kindPtr := func(k string) *gwv1beta1.Kind {
+		p := gwv1beta1.Kind(k)
 		return &p
 	}
 
@@ -615,24 +613,24 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 	}{
 		{
 			name: "Add LatticeService",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "serviceimport1",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service1-tg2",
 											Namespace: namespacePtr("tg1-ns1"),
 											Kind:      kindPtr("ServiceImport"),
@@ -652,25 +650,25 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 		},
 		{
 			name: "Add LatticeService, implicit namespace",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "serviceimport1",
 					Namespace: "tg1-ns2",
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name: "service1-tg2",
 											Kind: kindPtr("ServiceImport"),
 										},
@@ -689,27 +687,27 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 		},
 		{
 			name: "Delete LatticeService",
-			route: core.NewHTTPRoute(gateway_api.HTTPRoute{
+			route: core.NewHTTPRoute(gwv1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "serviceimport2",
 					Finalizers:        []string{"gateway.k8s.aws/resources"},
 					DeletionTimestamp: &now,
 				},
-				Spec: gateway_api.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api.CommonRouteSpec{
-						ParentRefs: []gateway_api.ParentReference{
+				Spec: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{
 								Name: "gateway1",
 							},
 						},
 					},
-					Rules: []gateway_api.HTTPRouteRule{
+					Rules: []gwv1beta1.HTTPRouteRule{
 
 						{
-							BackendRefs: []gateway_api.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api.BackendRef{
-										BackendObjectReference: gateway_api.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name:      "service1-tg2",
 											Namespace: namespacePtr("tg1-ns1"),
 											Kind:      kindPtr("ServiceImport"),
@@ -730,94 +728,94 @@ func Test_TGModelByHTTPRouteImportBuild(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Printf("Test >>>> %v\n", tt.name)
-		c := gomock.NewController(t)
-		defer c.Finish()
-		ctx := context.Background()
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.Background()
 
-		k8sClient := mock_client.NewMockClient(c)
+			mockK8sClient := mock_client.NewMockClient(c)
 
-		ds := latticestore.NewLatticeDataStore()
+			ds := latticestore.NewLatticeDataStore()
 
-		//builder := NewLatticeServiceBuilder(k8sClient, ds, nil)
+			//builder := NewLatticeServiceBuilder(mockK8sClient, ds, nil)
 
-		stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(tt.route.K8sObject())))
 
-		task := &latticeServiceModelBuildTask{
-			log:       gwlog.FallbackLogger,
-			route:     tt.route,
-			stack:     stack,
-			client:    k8sClient,
-			tgByResID: make(map[string]*latticemodel.TargetGroup),
-			datastore: ds,
-		}
-
-		for _, httpRules := range tt.route.Spec().Rules() {
-			for _, httpBackendRef := range httpRules.BackendRefs() {
-				if tt.svcImportExist {
-					k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-						func(ctx context.Context, name types.NamespacedName, svcImport *mcs_api.ServiceImport, arg3 ...interface{}) error {
-							//TODO add more
-							svcImport.ObjectMeta.Name = string(httpBackendRef.Name())
-							return nil
-						},
-					)
-				} else {
-					k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errors.New("serviceimport not exist"))
-				}
+			task := &latticeServiceModelBuildTask{
+				log:       gwlog.FallbackLogger,
+				route:     tt.route,
+				stack:     stack,
+				client:    mockK8sClient,
+				tgByResID: make(map[string]*model.TargetGroup),
+				datastore: ds,
 			}
-		}
-		k8sClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(nil)
 
-		err := task.buildTargetGroupsForRoute(ctx, k8sClient)
-
-		fmt.Printf("err %v\n", err)
-
-		if !tt.wantErrIsNil {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err)
-		}
-
-		if tt.wantErrIsNil {
-			// verify data store
 			for _, httpRules := range tt.route.Spec().Rules() {
 				for _, httpBackendRef := range httpRules.BackendRefs() {
-					ns := tt.route.Namespace()
-					if httpBackendRef.Namespace() != nil {
-						ns = string(*httpBackendRef.Namespace())
-					}
-					tgName := latticestore.TargetGroupName(string(httpBackendRef.Name()), ns)
-
-					fmt.Printf("httpBackendRef %s\n", *httpBackendRef.Kind())
-					if "Service" == *httpBackendRef.Kind() {
-						if tt.wantIsDeleted {
-							tg := task.tgByResID[tgName]
-							fmt.Printf("--task.tgByResID[tgName] %v \n", tg)
-							assert.Equal(t, true, tg.Spec.IsDeleted)
-						} else {
-							dsTG, err := ds.GetTargetGroup(tgName, tt.route.Name(), false)
-							assert.Equal(t, true, dsTG.ByBackendRef)
-							fmt.Printf("--dsTG %v\n", dsTG)
-							assert.Nil(t, err)
-						}
+					if tt.svcImportExist {
+						mockK8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, name types.NamespacedName, svcImport *mcsv1alpha1.ServiceImport, arg3 ...interface{}) error {
+								//TODO add more
+								svcImport.ObjectMeta.Name = string(httpBackendRef.Name())
+								return nil
+							},
+						)
 					} else {
-						dsTG, err := ds.GetTargetGroup(tgName, "", true)
-						fmt.Printf("dsTG %v\n", dsTG)
-						if tt.wantIsDeleted {
-							tg := task.tgByResID[tgName]
-							assert.Equal(t, true, tg.Spec.IsDeleted)
-						} else {
-							assert.Equal(t, false, dsTG.ByBackendRef)
-							assert.Equal(t, false, dsTG.ByServiceExport)
-							assert.Nil(t, err)
-						}
+						mockK8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errors.New("serviceimport not exist"))
 					}
-					assert.Nil(t, err)
 				}
 			}
+			mockK8sClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(nil)
 
-		}
+			err := task.buildTargetGroupsForRoute(ctx, mockK8sClient)
+
+			fmt.Printf("err %v\n", err)
+
+			if !tt.wantErrIsNil {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			if tt.wantErrIsNil {
+				// verify data store
+				for _, httpRules := range tt.route.Spec().Rules() {
+					for _, httpBackendRef := range httpRules.BackendRefs() {
+						ns := tt.route.Namespace()
+						if httpBackendRef.Namespace() != nil {
+							ns = string(*httpBackendRef.Namespace())
+						}
+						tgName := latticestore.TargetGroupName(string(httpBackendRef.Name()), ns)
+
+						fmt.Printf("httpBackendRef %s\n", *httpBackendRef.Kind())
+						if "Service" == *httpBackendRef.Kind() {
+							if tt.wantIsDeleted {
+								tg := task.tgByResID[tgName]
+								fmt.Printf("--task.tgByResID[tgName] %v \n", tg)
+								assert.Equal(t, true, tg.Spec.IsDeleted)
+							} else {
+								dsTG, err := ds.GetTargetGroup(tgName, tt.route.Name(), false)
+								assert.Equal(t, true, dsTG.ByBackendRef)
+								fmt.Printf("--dsTG %v\n", dsTG)
+								assert.Nil(t, err)
+							}
+						} else {
+							dsTG, err := ds.GetTargetGroup(tgName, "", true)
+							fmt.Printf("dsTG %v\n", dsTG)
+							if tt.wantIsDeleted {
+								tg := task.tgByResID[tgName]
+								assert.Equal(t, true, tg.Spec.IsDeleted)
+							} else {
+								assert.Equal(t, false, dsTG.ByBackendRef)
+								assert.Equal(t, false, dsTG.ByServiceExport)
+								assert.Nil(t, err)
+							}
+						}
+						assert.Nil(t, err)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/gateway/utils_test.go
+++ b/pkg/gateway/utils_test.go
@@ -9,10 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 )
 
@@ -29,17 +29,17 @@ func Test_getAttachedPolicy(t *testing.T) {
 		expectPolicyNotFound            bool
 	}
 	ns := "test-ns"
-	typedNs := gateway_api_v1alpha2.Namespace(ns)
+	typedNs := gwv1alpha2.Namespace(ns)
 	prtocol := "HTTP"
 	protocolVersion := "HTTP2"
 	trueBool := true
-	targetGroupPolicyHappyPath := &v1alpha1.TargetGroupPolicy{
+	targetGroupPolicyHappyPath := &anv1alpha1.TargetGroupPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-target-group-policy",
 			Namespace: ns,
 		},
-		Spec: v1alpha1.TargetGroupPolicySpec{
-			TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
+		Spec: anv1alpha1.TargetGroupPolicySpec{
+			TargetRef: &gwv1alpha2.PolicyTargetReference{
 				Group:     corev1.GroupName,
 				Name:      "svc-1",
 				Kind:      "Service",
@@ -50,32 +50,32 @@ func Test_getAttachedPolicy(t *testing.T) {
 		},
 	}
 
-	policyTargetRefSectionNil := targetGroupPolicyHappyPath.DeepCopyObject().(*v1alpha1.TargetGroupPolicy)
+	policyTargetRefSectionNil := targetGroupPolicyHappyPath.DeepCopyObject().(*anv1alpha1.TargetGroupPolicy)
 	policyTargetRefSectionNil.Spec.TargetRef = nil
 
-	policyTargetRefKindWrong := targetGroupPolicyHappyPath.DeepCopyObject().(*v1alpha1.TargetGroupPolicy)
+	policyTargetRefKindWrong := targetGroupPolicyHappyPath.DeepCopyObject().(*anv1alpha1.TargetGroupPolicy)
 	policyTargetRefKindWrong.Spec.TargetRef.Kind = "ServiceImport"
 
-	notRelatedTargetGroupPolicy := targetGroupPolicyHappyPath.DeepCopyObject().(*v1alpha1.TargetGroupPolicy)
+	notRelatedTargetGroupPolicy := targetGroupPolicyHappyPath.DeepCopyObject().(*anv1alpha1.TargetGroupPolicy)
 	notRelatedTargetGroupPolicy.Spec.TargetRef.Name = "another-svc"
 
-	vpcAssociationPolicyHappyPath := &v1alpha1.VpcAssociationPolicy{
+	vpcAssociationPolicyHappyPath := &anv1alpha1.VpcAssociationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-vpc-association-policy",
 			Namespace: ns,
 		},
-		Spec: v1alpha1.VpcAssociationPolicySpec{
-			TargetRef: &gateway_api_v1alpha2.PolicyTargetReference{
-				Group: gateway_api_v1alpha2.GroupName,
+		Spec: anv1alpha1.VpcAssociationPolicySpec{
+			TargetRef: &gwv1alpha2.PolicyTargetReference{
+				Group: gwv1alpha2.GroupName,
 				Name:  "gw-1",
 				Kind:  "Gateway",
 			},
-			SecurityGroupIds: []v1alpha1.SecurityGroupId{"sg-1", "sg-2"},
+			SecurityGroupIds: []anv1alpha1.SecurityGroupId{"sg-1", "sg-2"},
 			AssociateWithVpc: &trueBool,
 		},
 	}
 
-	notRelatedVpcAssociationPolicy := vpcAssociationPolicyHappyPath.DeepCopyObject().(*v1alpha1.VpcAssociationPolicy)
+	notRelatedVpcAssociationPolicy := vpcAssociationPolicyHappyPath.DeepCopyObject().(*anv1alpha1.VpcAssociationPolicy)
 	notRelatedVpcAssociationPolicy.Spec.TargetRef.Name = "another-gw"
 
 	var tests = []testCase{
@@ -86,7 +86,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "svc-1",
 				},
-				policy: &v1alpha1.TargetGroupPolicy{},
+				policy: &anv1alpha1.TargetGroupPolicy{},
 			},
 			expectedK8sClientReturnedPolicy: targetGroupPolicyHappyPath,
 			want:                            targetGroupPolicyHappyPath,
@@ -99,7 +99,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "another-svc",
 				},
-				policy: &v1alpha1.TargetGroupPolicy{},
+				policy: &anv1alpha1.TargetGroupPolicy{},
 			},
 			want:                            nil,
 			expectedK8sClientReturnedPolicy: targetGroupPolicyHappyPath,
@@ -112,7 +112,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "svc-1",
 				},
-				policy: &v1alpha1.TargetGroupPolicy{},
+				policy: &anv1alpha1.TargetGroupPolicy{},
 			},
 			want:                            nil,
 			expectedK8sClientReturnedPolicy: nil,
@@ -125,7 +125,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "svc-1",
 				},
-				policy: &v1alpha1.TargetGroupPolicy{},
+				policy: &anv1alpha1.TargetGroupPolicy{},
 			},
 			expectedK8sClientReturnedPolicy: policyTargetRefSectionNil,
 			want:                            nil,
@@ -138,7 +138,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "svc-1",
 				},
-				policy: &v1alpha1.TargetGroupPolicy{},
+				policy: &anv1alpha1.TargetGroupPolicy{},
 			},
 			expectedK8sClientReturnedPolicy: policyTargetRefKindWrong,
 			want:                            nil,
@@ -151,7 +151,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "gw-1",
 				},
-				policy: &v1alpha1.VpcAssociationPolicy{},
+				policy: &anv1alpha1.VpcAssociationPolicy{},
 			},
 			expectedK8sClientReturnedPolicy: vpcAssociationPolicyHappyPath,
 			want:                            vpcAssociationPolicyHappyPath,
@@ -164,7 +164,7 @@ func Test_getAttachedPolicy(t *testing.T) {
 					Namespace: ns,
 					Name:      "gw-1",
 				},
-				policy: &v1alpha1.VpcAssociationPolicy{},
+				policy: &anv1alpha1.VpcAssociationPolicy{},
 			},
 			expectedK8sClientReturnedPolicy: nil,
 			want:                            nil,
@@ -176,37 +176,37 @@ func Test_getAttachedPolicy(t *testing.T) {
 	ctx := context.TODO()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k8sClient := mock_client.NewMockClient(c)
+			mockK8sClient := mock_client.NewMockClient(c)
 
-			if _, ok := tt.args.policy.(*v1alpha1.TargetGroupPolicy); ok {
-				k8sClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, list *v1alpha1.TargetGroupPolicyList, arg3 ...interface{}) error {
+			if _, ok := tt.args.policy.(*anv1alpha1.TargetGroupPolicy); ok {
+				mockK8sClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list *anv1alpha1.TargetGroupPolicyList, arg3 ...interface{}) error {
 						list.Items = append(list.Items, *notRelatedTargetGroupPolicy)
 						if tt.expectedK8sClientReturnedPolicy != nil {
-							policy := tt.expectedK8sClientReturnedPolicy.(*v1alpha1.TargetGroupPolicy)
+							policy := tt.expectedK8sClientReturnedPolicy.(*anv1alpha1.TargetGroupPolicy)
 							list.Items = append(list.Items, *policy)
 						}
 						return nil
 					})
-			} else if _, ok := tt.args.policy.(*v1alpha1.VpcAssociationPolicy); ok {
-				k8sClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, list *v1alpha1.VpcAssociationPolicyList, arg3 ...interface{}) error {
+			} else if _, ok := tt.args.policy.(*anv1alpha1.VpcAssociationPolicy); ok {
+				mockK8sClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list *anv1alpha1.VpcAssociationPolicyList, arg3 ...interface{}) error {
 						list.Items = append(list.Items, *notRelatedVpcAssociationPolicy)
 						if tt.expectedK8sClientReturnedPolicy != nil {
-							policy := tt.expectedK8sClientReturnedPolicy.(*v1alpha1.VpcAssociationPolicy)
+							policy := tt.expectedK8sClientReturnedPolicy.(*anv1alpha1.VpcAssociationPolicy)
 							list.Items = append(list.Items, *policy)
 						}
 						return nil
 					})
 			}
 
-			got, err := GetAttachedPolicy(ctx, k8sClient, tt.args.refObjNamespacedName, tt.args.policy)
+			got, err := GetAttachedPolicy(ctx, mockK8sClient, tt.args.refObjNamespacedName, tt.args.policy)
 			if tt.expectPolicyNotFound {
 				assert.Nil(t, err)
 				assert.Nil(t, got)
 				return
 			}
-			assert.Equalf(t, tt.want, got, "GetAttachedPolicy(%v, %v, %v, %v)", ctx, k8sClient, tt.args.refObjNamespacedName, tt.args.policy)
+			assert.Equalf(t, tt.want, got, "GetAttachedPolicy(%v, %v, %v, %v)", ctx, mockK8sClient, tt.args.refObjNamespacedName, tt.args.policy)
 		})
 	}
 }

--- a/pkg/model/core/grpcroute_test.go
+++ b/pkg/model/core/grpcroute_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/pointer"
-	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gateway_api_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestGRPCRouteSpec_Equals(t *testing.T) {
-	name1 := gateway_api_v1alpha2.ObjectName("name1")
-	name2 := gateway_api_v1alpha2.ObjectName("name2")
+	name1 := gwv1alpha2.ObjectName("name1")
+	name2 := gwv1alpha2.ObjectName("name2")
 
 	tests := []struct {
 		routeSpec1  *GRPCRouteSpec
@@ -27,27 +27,27 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gateway_api_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1alpha2.ParentReference{
+				s: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
+						ParentRefs: []gwv1alpha2.ParentReference{
 							{},
 						},
 					},
-					Hostnames: []gateway_api_v1alpha2.Hostname{"example.com"},
-					Rules: []gateway_api_v1alpha2.GRPCRouteRule{
+					Hostnames: []gwv1alpha2.Hostname{"example.com"},
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{},
 					},
 				},
 			},
 			routeSpec2: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gateway_api_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1alpha2.ParentReference{
+				s: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
+						ParentRefs: []gwv1alpha2.ParentReference{
 							{},
 						},
 					},
-					Hostnames: []gateway_api_v1alpha2.Hostname{"example.com"},
-					Rules: []gateway_api_v1alpha2.GRPCRouteRule{
+					Hostnames: []gwv1alpha2.Hostname{"example.com"},
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{},
 					},
 				},
@@ -63,16 +63,16 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gateway_api_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1alpha2.ParentReference{{Name: "parent1"}},
+				s: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
+						ParentRefs: []gwv1alpha2.ParentReference{{Name: "parent1"}},
 					},
 				},
 			},
 			routeSpec2: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gateway_api_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1alpha2.ParentReference{{Name: "parent2"}},
+				s: gwv1alpha2.GRPCRouteSpec{
+					CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
+						ParentRefs: []gwv1alpha2.ParentReference{{Name: "parent2"}},
 					},
 				},
 			},
@@ -81,13 +81,13 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					Hostnames: []gateway_api_v1alpha2.Hostname{"example1.com"},
+				s: gwv1alpha2.GRPCRouteSpec{
+					Hostnames: []gwv1alpha2.Hostname{"example1.com"},
 				},
 			},
 			routeSpec2: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					Hostnames: []gateway_api_v1alpha2.Hostname{"example2.com"},
+				s: gwv1alpha2.GRPCRouteSpec{
+					Hostnames: []gwv1alpha2.Hostname{"example2.com"},
 				},
 			},
 			expectEqual: false,
@@ -95,16 +95,16 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					Rules: []gateway_api_v1alpha2.GRPCRouteRule{
+				s: gwv1alpha2.GRPCRouteSpec{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{},
 						{},
 					},
 				},
 			},
 			routeSpec2: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					Rules: []gateway_api_v1alpha2.GRPCRouteRule{
+				s: gwv1alpha2.GRPCRouteSpec{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{},
 					},
 				},
@@ -114,13 +114,13 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					Rules: []gateway_api_v1alpha2.GRPCRouteRule{
+				s: gwv1alpha2.GRPCRouteSpec{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
-									BackendRef: gateway_api_v1alpha2.BackendRef{
-										BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+									BackendRef: gwv1alpha2.BackendRef{
+										BackendObjectReference: gwv1alpha2.BackendObjectReference{
 											Name: name1,
 										},
 									},
@@ -131,13 +131,13 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 				},
 			},
 			routeSpec2: &GRPCRouteSpec{
-				s: gateway_api_v1alpha2.GRPCRouteSpec{
-					Rules: []gateway_api_v1alpha2.GRPCRouteRule{
+				s: gwv1alpha2.GRPCRouteSpec{
+					Rules: []gwv1alpha2.GRPCRouteRule{
 						{
-							BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+							BackendRefs: []gwv1alpha2.GRPCBackendRef{
 								{
-									BackendRef: gateway_api_v1alpha2.BackendRef{
-										BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+									BackendRef: gwv1alpha2.BackendRef{
+										BackendObjectReference: gwv1alpha2.BackendObjectReference{
 											Name: name2,
 										},
 									},
@@ -159,13 +159,15 @@ func TestGRPCRouteSpec_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.routeSpec1.Equals(test.routeSpec2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.routeSpec1.Equals(test.routeSpec2), test.description)
+		})
 	}
 }
 
 func TestGRPCRouteRule_Equals(t *testing.T) {
-	grpcMethodMatchType1 := gateway_api_v1alpha2.GRPCMethodMatchExact
-	grpcMethodMatchType2 := gateway_api_v1alpha2.GRPCMethodMatchRegularExpression
+	grpcMethodMatchType1 := gwv1alpha2.GRPCMethodMatchExact
+	grpcMethodMatchType2 := gwv1alpha2.GRPCMethodMatchRegularExpression
 
 	tests := []struct {
 		routeRule1  *GRPCRouteRule
@@ -181,21 +183,21 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+				r: gwv1alpha2.GRPCRouteRule{
+					BackendRefs: []gwv1alpha2.GRPCBackendRef{
 						{},
 					},
-					Matches: []gateway_api_v1alpha2.GRPCRouteMatch{
+					Matches: []gwv1alpha2.GRPCRouteMatch{
 						{},
 					},
 				},
 			},
 			routeRule2: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+				r: gwv1alpha2.GRPCRouteRule{
+					BackendRefs: []gwv1alpha2.GRPCBackendRef{
 						{},
 					},
-					Matches: []gateway_api_v1alpha2.GRPCRouteMatch{
+					Matches: []gwv1alpha2.GRPCRouteMatch{
 						{},
 					},
 				},
@@ -211,16 +213,16 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+				r: gwv1alpha2.GRPCRouteRule{
+					BackendRefs: []gwv1alpha2.GRPCBackendRef{
 						{},
 						{},
 					},
 				},
 			},
 			routeRule2: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+				r: gwv1alpha2.GRPCRouteRule{
+					BackendRefs: []gwv1alpha2.GRPCBackendRef{
 						{},
 					},
 				},
@@ -230,10 +232,10 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+				r: gwv1alpha2.GRPCRouteRule{
+					BackendRefs: []gwv1alpha2.GRPCBackendRef{
 						{
-							BackendRef: gateway_api_v1alpha2.BackendRef{
+							BackendRef: gwv1alpha2.BackendRef{
 								Weight: pointer.Int32(1),
 							},
 						},
@@ -241,10 +243,10 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 				},
 			},
 			routeRule2: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					BackendRefs: []gateway_api_v1alpha2.GRPCBackendRef{
+				r: gwv1alpha2.GRPCRouteRule{
+					BackendRefs: []gwv1alpha2.GRPCBackendRef{
 						{
-							BackendRef: gateway_api_v1alpha2.BackendRef{
+							BackendRef: gwv1alpha2.BackendRef{
 								Weight: pointer.Int32(2),
 							},
 						},
@@ -256,16 +258,16 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					Matches: []gateway_api_v1alpha2.GRPCRouteMatch{
+				r: gwv1alpha2.GRPCRouteRule{
+					Matches: []gwv1alpha2.GRPCRouteMatch{
 						{},
 						{},
 					},
 				},
 			},
 			routeRule2: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					Matches: []gateway_api_v1alpha2.GRPCRouteMatch{
+				r: gwv1alpha2.GRPCRouteRule{
+					Matches: []gwv1alpha2.GRPCRouteMatch{
 						{},
 					},
 				},
@@ -275,10 +277,10 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					Matches: []gateway_api_v1alpha2.GRPCRouteMatch{
+				r: gwv1alpha2.GRPCRouteRule{
+					Matches: []gwv1alpha2.GRPCRouteMatch{
 						{
-							Method: &gateway_api_v1alpha2.GRPCMethodMatch{
+							Method: &gwv1alpha2.GRPCMethodMatch{
 								Type: &grpcMethodMatchType1,
 							},
 						},
@@ -286,10 +288,10 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 				},
 			},
 			routeRule2: &GRPCRouteRule{
-				r: gateway_api_v1alpha2.GRPCRouteRule{
-					Matches: []gateway_api_v1alpha2.GRPCRouteMatch{
+				r: gwv1alpha2.GRPCRouteRule{
+					Matches: []gwv1alpha2.GRPCRouteMatch{
 						{
-							Method: &gateway_api_v1alpha2.GRPCMethodMatch{
+							Method: &gwv1alpha2.GRPCMethodMatch{
 								Type: &grpcMethodMatchType2,
 							},
 						},
@@ -308,23 +310,25 @@ func TestGRPCRouteRule_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.routeRule1.Equals(test.routeRule2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.routeRule1.Equals(test.routeRule2), test.description)
+		})
 	}
 }
 
 func TestGRPCBackendRef_Equals(t *testing.T) {
 	weight1 := pointer.Int32(1)
 	weight2 := pointer.Int32(2)
-	group1 := gateway_api_v1alpha2.Group("group1")
-	group2 := gateway_api_v1alpha2.Group("group2")
-	kind1 := gateway_api_v1alpha2.Kind("kind1")
-	kind2 := gateway_api_v1alpha2.Kind("kind2")
-	name1 := gateway_api_v1alpha2.ObjectName("name1")
-	name2 := gateway_api_v1alpha2.ObjectName("name2")
-	namespace1 := gateway_api_v1alpha2.Namespace("namespace1")
-	namespace2 := gateway_api_v1alpha2.Namespace("namespace2")
-	port1 := gateway_api_v1alpha2.PortNumber(1)
-	port2 := gateway_api_v1alpha2.PortNumber(2)
+	group1 := gwv1alpha2.Group("group1")
+	group2 := gwv1alpha2.Group("group2")
+	kind1 := gwv1alpha2.Kind("kind1")
+	kind2 := gwv1alpha2.Kind("kind2")
+	name1 := gwv1alpha2.ObjectName("name1")
+	name2 := gwv1alpha2.ObjectName("name2")
+	namespace1 := gwv1alpha2.Namespace("namespace1")
+	namespace2 := gwv1alpha2.Namespace("namespace2")
+	port1 := gwv1alpha2.PortNumber(1)
+	port2 := gwv1alpha2.PortNumber(2)
 
 	tests := []struct {
 		backendRef1 *GRPCBackendRef
@@ -340,10 +344,10 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
 						Weight: weight1,
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Group:     &group1,
 							Kind:      &kind1,
 							Name:      name1,
@@ -354,10 +358,10 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
 						Weight: weight1,
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Group:     &group1,
 							Kind:      &kind1,
 							Name:      name1,
@@ -378,15 +382,15 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
 						Weight: weight1,
 					},
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
 						Weight: weight2,
 					},
 				},
@@ -396,18 +400,18 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Group: &group1,
 						},
 					},
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Group: &group2,
 						},
 					},
@@ -418,18 +422,18 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Kind: &kind1,
 						},
 					},
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Kind: &kind2,
 						},
 					},
@@ -440,18 +444,18 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Name: name1,
 						},
 					},
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Name: name2,
 						},
 					},
@@ -462,18 +466,18 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Namespace: &namespace1,
 						},
 					},
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Namespace: &namespace2,
 						},
 					},
@@ -484,18 +488,18 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Port: &port1,
 						},
 					},
 				},
 			},
 			backendRef2: &GRPCBackendRef{
-				r: gateway_api_v1alpha2.GRPCBackendRef{
-					BackendRef: gateway_api_v1alpha2.BackendRef{
-						BackendObjectReference: gateway_api_v1alpha2.BackendObjectReference{
+				r: gwv1alpha2.GRPCBackendRef{
+					BackendRef: gwv1alpha2.BackendRef{
+						BackendObjectReference: gwv1alpha2.BackendObjectReference{
 							Port: &port2,
 						},
 					},
@@ -513,15 +517,17 @@ func TestGRPCBackendRef_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.backendRef1.Equals(test.backendRef2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.backendRef1.Equals(test.backendRef2), test.description)
+		})
 	}
 }
 
 func TestGRPCHeaderMatch_Equals(t *testing.T) {
-	headerMatchType1 := gateway_api_v1beta1.HeaderMatchExact
-	headerMatchType2 := gateway_api_v1beta1.HeaderMatchRegularExpression
-	name1 := gateway_api_v1alpha2.GRPCHeaderName("name1")
-	name2 := gateway_api_v1alpha2.GRPCHeaderName("name2")
+	headerMatchType1 := gwv1beta1.HeaderMatchExact
+	headerMatchType2 := gwv1beta1.HeaderMatchRegularExpression
+	name1 := gwv1alpha2.GRPCHeaderName("name1")
+	name2 := gwv1alpha2.GRPCHeaderName("name2")
 	value1 := "value1"
 	value2 := "value2"
 
@@ -539,14 +545,14 @@ func TestGRPCHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Type:  &headerMatchType1,
 					Name:  name1,
 					Value: value1,
 				},
 			},
 			headerMatch2: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Type:  &headerMatchType1,
 					Name:  name1,
 					Value: value1,
@@ -563,12 +569,12 @@ func TestGRPCHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Type: &headerMatchType1,
 				},
 			},
 			headerMatch2: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Type: &headerMatchType2,
 				},
 			},
@@ -577,12 +583,12 @@ func TestGRPCHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Name: name1,
 				},
 			},
 			headerMatch2: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Name: name2,
 				},
 			},
@@ -591,12 +597,12 @@ func TestGRPCHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Value: value1,
 				},
 			},
 			headerMatch2: &GRPCHeaderMatch{
-				m: gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCHeaderMatch{
 					Value: value2,
 				},
 			},
@@ -612,15 +618,17 @@ func TestGRPCHeaderMatch_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.headerMatch1.Equals(test.headerMatch2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.headerMatch1.Equals(test.headerMatch2), test.description)
+		})
 	}
 }
 
 func TestGRPCRouteMatch_Equals(t *testing.T) {
-	grpcMethodMatchType1 := gateway_api_v1alpha2.GRPCMethodMatchExact
-	grpcMethodMatchType2 := gateway_api_v1alpha2.GRPCMethodMatchRegularExpression
-	headerMatchType1 := gateway_api_v1beta1.HeaderMatchExact
-	headerMatchType2 := gateway_api_v1beta1.HeaderMatchRegularExpression
+	grpcMethodMatchType1 := gwv1alpha2.GRPCMethodMatchExact
+	grpcMethodMatchType2 := gwv1alpha2.GRPCMethodMatchRegularExpression
+	headerMatchType1 := gwv1beta1.HeaderMatchExact
+	headerMatchType2 := gwv1beta1.HeaderMatchRegularExpression
 
 	tests := []struct {
 		routeMatch1 *GRPCRouteMatch
@@ -636,17 +644,17 @@ func TestGRPCRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Method: &gateway_api_v1alpha2.GRPCMethodMatch{},
-					Headers: []gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Method: &gwv1alpha2.GRPCMethodMatch{},
+					Headers: []gwv1alpha2.GRPCHeaderMatch{
 						{},
 					},
 				},
 			},
 			routeMatch2: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Method: &gateway_api_v1alpha2.GRPCMethodMatch{},
-					Headers: []gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Method: &gwv1alpha2.GRPCMethodMatch{},
+					Headers: []gwv1alpha2.GRPCHeaderMatch{
 						{},
 					},
 				},
@@ -662,15 +670,15 @@ func TestGRPCRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Method: &gateway_api_v1alpha2.GRPCMethodMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Method: &gwv1alpha2.GRPCMethodMatch{
 						Type: &grpcMethodMatchType1,
 					},
 				},
 			},
 			routeMatch2: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Method: &gateway_api_v1alpha2.GRPCMethodMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Method: &gwv1alpha2.GRPCMethodMatch{
 						Type: &grpcMethodMatchType2,
 					},
 				},
@@ -680,16 +688,16 @@ func TestGRPCRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Headers: []gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Headers: []gwv1alpha2.GRPCHeaderMatch{
 						{},
 						{},
 					},
 				},
 			},
 			routeMatch2: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Headers: []gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Headers: []gwv1alpha2.GRPCHeaderMatch{
 						{},
 					},
 				},
@@ -699,8 +707,8 @@ func TestGRPCRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Headers: []gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Headers: []gwv1alpha2.GRPCHeaderMatch{
 						{
 							Type: &headerMatchType1,
 						},
@@ -708,8 +716,8 @@ func TestGRPCRouteMatch_Equals(t *testing.T) {
 				},
 			},
 			routeMatch2: &GRPCRouteMatch{
-				m: gateway_api_v1alpha2.GRPCRouteMatch{
-					Headers: []gateway_api_v1alpha2.GRPCHeaderMatch{
+				m: gwv1alpha2.GRPCRouteMatch{
+					Headers: []gwv1alpha2.GRPCHeaderMatch{
 						{
 							Type: &headerMatchType2,
 						},
@@ -728,6 +736,8 @@ func TestGRPCRouteMatch_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.routeMatch1.Equals(test.routeMatch2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.routeMatch1.Equals(test.routeMatch2), test.description)
+		})
 	}
 }

--- a/pkg/model/core/httproute_test.go
+++ b/pkg/model/core/httproute_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/pointer"
-	gateway_api_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestHTTPRouteSpec_Equals(t *testing.T) {
-	name1 := gateway_api_v1beta1.ObjectName("name1")
-	name2 := gateway_api_v1beta1.ObjectName("name2")
+	name1 := gwv1beta1.ObjectName("name1")
+	name2 := gwv1beta1.ObjectName("name2")
 
 	tests := []struct {
 		routeSpec1  *HTTPRouteSpec
@@ -26,27 +26,27 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api_v1beta1.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1beta1.ParentReference{
+				s: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{},
 						},
 					},
-					Hostnames: []gateway_api_v1beta1.Hostname{"example.com"},
-					Rules: []gateway_api_v1beta1.HTTPRouteRule{
+					Hostnames: []gwv1beta1.Hostname{"example.com"},
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{},
 					},
 				},
 			},
 			routeSpec2: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api_v1beta1.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1beta1.ParentReference{
+				s: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{
 							{},
 						},
 					},
-					Hostnames: []gateway_api_v1beta1.Hostname{"example.com"},
-					Rules: []gateway_api_v1beta1.HTTPRouteRule{
+					Hostnames: []gwv1beta1.Hostname{"example.com"},
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{},
 					},
 				},
@@ -62,16 +62,16 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api_v1beta1.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1beta1.ParentReference{{Name: "parent1"}},
+				s: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{{Name: "parent1"}},
 					},
 				},
 			},
 			routeSpec2: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gateway_api_v1beta1.CommonRouteSpec{
-						ParentRefs: []gateway_api_v1beta1.ParentReference{{Name: "parent2"}},
+				s: gwv1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1beta1.CommonRouteSpec{
+						ParentRefs: []gwv1beta1.ParentReference{{Name: "parent2"}},
 					},
 				},
 			},
@@ -80,13 +80,13 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					Hostnames: []gateway_api_v1beta1.Hostname{"example1.com"},
+				s: gwv1beta1.HTTPRouteSpec{
+					Hostnames: []gwv1beta1.Hostname{"example1.com"},
 				},
 			},
 			routeSpec2: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					Hostnames: []gateway_api_v1beta1.Hostname{"example2.com"},
+				s: gwv1beta1.HTTPRouteSpec{
+					Hostnames: []gwv1beta1.Hostname{"example2.com"},
 				},
 			},
 			expectEqual: false,
@@ -94,16 +94,16 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					Rules: []gateway_api_v1beta1.HTTPRouteRule{
+				s: gwv1beta1.HTTPRouteSpec{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{},
 						{},
 					},
 				},
 			},
 			routeSpec2: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					Rules: []gateway_api_v1beta1.HTTPRouteRule{
+				s: gwv1beta1.HTTPRouteSpec{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{},
 					},
 				},
@@ -113,13 +113,13 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 		},
 		{
 			routeSpec1: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					Rules: []gateway_api_v1beta1.HTTPRouteRule{
+				s: gwv1beta1.HTTPRouteSpec{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api_v1beta1.BackendRef{
-										BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name: name1,
 										},
 									},
@@ -130,13 +130,13 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 				},
 			},
 			routeSpec2: &HTTPRouteSpec{
-				s: gateway_api_v1beta1.HTTPRouteSpec{
-					Rules: []gateway_api_v1beta1.HTTPRouteRule{
+				s: gwv1beta1.HTTPRouteSpec{
+					Rules: []gwv1beta1.HTTPRouteRule{
 						{
-							BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+							BackendRefs: []gwv1beta1.HTTPBackendRef{
 								{
-									BackendRef: gateway_api_v1beta1.BackendRef{
-										BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+									BackendRef: gwv1beta1.BackendRef{
+										BackendObjectReference: gwv1beta1.BackendObjectReference{
 											Name: name2,
 										},
 									},
@@ -158,13 +158,15 @@ func TestHTTPRouteSpec_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.routeSpec1.Equals(test.routeSpec2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.routeSpec1.Equals(test.routeSpec2), test.description)
+		})
 	}
 }
 
 func TestHTTPRouteRule_Equals(t *testing.T) {
-	httpMethod1 := gateway_api_v1beta1.HTTPMethodPost
-	httpMethod2 := gateway_api_v1beta1.HTTPMethodGet
+	httpMethod1 := gwv1beta1.HTTPMethodPost
+	httpMethod2 := gwv1beta1.HTTPMethodGet
 
 	tests := []struct {
 		routeRule1  *HTTPRouteRule
@@ -180,21 +182,21 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+				r: gwv1beta1.HTTPRouteRule{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{},
 					},
-					Matches: []gateway_api_v1beta1.HTTPRouteMatch{
+					Matches: []gwv1beta1.HTTPRouteMatch{
 						{},
 					},
 				},
 			},
 			routeRule2: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+				r: gwv1beta1.HTTPRouteRule{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{},
 					},
-					Matches: []gateway_api_v1beta1.HTTPRouteMatch{
+					Matches: []gwv1beta1.HTTPRouteMatch{
 						{},
 					},
 				},
@@ -210,16 +212,16 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+				r: gwv1beta1.HTTPRouteRule{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{},
 						{},
 					},
 				},
 			},
 			routeRule2: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+				r: gwv1beta1.HTTPRouteRule{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{},
 					},
 				},
@@ -229,10 +231,10 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+				r: gwv1beta1.HTTPRouteRule{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{
-							BackendRef: gateway_api_v1beta1.BackendRef{
+							BackendRef: gwv1beta1.BackendRef{
 								Weight: pointer.Int32(1),
 							},
 						},
@@ -240,10 +242,10 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 				},
 			},
 			routeRule2: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					BackendRefs: []gateway_api_v1beta1.HTTPBackendRef{
+				r: gwv1beta1.HTTPRouteRule{
+					BackendRefs: []gwv1beta1.HTTPBackendRef{
 						{
-							BackendRef: gateway_api_v1beta1.BackendRef{
+							BackendRef: gwv1beta1.BackendRef{
 								Weight: pointer.Int32(2),
 							},
 						},
@@ -255,16 +257,16 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					Matches: []gateway_api_v1beta1.HTTPRouteMatch{
+				r: gwv1beta1.HTTPRouteRule{
+					Matches: []gwv1beta1.HTTPRouteMatch{
 						{},
 						{},
 					},
 				},
 			},
 			routeRule2: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					Matches: []gateway_api_v1beta1.HTTPRouteMatch{
+				r: gwv1beta1.HTTPRouteRule{
+					Matches: []gwv1beta1.HTTPRouteMatch{
 						{},
 					},
 				},
@@ -274,8 +276,8 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 		},
 		{
 			routeRule1: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					Matches: []gateway_api_v1beta1.HTTPRouteMatch{
+				r: gwv1beta1.HTTPRouteRule{
+					Matches: []gwv1beta1.HTTPRouteMatch{
 						{
 							Method: &httpMethod1,
 						},
@@ -283,8 +285,8 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 				},
 			},
 			routeRule2: &HTTPRouteRule{
-				r: gateway_api_v1beta1.HTTPRouteRule{
-					Matches: []gateway_api_v1beta1.HTTPRouteMatch{
+				r: gwv1beta1.HTTPRouteRule{
+					Matches: []gwv1beta1.HTTPRouteMatch{
 						{
 							Method: &httpMethod2,
 						},
@@ -303,23 +305,25 @@ func TestHTTPRouteRule_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.routeRule1.Equals(test.routeRule2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.routeRule1.Equals(test.routeRule2), test.description)
+		})
 	}
 }
 
 func TestHTTPBackendRef_Equals(t *testing.T) {
 	weight1 := pointer.Int32(1)
 	weight2 := pointer.Int32(2)
-	group1 := gateway_api_v1beta1.Group("group1")
-	group2 := gateway_api_v1beta1.Group("group2")
-	kind1 := gateway_api_v1beta1.Kind("kind1")
-	kind2 := gateway_api_v1beta1.Kind("kind2")
-	name1 := gateway_api_v1beta1.ObjectName("name1")
-	name2 := gateway_api_v1beta1.ObjectName("name2")
-	namespace1 := gateway_api_v1beta1.Namespace("namespace1")
-	namespace2 := gateway_api_v1beta1.Namespace("namespace2")
-	port1 := gateway_api_v1beta1.PortNumber(1)
-	port2 := gateway_api_v1beta1.PortNumber(2)
+	group1 := gwv1beta1.Group("group1")
+	group2 := gwv1beta1.Group("group2")
+	kind1 := gwv1beta1.Kind("kind1")
+	kind2 := gwv1beta1.Kind("kind2")
+	name1 := gwv1beta1.ObjectName("name1")
+	name2 := gwv1beta1.ObjectName("name2")
+	namespace1 := gwv1beta1.Namespace("namespace1")
+	namespace2 := gwv1beta1.Namespace("namespace2")
+	port1 := gwv1beta1.PortNumber(1)
+	port2 := gwv1beta1.PortNumber(2)
 
 	tests := []struct {
 		backendRef1 *HTTPBackendRef
@@ -335,10 +339,10 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
 						Weight: weight1,
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Group:     &group1,
 							Kind:      &kind1,
 							Name:      name1,
@@ -349,10 +353,10 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
 						Weight: weight1,
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Group:     &group1,
 							Kind:      &kind1,
 							Name:      name1,
@@ -373,15 +377,15 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
 						Weight: weight1,
 					},
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
 						Weight: weight2,
 					},
 				},
@@ -391,18 +395,18 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Group: &group1,
 						},
 					},
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Group: &group2,
 						},
 					},
@@ -413,18 +417,18 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Kind: &kind1,
 						},
 					},
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Kind: &kind2,
 						},
 					},
@@ -435,18 +439,18 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Name: name1,
 						},
 					},
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Name: name2,
 						},
 					},
@@ -457,18 +461,18 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Namespace: &namespace1,
 						},
 					},
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Namespace: &namespace2,
 						},
 					},
@@ -479,18 +483,18 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 		},
 		{
 			backendRef1: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Port: &port1,
 						},
 					},
 				},
 			},
 			backendRef2: &HTTPBackendRef{
-				r: gateway_api_v1beta1.HTTPBackendRef{
-					BackendRef: gateway_api_v1beta1.BackendRef{
-						BackendObjectReference: gateway_api_v1beta1.BackendObjectReference{
+				r: gwv1beta1.HTTPBackendRef{
+					BackendRef: gwv1beta1.BackendRef{
+						BackendObjectReference: gwv1beta1.BackendObjectReference{
 							Port: &port2,
 						},
 					},
@@ -508,15 +512,17 @@ func TestHTTPBackendRef_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.backendRef1.Equals(test.backendRef2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.backendRef1.Equals(test.backendRef2), test.description)
+		})
 	}
 }
 
 func TestHTTPHeaderMatch_Equals(t *testing.T) {
-	headerMatchType1 := gateway_api_v1beta1.HeaderMatchExact
-	headerMatchType2 := gateway_api_v1beta1.HeaderMatchRegularExpression
-	name1 := gateway_api_v1beta1.HTTPHeaderName("name1")
-	name2 := gateway_api_v1beta1.HTTPHeaderName("name2")
+	headerMatchType1 := gwv1beta1.HeaderMatchExact
+	headerMatchType2 := gwv1beta1.HeaderMatchRegularExpression
+	name1 := gwv1beta1.HTTPHeaderName("name1")
+	name2 := gwv1beta1.HTTPHeaderName("name2")
 	value1 := "value1"
 	value2 := "value2"
 
@@ -534,14 +540,14 @@ func TestHTTPHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Type:  &headerMatchType1,
 					Name:  name1,
 					Value: value1,
 				},
 			},
 			headerMatch2: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Type:  &headerMatchType1,
 					Name:  name1,
 					Value: value1,
@@ -558,12 +564,12 @@ func TestHTTPHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Type: &headerMatchType1,
 				},
 			},
 			headerMatch2: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Type: &headerMatchType2,
 				},
 			},
@@ -572,12 +578,12 @@ func TestHTTPHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Name: name1,
 				},
 			},
 			headerMatch2: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Name: name2,
 				},
 			},
@@ -586,12 +592,12 @@ func TestHTTPHeaderMatch_Equals(t *testing.T) {
 		},
 		{
 			headerMatch1: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Value: value1,
 				},
 			},
 			headerMatch2: &HTTPHeaderMatch{
-				m: gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPHeaderMatch{
 					Value: value2,
 				},
 			},
@@ -607,19 +613,21 @@ func TestHTTPHeaderMatch_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.headerMatch1.Equals(test.headerMatch2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.headerMatch1.Equals(test.headerMatch2), test.description)
+		})
 	}
 }
 
 func TestHTTPRouteMatch_Equals(t *testing.T) {
-	httpMethod1 := gateway_api_v1beta1.HTTPMethodPost
-	httpMethod2 := gateway_api_v1beta1.HTTPMethodGet
-	pathMatchType1 := gateway_api_v1beta1.PathMatchExact
-	pathMatchType2 := gateway_api_v1beta1.PathMatchPathPrefix
-	headerMatchType1 := gateway_api_v1beta1.HeaderMatchExact
-	headerMatchType2 := gateway_api_v1beta1.HeaderMatchRegularExpression
-	queryParamMatchType1 := gateway_api_v1beta1.QueryParamMatchExact
-	queryParamMatchType2 := gateway_api_v1beta1.QueryParamMatchRegularExpression
+	httpMethod1 := gwv1beta1.HTTPMethodPost
+	httpMethod2 := gwv1beta1.HTTPMethodGet
+	pathMatchType1 := gwv1beta1.PathMatchExact
+	pathMatchType2 := gwv1beta1.PathMatchPathPrefix
+	headerMatchType1 := gwv1beta1.HeaderMatchExact
+	headerMatchType2 := gwv1beta1.HeaderMatchRegularExpression
+	queryParamMatchType1 := gwv1beta1.QueryParamMatchExact
+	queryParamMatchType2 := gwv1beta1.QueryParamMatchRegularExpression
 
 	tests := []struct {
 		routeMatch1 *HTTPRouteMatch
@@ -635,24 +643,24 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Path: &gateway_api_v1beta1.HTTPPathMatch{},
-					Headers: []gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Path: &gwv1beta1.HTTPPathMatch{},
+					Headers: []gwv1beta1.HTTPHeaderMatch{
 						{},
 					},
-					QueryParams: []gateway_api_v1beta1.HTTPQueryParamMatch{
+					QueryParams: []gwv1beta1.HTTPQueryParamMatch{
 						{},
 					},
 					Method: &httpMethod1,
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Path: &gateway_api_v1beta1.HTTPPathMatch{},
-					Headers: []gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Path: &gwv1beta1.HTTPPathMatch{},
+					Headers: []gwv1beta1.HTTPHeaderMatch{
 						{},
 					},
-					QueryParams: []gateway_api_v1beta1.HTTPQueryParamMatch{
+					QueryParams: []gwv1beta1.HTTPQueryParamMatch{
 						{},
 					},
 					Method: &httpMethod1,
@@ -669,15 +677,15 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Path: &gateway_api_v1beta1.HTTPPathMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Path: &gwv1beta1.HTTPPathMatch{
 						Type: &pathMatchType1,
 					},
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Path: &gateway_api_v1beta1.HTTPPathMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Path: &gwv1beta1.HTTPPathMatch{
 						Type: &pathMatchType2,
 					},
 				},
@@ -687,16 +695,16 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Headers: []gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Headers: []gwv1beta1.HTTPHeaderMatch{
 						{},
 						{},
 					},
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Headers: []gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Headers: []gwv1beta1.HTTPHeaderMatch{
 						{},
 					},
 				},
@@ -706,8 +714,8 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Headers: []gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Headers: []gwv1beta1.HTTPHeaderMatch{
 						{
 							Type: &headerMatchType1,
 						},
@@ -715,8 +723,8 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					Headers: []gateway_api_v1beta1.HTTPHeaderMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					Headers: []gwv1beta1.HTTPHeaderMatch{
 						{
 							Type: &headerMatchType2,
 						},
@@ -728,16 +736,16 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					QueryParams: []gateway_api_v1beta1.HTTPQueryParamMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					QueryParams: []gwv1beta1.HTTPQueryParamMatch{
 						{},
 						{},
 					},
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					QueryParams: []gateway_api_v1beta1.HTTPQueryParamMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					QueryParams: []gwv1beta1.HTTPQueryParamMatch{
 						{},
 					},
 				},
@@ -747,8 +755,8 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					QueryParams: []gateway_api_v1beta1.HTTPQueryParamMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					QueryParams: []gwv1beta1.HTTPQueryParamMatch{
 						{
 							Type: &queryParamMatchType1,
 						},
@@ -756,8 +764,8 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
-					QueryParams: []gateway_api_v1beta1.HTTPQueryParamMatch{
+				m: gwv1beta1.HTTPRouteMatch{
+					QueryParams: []gwv1beta1.HTTPQueryParamMatch{
 						{
 							Type: &queryParamMatchType2,
 						},
@@ -769,12 +777,12 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 		},
 		{
 			routeMatch1: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
+				m: gwv1beta1.HTTPRouteMatch{
 					Method: &httpMethod1,
 				},
 			},
 			routeMatch2: &HTTPRouteMatch{
-				m: gateway_api_v1beta1.HTTPRouteMatch{
+				m: gwv1beta1.HTTPRouteMatch{
 					Method: &httpMethod2,
 				},
 			},
@@ -790,6 +798,8 @@ func TestHTTPRouteMatch_Equals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectEqual, test.routeMatch1.Equals(test.routeMatch2), test.description)
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expectEqual, test.routeMatch1.Equals(test.routeMatch2), test.description)
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Standardizes on use of ```t.Run``` for parameterized tests, standardizes imports, standardizes naming of mocked resources. No functional changes. Small update to developer cheat sheet. Also removed lingering references to "mesh".

**Testing done on this change**:
```└─[$] <git:(test-cleanup*)> [laptop] make presubmit
?   	github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1	[no test files]
ok  	github.com/aws/aws-application-networking-k8s/pkg/aws	0.441s	coverage: 24.2% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/aws/services	0.584s	coverage: 9.7% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/config	0.597s	coverage: 32.9% of statements
?   	github.com/aws/aws-application-networking-k8s/pkg/k8s	[no test files]
?   	github.com/aws/aws-application-networking-k8s/pkg/model/lattice	[no test files]
ok  	github.com/aws/aws-application-networking-k8s/pkg/deploy	0.854s	coverage: 19.4% of statements
?   	github.com/aws/aws-application-networking-k8s/pkg/runtime	[no test files]
?   	github.com/aws/aws-application-networking-k8s/pkg/utils	[no test files]
?   	github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog	[no test files]
?   	github.com/aws/aws-application-networking-k8s/pkg/utils/retry	[no test files]
?   	github.com/aws/aws-application-networking-k8s/pkg/utils/ttime	[no test files]
ok  	github.com/aws/aws-application-networking-k8s/pkg/deploy/externaldns	1.314s	coverage: 75.6% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice	1.153s	coverage: 84.7% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/gateway	1.615s	coverage: 77.7% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/latticestore	2.018s	coverage: 64.1% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/model/core	1.914s	coverage: 61.7% of statements
ok  	github.com/aws/aws-application-networking-k8s/pkg/model/core/graph	2.100s	coverage: 17.2% of statements
ok  	github.com/aws/aws-application-networking-k8s/controllers	0.638s	coverage: 0.0% of statements
ok  	github.com/aws/aws-application-networking-k8s/controllers/eventhandlers	0.963s	coverage: 53.5% of statements
```

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.