### PR TITLE
Generalize TargetRefExists() and UpdatePolicyStatus() methods for Policy CRDs

### DIFF
--- a/pkg/utils/policy/policy.go
+++ b/pkg/utils/policy/policy.go
@@ -1,0 +1,85 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+)
+
+func AccessLogPolicyTargetRefExists(ctx context.Context, client client.Client, logger gwlog.Logger, policy core.Policy) (bool, error) {
+	logger.Debugf("Checking if AccessLogPolicy targetRef exists")
+	return checkGatewayOrRouteTargetRefExistsForPolicy(ctx, client, policy)
+}
+
+func AuthPolicyTargetRefExists(ctx context.Context, client client.Client, logger gwlog.Logger, policy core.Policy) (bool, error) {
+	logger.Debugf("Checking if AuthPolicy targetRef exists")
+	return checkGatewayOrRouteTargetRefExistsForPolicy(ctx, client, policy)
+}
+
+func checkGatewayOrRouteTargetRefExistsForPolicy(ctx context.Context, client client.Client, policy core.Policy) (bool, error) {
+	targetRefNamespace := policy.GetNamespacedName().Namespace
+	targetRef := policy.GetTargetRef()
+	if targetRef.Namespace != nil {
+		targetRefNamespace = string(*targetRef.Namespace)
+	}
+	targetRefNamespacedName := types.NamespacedName{
+		Name:      string(targetRef.Name),
+		Namespace: targetRefNamespace,
+	}
+
+	var err error
+	switch targetRef.Kind {
+	case "Gateway":
+		gw := &gwv1beta1.Gateway{}
+		err = client.Get(ctx, targetRefNamespacedName, gw)
+	case "HTTPRoute":
+		httpRoute := &gwv1beta1.HTTPRoute{}
+		err = client.Get(ctx, targetRefNamespacedName, httpRoute)
+	case "GRPCRoute":
+		grpcRoute := &gwv1alpha2.GRPCRoute{}
+		err = client.Get(ctx, targetRefNamespacedName, grpcRoute)
+	default:
+		return false, fmt.Errorf("policy targetRef is for an unsupported Kind: %s",
+			targetRef.Kind)
+	}
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err
+	}
+	return err == nil, nil
+}
+
+func UpdatePolicyStatus(
+	ctx context.Context,
+	k8sClient client.Client,
+	policy core.Policy,
+	reason gwv1alpha2.PolicyConditionReason,
+	message string,
+) error {
+	status := apimachineryv1.ConditionTrue
+	if reason != gwv1alpha2.PolicyReasonAccepted {
+		status = apimachineryv1.ConditionFalse
+	}
+	newConditions := utils.GetNewConditions(policy.GetStatusConditions(), apimachineryv1.Condition{
+		Type:               string(gwv1alpha2.PolicyConditionAccepted),
+		ObservedGeneration: policy.(client.Object).GetGeneration(),
+		Message:            message,
+		Status:             status,
+		Reason:             string(reason),
+	})
+	policy.SetStatusConditions(newConditions)
+	if err := k8sClient.Status().Update(ctx, policy.(client.Object)); err != nil {
+		return fmt.Errorf("failed to set Policy Accepted status to %s and reason to %s, %w",
+			status, reason, err)
+	}
+	return nil
+}

