### PR TITLE
Added events to Access Log Policy and fixed missing helm permission

### DIFF
--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -202,6 +202,14 @@ rules:
   - patch
   - update
 - apiGroups:
+    - application-networking.k8s.aws
+  resources:
+    - accesslogpolicies/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
     - gateway.networking.k8s.io
   resources:
     - grpcroutes

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -1,6 +1,11 @@
 package k8s
 
 const (
+	// Generic events
+	ReconcilingEvent     = "Reconciling"
+	ReconciledEvent      = "Reconciled"
+	FailedReconcileEvent = "FailedReconcile"
+
 	// Gateway events
 	GatewayEventReasonFailedAddFinalizer = "FailedAddFinalizer"
 	GatewayEventReasonFailedBuildModel   = "FailedBuildModel"
@@ -28,8 +33,4 @@ const (
 	ServiceImportEventReasonFailedAddFinalizer = "FailedAddFinalizer"
 	ServiceImportEventReasonFailedBuildModel   = "FailedBuildModel"
 	ServiceImportEventReasonFailedDeployModel  = "FailedDeployModel"
-
-	// AccessLogPolicy events
-	AccessLogPolicyEventReasonFailedAddFinalizer = "FailedAddFinalizer"
-	AccessLogPolicyEventReasonFailedBuildModel   = "FailedBuildModel"
 )

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const AnnotationPrefix = "application-networking.k8s.aws/"
@@ -21,6 +22,13 @@ func NamespacedName(obj NamespacedAndNamed) types.NamespacedName {
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}
+}
+
+func NamespaceOrDefault(namespace *v1beta1.Namespace) string {
+	if namespace == nil {
+		return "default"
+	}
+	return string(*namespace)
 }
 
 func IsGVKSupported(mgr ctrl.Manager, groupVersion string, kind string) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
Feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
- Adds missing helm permission for AccessLogPolicy/status
- Adds event publishing for AccessLogPolicy resources

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
e2e tests will be updated in a followup PR

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.