### PR TITLE
Update examples/inventory-route-bluegreen-single-cluster.yaml

### DIFF
--- a/examples/inventory-route-bluegreen-single-cluster.yaml
+++ b/examples/inventory-route-bluegreen-single-cluster.yaml
@@ -14,5 +14,5 @@ spec:
       weight: 50
     - name: inventory-ver2
       kind: Service
-      port: 8090
+      port: 80
       weight: 50


### PR DESCRIPTION
Fixed port to match service instead of pod

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.