### PR TITLE
test: add e2e tests for Target Group Policy CRD

### DIFF
--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -322,6 +322,21 @@ func (env *Framework) GetTargetGroupWithProtocol(ctx context.Context, service *v
 	return found
 }
 
+func (env *Framework) GetFullTargetGroupFromSummary(
+	ctx context.Context,
+	tgSummary *vpclattice.TargetGroupSummary) *vpclattice.GetTargetGroupOutput {
+
+	tg, err := env.LatticeClient.GetTargetGroupWithContext(ctx, &vpclattice.GetTargetGroupInput{
+		TargetGroupIdentifier: tgSummary.Arn,
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	return tg
+}
+
 // TODO: Create a new function that only verifying deployment len(podList.Items)==*deployment.Spec.Replicas, and don't do lattice.ListTargets() api call
 func (env *Framework) GetTargets(ctx context.Context, targetGroup *vpclattice.TargetGroupSummary, deployment *appsv1.Deployment) []*vpclattice.TargetSummary {
 	var found []*vpclattice.TargetSummary

--- a/test/pkg/test/target_group_policy.go
+++ b/test/pkg/test/target_group_policy.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type TargetGroupPolicyConfig struct {
+	PolicyName      string
+	Protocol        *string
+	ProtocolVersion *string
+	HealthCheck     *anv1alpha1.HealthCheckConfig
+}
+
+func (env *Framework) CreateTargetGroupPolicy(
+	service *corev1.Service,
+	config *TargetGroupPolicyConfig,
+) *anv1alpha1.TargetGroupPolicy {
+	return &anv1alpha1.TargetGroupPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "TargetGroupPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: service.Namespace,
+			Name:      config.PolicyName,
+		},
+		Spec: anv1alpha1.TargetGroupPolicySpec{
+			TargetRef: &gwv1alpha2.PolicyTargetReference{
+				Kind: gwv1beta1.Kind("Service"),
+				Name: gwv1beta1.ObjectName(service.Name),
+			},
+			Protocol:        config.Protocol,
+			ProtocolVersion: config.ProtocolVersion,
+			HealthCheck:     config.HealthCheck,
+		},
+	}
+}
+
+func (env *Framework) UpdateTargetGroupPolicy(
+	policy *anv1alpha1.TargetGroupPolicy,
+	config *TargetGroupPolicyConfig,
+) *anv1alpha1.TargetGroupPolicy {
+	if config.Protocol != nil {
+		policy.Spec.Protocol = config.Protocol
+	}
+
+	if config.ProtocolVersion != nil {
+		policy.Spec.ProtocolVersion = config.ProtocolVersion
+	}
+
+	if config.HealthCheck != nil {
+		policy.Spec.HealthCheck = config.HealthCheck
+	}
+
+	return policy
+}

--- a/test/suites/integration/target_group_policy_test.go
+++ b/test/suites/integration/target_group_policy_test.go
@@ -1,0 +1,144 @@
+package integration
+
+import (
+	"time"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var _ = Describe("Target Group Policy Tests", Ordered, func() {
+	var (
+		deployment *appsv1.Deployment
+		service    *corev1.Service
+		httpRoute  *gwv1beta1.HTTPRoute
+		policy     *v1alpha1.TargetGroupPolicy
+	)
+
+	BeforeAll(func() {
+		deployment, service = testFramework.NewNginxApp(test.ElasticSearchOptions{
+			Name:      "target-group-policy-test",
+			Namespace: k8snamespace,
+		})
+
+		httpRoute = testFramework.NewHttpRoute(testGateway, service, service.Kind)
+
+		testFramework.ExpectCreated(ctx, deployment, service, httpRoute)
+	})
+
+	It("Update Protocol creates new Target Group", func() {
+		policy = testFramework.CreateTargetGroupPolicy(service, &test.TargetGroupPolicyConfig{
+			PolicyName: "test-policy",
+			Protocol:   aws.String(vpclattice.TargetGroupProtocolHttp),
+		})
+
+		testFramework.ExpectCreated(ctx, policy)
+
+		tg := testFramework.GetTargetGroup(ctx, service)
+
+		Expect(*tg.Protocol).To(Equal(vpclattice.TargetGroupProtocolHttp))
+
+		testFramework.UpdateTargetGroupPolicy(policy, &test.TargetGroupPolicyConfig{
+			Protocol: aws.String(vpclattice.TargetGroupProtocolHttps),
+		})
+
+		testFramework.ExpectUpdated(ctx, policy)
+
+		httpsTG := testFramework.GetTargetGroupWithProtocol(ctx, service, "https", "http1")
+
+		Expect(*httpsTG.Protocol).To(Equal(vpclattice.TargetGroupProtocolHttps))
+	})
+
+	It("Delete Target Group Policy reset health check config for HTTP and HTTP1 Target Group", func() {
+		policy = testFramework.CreateTargetGroupPolicy(service, &test.TargetGroupPolicyConfig{
+			PolicyName:      "test-policy",
+			Protocol:        aws.String(vpclattice.TargetGroupProtocolHttp),
+			ProtocolVersion: aws.String(vpclattice.TargetGroupProtocolVersionHttp1),
+			HealthCheck: &v1alpha1.HealthCheckConfig{
+				IntervalSeconds: aws.Int64(7),
+				StatusMatch:     aws.String("200,204"),
+			},
+		})
+
+		testFramework.ExpectCreated(ctx, policy)
+
+		// time.Sleep(10 * time.Second)
+
+		Eventually(func(g Gomega) {
+			tgSummary := testFramework.GetTargetGroup(ctx, service)
+
+			tg := testFramework.GetFullTargetGroupFromSummary(ctx, tgSummary)
+
+			g.Expect(*tg.Config.HealthCheck.ProtocolVersion).To(Equal(vpclattice.TargetGroupProtocolVersionHttp1))
+			g.Expect(*tg.Config.HealthCheck.Protocol).To(Equal(vpclattice.TargetGroupProtocolHttp))
+			g.Expect(*tg.Config.HealthCheck.HealthCheckIntervalSeconds).To(BeEquivalentTo(7))
+			g.Expect(*tg.Config.HealthCheck.Matcher.HttpCode).To(Equal("200,204"))
+		}).Within(10 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
+
+		testFramework.ExpectDeletedThenNotFound(ctx, policy)
+
+		Eventually(func(g Gomega) {
+			tgSummary := testFramework.GetTargetGroup(ctx, service)
+
+			tg := testFramework.GetFullTargetGroupFromSummary(ctx, tgSummary)
+
+			g.Expect(*tg.Config.HealthCheck).To(Equal(vpclattice.HealthCheckConfig{
+				Enabled:                    aws.Bool(true),
+				Path:                       aws.String("/"),
+				HealthCheckIntervalSeconds: aws.Int64(30),
+				HealthCheckTimeoutSeconds:  aws.Int64(5),
+				HealthyThresholdCount:      aws.Int64(5),
+				UnhealthyThresholdCount:    aws.Int64(2),
+				Protocol:                   aws.String(vpclattice.TargetGroupProtocolHttp),
+				ProtocolVersion:            aws.String(vpclattice.TargetGroupProtocolVersionHttp1),
+				Port:                       nil,
+				Matcher: &vpclattice.Matcher{
+					HttpCode: aws.String("200"),
+				},
+			}))
+		}).Within(10 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
+	})
+
+	It("Delete Target Group Policy create HTTP and HTTP1 Target Group", func() {
+		policy = testFramework.CreateTargetGroupPolicy(service, &test.TargetGroupPolicyConfig{
+			PolicyName:      "test-policy",
+			Protocol:        aws.String(vpclattice.TargetGroupProtocolHttps),
+			ProtocolVersion: aws.String(vpclattice.TargetGroupProtocolVersionHttp2),
+		})
+
+		testFramework.ExpectCreated(ctx, policy)
+
+		tg := testFramework.GetTargetGroupWithProtocol(ctx, service, "https", "http2")
+
+		Expect(*tg.Protocol).To(Equal(vpclattice.TargetGroupProtocolHttps))
+
+		testFramework.ExpectDeleted(ctx, policy)
+
+		httpTG := testFramework.GetTargetGroup(ctx, service)
+
+		Expect(*httpTG.Protocol).To(Equal(vpclattice.TargetGroupProtocolHttp))
+	})
+
+	AfterEach(func() {
+		testFramework.ExpectDeleted(
+			ctx,
+			policy,
+		)
+	})
+
+	AfterAll(func() {
+		testFramework.ExpectDeleted(
+			ctx,
+			deployment,
+			service,
+			httpRoute,
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** test

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**: #379


**What does this PR do / Why do we need it**: add e2e tests for Target Group Policy CRD


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:

`make e2e-test` outputs:

```
Ran 38 of 38 Specs in 2715.256 seconds
SUCCESS! -- 38 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2716.14s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   2716.173s
```

<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**: add `test/suites/integration/target_group_policy_test.go` 

<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: No
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: N/A

**Does this PR introduce any user-facing change?**: No

<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.