### PR TITLE
add default tags to all lattice resources

### DIFF
--- a/pkg/deploy/lattice/config_test.go
+++ b/pkg/deploy/lattice/config_test.go
@@ -1,0 +1,10 @@
+package lattice
+
+import pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+
+var TestCloudConfig = pkg_aws.CloudConfig{
+	VpcId:       "vpc-id",
+	AccountId:   "account-id",
+	Region:      "region",
+	ClusterName: "cluster",
+}

--- a/pkg/deploy/lattice/listener_manager.go
+++ b/pkg/deploy/lattice/listener_manager.go
@@ -104,7 +104,7 @@ func (d *defaultListenerManager) Create(
 		Port:              aws.Int64(listener.Spec.Port),
 		Protocol:          aws.String(listener.Spec.Protocol),
 		ServiceIdentifier: aws.String(*svc.Id),
-		Tags:              nil,
+		Tags:              d.cloud.DefaultTags(),
 	}
 
 	resp, err := d.cloud.Lattice().CreateListener(&listenerInput)

--- a/pkg/deploy/lattice/rule_manager.go
+++ b/pkg/deploy/lattice/rule_manager.go
@@ -242,6 +242,7 @@ func (r *defaultRuleManager) Create(ctx context.Context, rule *model.Rule) (mode
 		Name:              aws.String(ruleName),
 		Priority:          aws.Int64(ruleStatus.Priority),
 		ServiceIdentifier: aws.String(*latticeService.Id),
+		Tags:              r.cloud.DefaultTags(),
 	}
 
 	resp, err := r.cloud.Lattice().CreateRule(&ruleInput)

--- a/pkg/deploy/lattice/rule_manager_test.go
+++ b/pkg/deploy/lattice/rule_manager_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/latticestore"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
-	mocks_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 
 	"github.com/golang/mock/gomock"
@@ -528,12 +528,11 @@ func Test_CreateRule(t *testing.T) {
 			ctx := context.TODO()
 
 			mockLattice := mocks.NewMockLattice(c)
-			mockCloud := mocks_aws.NewMockCloud(c)
-			mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+			cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
 
 			latticeDataStore := latticestore.NewLatticeDataStore()
 
-			ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+			ruleManager := NewRuleManager(gwlog.FallbackLogger, cloud, latticeDataStore)
 
 			if !tt.noServiceID {
 				mockLattice.EXPECT().FindService(gomock.Any(), gomock.Any()).Return(
@@ -660,6 +659,7 @@ func Test_CreateRule(t *testing.T) {
 						Match: &vpclattice.RuleMatch{
 							HttpMatch: &httpMatch,
 						},
+						Tags: cloud.DefaultTags(),
 					}
 					ruleOutput := vpclattice.CreateRuleOutput{
 						Id: aws.String(ruleID),
@@ -754,12 +754,11 @@ func Test_UpdateRule(t *testing.T) {
 			ctx := context.TODO()
 
 			mockLattice := mocks.NewMockLattice(c)
-			mockCloud := mocks_aws.NewMockCloud(c)
-			mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+			cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
 
 			latticeDataStore := latticestore.NewLatticeDataStore()
 
-			ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+			ruleManager := NewRuleManager(gwlog.FallbackLogger, cloud, latticeDataStore)
 
 			var i = 0
 			if !tt.noServiceID {
@@ -824,7 +823,7 @@ func Test_List(t *testing.T) {
 	ctx := context.TODO()
 
 	mockLattice := mocks.NewMockLattice(c)
-	mockCloud := mocks_aws.NewMockCloud(c)
+	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
 
 	serviceID := "service1-ID"
 	listenerID := "listener-ID"
@@ -851,9 +850,8 @@ func Test_List(t *testing.T) {
 	latticeDataStore := latticestore.NewLatticeDataStore()
 
 	mockLattice.EXPECT().ListRules(&ruleInput).Return(&ruleOutput, nil)
-	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
-	ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+	ruleManager := NewRuleManager(gwlog.FallbackLogger, cloud, latticeDataStore)
 
 	resp, err := ruleManager.List(ctx, serviceID, listenerID)
 
@@ -874,7 +872,7 @@ func Test_GetRule(t *testing.T) {
 	ctx := context.TODO()
 
 	mockLattice := mocks.NewMockLattice(c)
-	mockCloud := mocks_aws.NewMockCloud(c)
+	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
 
 	serviceID := "service1-ID"
 	listenerID := "listener-ID"
@@ -897,9 +895,8 @@ func Test_GetRule(t *testing.T) {
 	}
 
 	mockLattice.EXPECT().GetRule(&ruleGetInput).Return(&ruleGetOutput, nil)
-	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
-	ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+	ruleManager := NewRuleManager(gwlog.FallbackLogger, cloud, latticeDataStore)
 
 	resp, err := ruleManager.Get(ctx, serviceID, listenerID, ruleID)
 
@@ -916,7 +913,7 @@ func Test_DeleteRule(t *testing.T) {
 	ctx := context.TODO()
 
 	mockLattice := mocks.NewMockLattice(c)
-	mockCloud := mocks_aws.NewMockCloud(c)
+	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
 
 	serviceID := "service1-ID"
 	listenerID := "listener-ID"
@@ -932,9 +929,8 @@ func Test_DeleteRule(t *testing.T) {
 
 	ruleDeleteOuput := vpclattice.DeleteRuleOutput{}
 	mockLattice.EXPECT().DeleteRule(&ruleDeleteInput).Return(&ruleDeleteOuput, nil)
-	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
 
-	ruleManager := NewRuleManager(gwlog.FallbackLogger, mockCloud, latticeDataStore)
+	ruleManager := NewRuleManager(gwlog.FallbackLogger, cloud, latticeDataStore)
 
 	ruleManager.Delete(ctx, ruleID, listenerID, serviceID)
 

--- a/pkg/deploy/lattice/service_manager.go
+++ b/pkg/deploy/lattice/service_manager.go
@@ -3,6 +3,7 @@ package lattice
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -90,6 +91,7 @@ func (m *defaultServiceManager) newCreateSvcReq(svc *Service) *CreateSvcReq {
 	svcName := svc.LatticeServiceName()
 	req := &vpclattice.CreateServiceInput{
 		Name: &svcName,
+		Tags: m.cloud.DefaultTags(),
 	}
 
 	if svc.Spec.CustomerDomainName != "" {

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -80,7 +80,7 @@ func (m *defaultServiceNetworkManager) CreateOrUpdate(ctx context.Context, servi
 		// This means, the service network can only be deleted by the controller running in this VPC
 		serviceNetworkInput := vpclattice.CreateServiceNetworkInput{
 			Name: &serviceNetwork.Spec.Name,
-			Tags: make(map[string]*string),
+			Tags: m.cloud.DefaultTags(),
 		}
 		serviceNetworkInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
 

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -113,7 +113,7 @@ func (s *defaultTargetGroupManager) Create(
 		Config: tgConfig,
 		Name:   &latticeTGName,
 		Type:   &targetGroupType,
-		Tags:   make(map[string]*string),
+		Tags:   s.cloud.DefaultTags(),
 	}
 	createTargetGroupInput.Tags[model.K8SServiceNameKey] = &targetGroup.Spec.Config.K8SServiceName
 	createTargetGroupInput.Tags[model.K8SServiceNamespaceKey] = &targetGroup.Spec.Config.K8SServiceNamespace


### PR DESCRIPTION
Note:
Add default tags to all lattice resources (managers). Major change in managers. Test changes are mostly layout and cloud mock removal.

closes #392 