### PR TITLE
use ISO8601 for production logs

### DIFF
--- a/pkg/utils/gwlog/gwlog.go
+++ b/pkg/utils/gwlog/gwlog.go
@@ -17,6 +17,7 @@ func NewLogger(debug bool) Logger {
 	} else {
 		zc = zap.NewProductionConfig()
 		zc.DisableStacktrace = true
+		zc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	}
 	z, err := zc.Build()
 	if err != nil {


### PR DESCRIPTION
Note:
Switch to ISO8601 for production logs. Debug logs are ISO8601.

Currently prod is Unix epoch timestamp:
debug: `2023-10-25T18:07:38.698-0700	INFO	controller.gateway-class`
prod: `{"level":"info","ts":1698340801.9449012,"logger":"controller.gateway-class"`

New prod log: `{"level":"info","ts":"2023-10-26T10:54:35.722-0700","logger":"controller.gateway"`