--- a/pkg/utils/policy/policy_test.go
+++ b/pkg/utils/policy/policy_test.go
@@ -1,0 +1,212 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	mockclient "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+)
+
+func Test_checkGatewayOrRouteTargetRefExistsForPolicy(t *testing.T) {
+	testNamespace := gwv1beta1.Namespace("test-ns")
+
+	notFoundError := fmt.Errorf("k8s resource not found")
+	type args struct {
+		policy core.Policy
+	}
+	tests := []struct {
+		name                         string
+		args                         args
+		expectedK8sClientReturnedObj client.Object
+		want                         bool
+		wantErr                      error
+	}{
+		{
+			name: "AccessLogPolicy TargetRef gateway exists in the k8s, happy path",
+			args: args{
+				policy: &anv1alpha1.AccessLogPolicy{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: anv1alpha1.AccessLogPolicySpec{
+						DestinationArn: aws.String("destination-arn-123"),
+						TargetRef: &gwv1alpha2.PolicyTargetReference{
+							Group:     gwv1beta1.GroupName,
+							Kind:      "Gateway",
+							Name:      "test-gw",
+							Namespace: &testNamespace,
+						},
+					},
+				},
+			},
+			expectedK8sClientReturnedObj: &gwv1beta1.Gateway{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gw",
+					Namespace: string(testNamespace),
+				},
+			},
+			want:    true,
+			wantErr: nil,
+		},
+		{
+			name: "AccessLogPolicy TargetRef GRPCRoute exists in the k8s, happy path",
+			args: args{
+				policy: &anv1alpha1.AccessLogPolicy{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: anv1alpha1.AccessLogPolicySpec{
+						DestinationArn: aws.String("destination-arn-123"),
+						TargetRef: &gwv1alpha2.PolicyTargetReference{
+							Group:     gwv1beta1.GroupName,
+							Kind:      "GRPCRoute",
+							Name:      "test-grpcroute",
+							Namespace: &testNamespace,
+						},
+					},
+				},
+			},
+			expectedK8sClientReturnedObj: &gwv1alpha2.GRPCRoute{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-grpcroute",
+					Namespace: string(testNamespace),
+				},
+			},
+			want:    true,
+			wantErr: nil,
+		},
+		{
+			name: "AccessLogPolicy TargetRef GRPCRoute not exist in the k8s",
+			args: args{
+				policy: &anv1alpha1.AccessLogPolicy{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: anv1alpha1.AccessLogPolicySpec{
+						DestinationArn: aws.String("destination-arn-123"),
+						TargetRef: &gwv1alpha2.PolicyTargetReference{
+							Group:     gwv1beta1.GroupName,
+							Kind:      "GRPCRoute",
+							Name:      "another-grpcroute",
+							Namespace: &testNamespace,
+						},
+					},
+				},
+			},
+			expectedK8sClientReturnedObj: nil,
+			want:                         false,
+			wantErr:                      notFoundError,
+		},
+		{
+			name: "IAMAuthPolicy TargetRef HTTPRoute exists in the k8s, happy path",
+			args: args{
+				policy: &anv1alpha1.IAMAuthPolicy{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: anv1alpha1.IAMAuthPolicySpec{
+						Policy: "policy content",
+						TargetRef: &gwv1alpha2.PolicyTargetReference{
+							Group:     gwv1beta1.GroupName,
+							Kind:      "HTTPRoute",
+							Name:      "test-httproute",
+							Namespace: &testNamespace,
+						},
+					},
+				},
+			},
+			expectedK8sClientReturnedObj: &gwv1beta1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-httproute",
+					Namespace: string(testNamespace),
+				},
+			},
+			want:    true,
+			wantErr: nil,
+		},
+		{
+			name: "IAMAuthPolicy TargetRef HTTPRoute not exist in the k8s",
+			args: args{
+				policy: &anv1alpha1.IAMAuthPolicy{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: anv1alpha1.IAMAuthPolicySpec{
+						Policy: "policy content",
+						TargetRef: &gwv1alpha2.PolicyTargetReference{
+							Group:     gwv1beta1.GroupName,
+							Kind:      "HTTPRoute",
+							Name:      "not-matched-httproute",
+							Namespace: &testNamespace,
+						},
+					},
+				},
+			},
+			expectedK8sClientReturnedObj: nil,
+			want:                         false,
+			wantErr:                      notFoundError,
+		},
+	}
+	for _, tt := range tests {
+		ctx := context.TODO()
+		c := gomock.NewController(t)
+
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := mockclient.NewMockClient(c)
+
+			switch tt.args.policy.GetTargetRef().Kind {
+			case "Gateway":
+				k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, name types.NamespacedName, retObj *gwv1beta1.Gateway, arg3 ...interface{}) error {
+						if tt.expectedK8sClientReturnedObj == nil {
+							return notFoundError
+						} else {
+							retObj.Name = tt.expectedK8sClientReturnedObj.(*gwv1beta1.Gateway).Name
+							retObj.Namespace = tt.expectedK8sClientReturnedObj.(*gwv1beta1.Gateway).Namespace
+							return nil
+						}
+					})
+			case "HTTPRoute":
+				k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, name types.NamespacedName, retObj *gwv1beta1.HTTPRoute, arg3 ...interface{}) error {
+						if tt.expectedK8sClientReturnedObj == nil {
+							return notFoundError
+						} else {
+							retObj.Name = tt.expectedK8sClientReturnedObj.(*gwv1beta1.HTTPRoute).Name
+							retObj.Namespace = tt.expectedK8sClientReturnedObj.(*gwv1beta1.HTTPRoute).Namespace
+							return nil
+						}
+					})
+			case "GRPCRoute":
+				k8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, name types.NamespacedName, retObj *gwv1alpha2.GRPCRoute, arg3 ...interface{}) error {
+						if tt.expectedK8sClientReturnedObj == nil {
+							return notFoundError
+						} else {
+							retObj.Name = tt.expectedK8sClientReturnedObj.(*gwv1alpha2.GRPCRoute).Name
+							retObj.Namespace = tt.expectedK8sClientReturnedObj.(*gwv1alpha2.GRPCRoute).Namespace
+							return nil
+						}
+					})
+			}
+
+			got, err := checkGatewayOrRouteTargetRefExistsForPolicy(ctx, k8sClient, tt.args.policy)
+			if tt.wantErr != nil {
+				assert.Equal(t, tt.wantErr, err)
+				return
+			}
+			assert.Equalf(t, tt.want, got, "checkGatewayOrRouteTargetRefExistsForPolicy(%v, %v, %v)", ctx, k8sClient, tt.args.policy)
+			assert.Equal(t, nil, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.