### PR TITLE
Enabled Dependabot for monthly minor version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    versioning-strategy: "lockfile-only"
+    ignore:
+      - dependency-name: "gateway-api"
+    allow:
+      - dependency-type: "direct"
+        update-types: ["semver:minor"]


### PR DESCRIPTION
Enabling Dependabot for monthly minor version updates on all dependencies except Gateway API