### PR TITLE
add IAM Auth Policy dummy controller

### DIFF
--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -73,18 +73,18 @@ func addOptionalCRDs(scheme *runtime.Scheme) {
 	scheme.AddKnownTypes(dnsEndpoint, &endpoint.DNSEndpoint{}, &endpoint.DNSEndpointList{})
 	metav1.AddToGroupVersion(scheme, dnsEndpoint)
 
-	awsGatewayControllerCRDGroupVersion := schema.GroupVersion{
+	groupVersion := schema.GroupVersion{
 		Group:   anv1alpha1.GroupName,
 		Version: "v1alpha1",
 	}
-	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &anv1alpha1.TargetGroupPolicy{}, &anv1alpha1.TargetGroupPolicyList{})
-	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
 
-	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &anv1alpha1.VpcAssociationPolicy{}, &anv1alpha1.VpcAssociationPolicyList{})
-	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
+	scheme.AddKnownTypes(groupVersion,
+		&anv1alpha1.TargetGroupPolicy{}, &anv1alpha1.TargetGroupPolicyList{},
+		&anv1alpha1.AccessLogPolicy{}, &anv1alpha1.AccessLogPolicyList{},
+		&anv1alpha1.VpcAssociationPolicy{}, &anv1alpha1.VpcAssociationPolicyList{},
+		&anv1alpha1.IAMAuthPolicy{}, &anv1alpha1.IAMAuthPolicyList{})
 
-	scheme.AddKnownTypes(awsGatewayControllerCRDGroupVersion, &anv1alpha1.AccessLogPolicy{}, &anv1alpha1.AccessLogPolicyList{})
-	metav1.AddToGroupVersion(scheme, awsGatewayControllerCRDGroupVersion)
+	metav1.AddToGroupVersion(scheme, groupVersion)
 }
 
 func main() {
@@ -184,6 +184,11 @@ func main() {
 	err = controllers.RegisterAccessLogPolicyController(ctrlLog.Named("access-log-policy"), cloud, finalizerManager, mgr)
 	if err != nil {
 		setupLog.Fatalf("accesslogpolicy controller setup failed: %s", err)
+	}
+
+	err = controllers.RegisterIAMAuthPolicyController(ctrlLog.Named("iam-auth-policy"), mgr)
+	if err != nil {
+		setupLog.Fatalf("iam auth policy controller setup failed: %s", err)
 	}
 
 	go latticestore.GetDefaultLatticeDataStore().ServeIntrospection()

--- a/controllers/iamauthpolicy_controller.go
+++ b/controllers/iamauthpolicy_controller.go
@@ -1,0 +1,68 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type IAMAuthPolicyController struct {
+	log    gwlog.Logger
+	client client.Client
+}
+
+func RegisterIAMAuthPolicyController(log gwlog.Logger, mgr ctrl.Manager) error {
+	controller := &IAMAuthPolicyController{
+		log:    log,
+		client: mgr.GetClient(),
+	}
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&anv1alpha1.IAMAuthPolicy{}).
+		Complete(controller)
+	return err
+}
+
+func (c *IAMAuthPolicyController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	c.log.Infow("reconcile", "req", req)
+
+	policy := &anv1alpha1.IAMAuthPolicy{}
+	err := c.client.Get(ctx, req.NamespacedName, policy)
+	if !k8serr.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	switch policy.Spec.TargetRef.Kind {
+	case "Gateway":
+		err = c.reconcileGateway(ctx, policy)
+		break
+	case "HTTPRoute":
+	case "GRPCRoute":
+		err = c.reconcileRoute(ctx, policy)
+		break
+	default:
+		err = fmt.Errorf("unsupported targetRef type, req=%s, kind=%s",
+			req, policy.Spec.TargetRef.Kind)
+	}
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	c.log.Infow("successfully reconciled", "req", req)
+	return ctrl.Result{}, nil
+}
+
+func (c *IAMAuthPolicyController) reconcileGateway(ctx context.Context, policy *anv1alpha1.IAMAuthPolicy) error {
+	c.log.Debugw("reconcile gateway iam policy", "policy", policy)
+	return nil
+}
+
+func (c IAMAuthPolicyController) reconcileRoute(ctx context.Context, policy *anv1alpha1.IAMAuthPolicy) error {
+	c.log.Debugw("reconcile route iam policy", "policy", policy)
+	return nil
+}


### PR DESCRIPTION
Note:
Add dummy controller for IAM Auth Policy. Policy can be attached to Lattice Service Network or Service. We support only Gateway, HTTP and GRPC routes as target references right now. I will split reconciliation into Gateway and Route types.

Partly #18 