### PR TITLE
add IAM Auth Policy create/update/delete

### DIFF
--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -186,7 +186,7 @@ func main() {
 		setupLog.Fatalf("accesslogpolicy controller setup failed: %s", err)
 	}
 
-	err = controllers.RegisterIAMAuthPolicyController(ctrlLog.Named("iam-auth-policy"), mgr)
+	err = controllers.RegisterIAMAuthPolicyController(ctrlLog.Named("iam-auth-policy"), mgr, cloud)
 	if err != nil {
 		setupLog.Fatalf("iam auth policy controller setup failed: %s", err)
 	}

--- a/controllers/iamauthpolicy_controller.go
+++ b/controllers/iamauthpolicy_controller.go
@@ -2,25 +2,32 @@ package controllers
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	deploy "github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type IAMAuthPolicyController struct {
-	log    gwlog.Logger
-	client client.Client
+	log       gwlog.Logger
+	client    client.Client
+	policyMgr deploy.IAMAuthPolicyManager
 }
 
-func RegisterIAMAuthPolicyController(log gwlog.Logger, mgr ctrl.Manager) error {
+func RegisterIAMAuthPolicyController(log gwlog.Logger, mgr ctrl.Manager, cloud pkg_aws.Cloud) error {
 	controller := &IAMAuthPolicyController{
-		log:    log,
-		client: mgr.GetClient(),
+		log:       log,
+		client:    mgr.GetClient(),
+		policyMgr: deploy.IAMAuthPolicyManager{Cloud: cloud},
 	}
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&anv1alpha1.IAMAuthPolicy{}).
@@ -29,32 +36,154 @@ func RegisterIAMAuthPolicyController(log gwlog.Logger, mgr ctrl.Manager) error {
 }
 
 func (c *IAMAuthPolicyController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	c.log.Infow("reconcile", "req", req)
+	k8sPolicy := &anv1alpha1.IAMAuthPolicy{}
+	err := c.client.Get(ctx, req.NamespacedName, k8sPolicy)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	c.log.Infow("reconcile", "req", req, "targetRef", k8sPolicy.Spec.TargetRef)
 
-	policy := &anv1alpha1.IAMAuthPolicy{}
-	err := c.client.Get(ctx, req.NamespacedName, policy)
-	if !k8serr.IsNotFound(err) {
+	c.handleFinalizer(ctx, k8sPolicy)
+
+	isDelete := !k8sPolicy.DeletionTimestamp.IsZero()
+	kind := k8sPolicy.Spec.TargetRef.Kind
+	var reconcileFunc func(context.Context, *anv1alpha1.IAMAuthPolicy) (string, error)
+	switch kind {
+	case "Gateway":
+		if isDelete {
+			reconcileFunc = c.deleteGatewayPolicy
+		} else {
+			reconcileFunc = c.upsertGatewayPolicy
+		}
+	case "HTTPRoute", "GRPCRoute":
+		if isDelete {
+			reconcileFunc = c.deleteRoutePolicy
+		} else {
+			reconcileFunc = c.upsertRoutePolicy
+		}
+	}
+
+	latticeResourceId, err := reconcileFunc(ctx, k8sPolicy)
+	if err != nil {
+		if services.IsNotFoundError(err) {
+			c.log.Infof("reconcile error, retry in 30sec: %s", err)
+			return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
-	switch policy.Spec.TargetRef.Kind {
-	case "Gateway":
-		err = c.reconcileGateway(ctx, policy)
-		break
-	case "HTTPRoute":
-	case "GRPCRoute":
-		err = c.reconcileRoute(ctx, policy)
-		break
-	default:
-		err = fmt.Errorf("unsupported targetRef type, req=%s, kind=%s",
-			req, policy.Spec.TargetRef.Kind)
-	}
+	k8sPolicy.Annotations["application-networking.k8s.aws/resourceId"] = latticeResourceId
+
+	err = c.client.Update(ctx, k8sPolicy)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	c.log.Infow("successfully reconciled", "req", req)
+	c.log.Infow("reconciled IAM policy",
+		"req", req,
+		"targetRef", k8sPolicy.Spec.TargetRef,
+		"latticeResorceId", latticeResourceId,
+		"isDeleted", isDelete,
+	)
 	return ctrl.Result{}, nil
+}
+
+func (c *IAMAuthPolicyController) handleFinalizer(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) {
+	authPolicyFinalizer := "iamauthpolicy.k8s.aws/resources"
+	if k8sPolicy.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(k8sPolicy, authPolicyFinalizer) {
+			controllerutil.AddFinalizer(k8sPolicy, authPolicyFinalizer)
+		}
+	} else {
+		if controllerutil.ContainsFinalizer(k8sPolicy, authPolicyFinalizer) {
+			controllerutil.RemoveFinalizer(k8sPolicy, authPolicyFinalizer)
+		}
+	}
+}
+
+func (c *IAMAuthPolicyController) deleteGatewayPolicy(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (string, error) {
+	snId, err := c.findSnId(ctx, k8sPolicy)
+	if err != nil {
+		return "", err
+	}
+	err = c.policyMgr.Delete(ctx, snId)
+	if err != nil {
+		return "", err
+	}
+	return snId, nil
+}
+
+func (c *IAMAuthPolicyController) findSnId(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (string, error) {
+	tr := k8sPolicy.Spec.TargetRef
+	snInfo, err := c.policyMgr.Cloud.Lattice().FindServiceNetworkByK8sName(ctx, string(tr.Name))
+	if err != nil {
+		return "", err
+	}
+	return *snInfo.SvcNetwork.Id, nil
+}
+
+func (c *IAMAuthPolicyController) upsertGatewayPolicy(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (string, error) {
+	snId, err := c.findSnId(ctx, k8sPolicy)
+	if err != nil {
+		return "", err
+	}
+	err = c.policyMgr.EnableSnIAMAuth(ctx, snId)
+	if err != nil {
+		return "", err
+	}
+	err = c.putPolicy(ctx, snId, k8sPolicy.Spec.Policy)
+	if err != nil {
+		return "", err
+	}
+
+	return snId, nil
+}
+
+func (c *IAMAuthPolicyController) findSvcId(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (string, error) {
+	tr := k8sPolicy.Spec.TargetRef
+	svcName := utils.LatticeServiceName(string(tr.Name), k8sPolicy.Namespace)
+	svcInfo, err := c.policyMgr.Cloud.Lattice().FindServiceByK8sName(ctx, svcName)
+	if err != nil {
+		return "", err
+	}
+	return *svcInfo.Id, nil
+}
+
+func (c *IAMAuthPolicyController) deleteRoutePolicy(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (string, error) {
+	svcId, err := c.findSvcId(ctx, k8sPolicy)
+	if err != nil {
+		return "", err
+	}
+	err = c.policyMgr.Delete(ctx, svcId)
+	if err != nil {
+		return "", err
+	}
+	return svcId, nil
+}
+
+func (c *IAMAuthPolicyController) upsertRoutePolicy(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (string, error) {
+	svcId, err := c.findSvcId(ctx, k8sPolicy)
+	if err != nil {
+		return "", err
+	}
+	err = c.policyMgr.EnableSvcIAMAuth(ctx, svcId)
+	if err != nil {
+		return "", err
+	}
+	err = c.putPolicy(ctx, svcId, k8sPolicy.Spec.Policy)
+	if err != nil {
+		return "", err
+	}
+	return svcId, nil
+}
+
+func (c *IAMAuthPolicyController) putPolicy(ctx context.Context, resId, policy string) error {
+	modelPolicy := model.IAMAuthPolicy{
+		ResourceId: resId,
+		Policy:     policy,
+	}
+	_, err := c.policyMgr.Put(ctx, modelPolicy)
+	return err
 }
 
 func (c *IAMAuthPolicyController) reconcileGateway(ctx context.Context, policy *anv1alpha1.IAMAuthPolicy) error {

--- a/pkg/aws/services/vpclattice.go
+++ b/pkg/aws/services/vpclattice.go
@@ -104,6 +104,8 @@ type Lattice interface {
 	ListServiceNetworkServiceAssociationsAsList(ctx context.Context, input *vpclattice.ListServiceNetworkServiceAssociationsInput) ([]*vpclattice.ServiceNetworkServiceAssociationSummary, error)
 	FindServiceNetwork(ctx context.Context, name string, accountId string) (*ServiceNetworkInfo, error)
 	FindService(ctx context.Context, nameProvider LatticeServiceNameProvider) (*vpclattice.ServiceSummary, error)
+	FindServiceByK8sName(ctx context.Context, k8sname string) (*vpclattice.ServiceSummary, error)
+	FindServiceNetworkByK8sName(ctx context.Context, k8sname string) (*ServiceNetworkInfo, error)
 }
 
 type defaultLattice struct {
@@ -314,4 +316,12 @@ func accountIdMatches(accountId string, itemArn string) (bool, error) {
 	}
 
 	return accountId == parsedArn.AccountID, nil
+}
+
+func (d *defaultLattice) FindServiceByK8sName(ctx context.Context, k8sname string) (*vpclattice.ServiceSummary, error) {
+	return d.FindService(ctx, NewDefaultLatticeServiceNameProvider(k8sname))
+}
+
+func (d *defaultLattice) FindServiceNetworkByK8sName(ctx context.Context, k8sname string) (*ServiceNetworkInfo, error) {
+	return d.FindServiceNetwork(ctx, k8sname, "")
 }

--- a/pkg/aws/services/vpclattice_mocks.go
+++ b/pkg/aws/services/vpclattice_mocks.go
@@ -1051,6 +1051,21 @@ func (mr *MockLatticeMockRecorder) FindService(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindService", reflect.TypeOf((*MockLattice)(nil).FindService), arg0, arg1)
 }
 
+// FindServiceByK8sName mocks base method.
+func (m *MockLattice) FindServiceByK8sName(arg0 context.Context, arg1 string) (*vpclattice.ServiceSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindServiceByK8sName", arg0, arg1)
+	ret0, _ := ret[0].(*vpclattice.ServiceSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindServiceByK8sName indicates an expected call of FindServiceByK8sName.
+func (mr *MockLatticeMockRecorder) FindServiceByK8sName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindServiceByK8sName", reflect.TypeOf((*MockLattice)(nil).FindServiceByK8sName), arg0, arg1)
+}
+
 // FindServiceNetwork mocks base method.
 func (m *MockLattice) FindServiceNetwork(arg0 context.Context, arg1, arg2 string) (*ServiceNetworkInfo, error) {
 	m.ctrl.T.Helper()
@@ -1064,6 +1079,21 @@ func (m *MockLattice) FindServiceNetwork(arg0 context.Context, arg1, arg2 string
 func (mr *MockLatticeMockRecorder) FindServiceNetwork(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindServiceNetwork", reflect.TypeOf((*MockLattice)(nil).FindServiceNetwork), arg0, arg1, arg2)
+}
+
+// FindServiceNetworkByK8sName mocks base method.
+func (m *MockLattice) FindServiceNetworkByK8sName(arg0 context.Context, arg1 string) (*ServiceNetworkInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindServiceNetworkByK8sName", arg0, arg1)
+	ret0, _ := ret[0].(*ServiceNetworkInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindServiceNetworkByK8sName indicates an expected call of FindServiceNetworkByK8sName.
+func (mr *MockLatticeMockRecorder) FindServiceNetworkByK8sName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindServiceNetworkByK8sName", reflect.TypeOf((*MockLattice)(nil).FindServiceNetworkByK8sName), arg0, arg1)
 }
 
 // GetAccessLogSubscription mocks base method.

--- a/pkg/deploy/lattice/iamauthpolicy_manager.go
+++ b/pkg/deploy/lattice/iamauthpolicy_manager.go
@@ -1,0 +1,59 @@
+package lattice
+
+import (
+	"context"
+
+	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+)
+
+type IAMAuthPolicyManager struct {
+	Cloud pkg_aws.Cloud
+}
+
+func (m *IAMAuthPolicyManager) Put(ctx context.Context, policy model.IAMAuthPolicy) (model.IAMAuthPolicyStatus, error) {
+	req := &vpclattice.PutAuthPolicyInput{
+		Policy:             &policy.Policy,
+		ResourceIdentifier: &policy.ResourceId,
+	}
+	resp, err := m.Cloud.Lattice().PutAuthPolicyWithContext(ctx, req)
+	if err != nil {
+		return model.IAMAuthPolicyStatus{}, err
+	}
+	return model.IAMAuthPolicyStatus{
+		ResourceId: policy.ResourceId,
+		State:      *resp.State,
+	}, nil
+}
+
+func (m *IAMAuthPolicyManager) Delete(ctx context.Context, resourceId string) error {
+	req := &vpclattice.DeleteAuthPolicyInput{
+		ResourceIdentifier: &resourceId,
+	}
+	_, err := m.Cloud.Lattice().DeleteAuthPolicyWithContext(ctx, req)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *IAMAuthPolicyManager) EnableSnIAMAuth(ctx context.Context, snId string) error {
+	req := &vpclattice.UpdateServiceNetworkInput{
+		AuthType:                 aws.String(vpclattice.AuthTypeAwsIam),
+		ServiceNetworkIdentifier: &snId,
+	}
+	_, err := m.Cloud.Lattice().UpdateServiceNetworkWithContext(ctx, req)
+	return err
+}
+
+func (m *IAMAuthPolicyManager) EnableSvcIAMAuth(ctx context.Context, svcId string) error {
+	req := &vpclattice.UpdateServiceInput{
+		AuthType:          aws.String(vpclattice.AuthTypeAwsIam),
+		ServiceIdentifier: &svcId,
+	}
+	_, err := m.Cloud.Lattice().UpdateServiceWithContext(ctx, req)
+	return err
+}

--- a/pkg/deploy/lattice/iamauthpolicy_manager.go
+++ b/pkg/deploy/lattice/iamauthpolicy_manager.go
@@ -6,7 +6,6 @@ import (
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 )
 
@@ -41,8 +40,15 @@ func (m *IAMAuthPolicyManager) Delete(ctx context.Context, resourceId string) er
 }
 
 func (m *IAMAuthPolicyManager) EnableSnIAMAuth(ctx context.Context, snId string) error {
+	return m.setSnAuthType(ctx, snId, vpclattice.AuthTypeAwsIam)
+}
+func (m *IAMAuthPolicyManager) DisableSnIAMAuth(ctx context.Context, snId string) error {
+	return m.setSnAuthType(ctx, snId, vpclattice.AuthTypeNone)
+}
+
+func (m *IAMAuthPolicyManager) setSnAuthType(ctx context.Context, snId, authType string) error {
 	req := &vpclattice.UpdateServiceNetworkInput{
-		AuthType:                 aws.String(vpclattice.AuthTypeAwsIam),
+		AuthType:                 &authType,
 		ServiceNetworkIdentifier: &snId,
 	}
 	_, err := m.Cloud.Lattice().UpdateServiceNetworkWithContext(ctx, req)
@@ -50,8 +56,16 @@ func (m *IAMAuthPolicyManager) EnableSnIAMAuth(ctx context.Context, snId string)
 }
 
 func (m *IAMAuthPolicyManager) EnableSvcIAMAuth(ctx context.Context, svcId string) error {
+	return m.setSvcAuthType(ctx, svcId, vpclattice.AuthTypeAwsIam)
+}
+
+func (m *IAMAuthPolicyManager) DisableSvcIAMAuth(ctx context.Context, svcId string) error {
+	return m.setSvcAuthType(ctx, svcId, vpclattice.AuthTypeNone)
+}
+
+func (m *IAMAuthPolicyManager) setSvcAuthType(ctx context.Context, svcId, authType string) error {
 	req := &vpclattice.UpdateServiceInput{
-		AuthType:          aws.String(vpclattice.AuthTypeAwsIam),
+		AuthType:          &authType,
 		ServiceIdentifier: &svcId,
 	}
 	_, err := m.Cloud.Lattice().UpdateServiceWithContext(ctx, req)

--- a/pkg/deploy/lattice/iamauthpolicy_manager_test.go
+++ b/pkg/deploy/lattice/iamauthpolicy_manager_test.go
@@ -1,0 +1,105 @@
+package lattice
+
+import (
+	"context"
+	"testing"
+
+	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIAMAuthPolicyManager(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	mockLattice := mocks.NewMockLattice(c)
+	cfg := pkg_aws.CloudConfig{VpcId: "vpc-id", AccountId: "account-id"}
+	cl := pkg_aws.NewDefaultCloud(mockLattice, cfg)
+	ctx := context.Background()
+
+	m := IAMAuthPolicyManager{
+		Cloud: cl,
+	}
+
+	t.Run("existing sn", func(t *testing.T) {
+		snId := "sn-abc"
+
+		policy := model.IAMAuthPolicy{
+			ResourceId: snId,
+			Policy:     "{}",
+		}
+
+		mockLattice.EXPECT().
+			PutAuthPolicyWithContext(gomock.Any(), &vpclattice.PutAuthPolicyInput{
+				Policy:             &policy.Policy,
+				ResourceIdentifier: &snId,
+			}).
+			Return(&vpclattice.PutAuthPolicyOutput{
+				Policy: &policy.Policy,
+				State:  aws.String(vpclattice.AuthPolicyStateActive),
+			}, nil).Times(1)
+
+		statusGot, _ := m.Put(ctx, policy)
+		statusWant := model.IAMAuthPolicyStatus{
+			ResourceId: snId,
+			State:      vpclattice.AuthPolicyStateActive,
+		}
+		assert.Equal(t, statusWant, statusGot)
+	})
+
+	t.Run("existing svc", func(t *testing.T) {
+		svcId := "svc-abc"
+
+		policy := model.IAMAuthPolicy{
+			ResourceId: svcId,
+			Policy:     "{}",
+		}
+
+		mockLattice.EXPECT().
+			PutAuthPolicyWithContext(gomock.Any(), &vpclattice.PutAuthPolicyInput{
+				Policy:             &policy.Policy,
+				ResourceIdentifier: &svcId,
+			}).
+			Return(&vpclattice.PutAuthPolicyOutput{
+				Policy: &policy.Policy,
+				State:  aws.String(vpclattice.AuthPolicyStateActive),
+			}, nil).Times(1)
+
+		statusGot, _ := m.Put(ctx, policy)
+		statusWant := model.IAMAuthPolicyStatus{
+			ResourceId: svcId,
+			State:      vpclattice.AuthPolicyStateActive,
+		}
+		assert.Equal(t, statusWant, statusGot)
+	})
+
+	t.Run("enable SN IAM Auth", func(t *testing.T) {
+		snId := "snId"
+
+		mockLattice.EXPECT().
+			UpdateServiceNetworkWithContext(ctx, &vpclattice.UpdateServiceNetworkInput{
+				AuthType:                 aws.String(vpclattice.AuthTypeAwsIam),
+				ServiceNetworkIdentifier: &snId,
+			}).Return(&vpclattice.UpdateServiceNetworkOutput{}, nil).Times(1)
+
+		m.EnableSnIAMAuth(ctx, snId)
+	})
+
+	t.Run("enable Svc IAM Auth", func(t *testing.T) {
+		svcId := "svcId"
+
+		mockLattice.EXPECT().
+			UpdateServiceWithContext(ctx, &vpclattice.UpdateServiceInput{
+				AuthType:          aws.String(vpclattice.AuthTypeAwsIam),
+				ServiceIdentifier: &svcId,
+			}).Return(&vpclattice.UpdateServiceOutput{}, nil).Times(1)
+
+		m.EnableSvcIAMAuth(ctx, svcId)
+	})
+}

--- a/pkg/model/lattice/iamauthpolicy.go
+++ b/pkg/model/lattice/iamauthpolicy.go
@@ -1,0 +1,11 @@
+package lattice
+
+type IAMAuthPolicy struct {
+	ResourceId string
+	Policy     string
+}
+
+type IAMAuthPolicyStatus struct {
+	ResourceId string
+	State      string
+}

--- a/pkg/utils/gwlog/gwlog.go
+++ b/pkg/utils/gwlog/gwlog.go
@@ -16,6 +16,7 @@ func NewLogger(debug bool) Logger {
 		zc.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 	} else {
 		zc = zap.NewProductionConfig()
+		zc.DisableStacktrace = true
 	}
 	z, err := zc.Build()
 	if err != nil {


### PR DESCRIPTION
Note:
Add model and manager for IAM Auth Policy. Currently handles only happy path when SN or Svc exists. If Lattice targetRef does not exists will print NotFound exceptions and retry later.

Always change AuthPolicy for Sn and Svc to AWS_IAM on upsert.

Tests:
Created SN and Svc in Lattice console. Applied and deleted `examples/iam-auth-policy-example.yaml` for SN and Svc.