### PR TITLE
 BugFix: ServiceExport controller  should handle Pods IPs Mutation

### DIFF
--- a/controllers/serviceexport_controller.go
+++ b/controllers/serviceexport_controller.go
@@ -83,7 +83,8 @@ func RegisterServiceExportController(
 
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&anv1alpha1.ServiceExport{}).
-		Watches(&source.Kind{Type: &corev1.Service{}}, svcEventHandler.MapToServiceExport())
+		Watches(&source.Kind{Type: &corev1.Service{}}, svcEventHandler.MapToServiceExport()).
+		Watches(&source.Kind{Type: &corev1.Endpoints{}}, svcEventHandler.MapToServiceExport())
 
 	if ok, err := k8s.IsGVKSupported(mgr, anv1alpha1.GroupVersion.String(), anv1alpha1.TargetGroupPolicyKind); ok {
 		builder.Watches(&source.Kind{Type: &anv1alpha1.TargetGroupPolicy{}}, svcEventHandler.MapToServiceExport())

--- a/test/suites/integration/serviceexport_mutation_test.go
+++ b/test/suites/integration/serviceexport_mutation_test.go
@@ -6,10 +6,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 )
 
@@ -50,19 +55,55 @@ var _ = Describe("ServiceExport Mutation Test", func() {
 			)
 		})
 
-		When("Delete ServiceExport, while corresponding K8sService exists", func() {
-			It("Expect targetGroup not found", func() {
-				testFramework.ExpectDeletedThenNotFound(ctx, serviceExport)
-				testFramework.VerifyTargetGroupNotFound(targetGroup)
-			})
-		})
+		When("Update number of pods for a k8s service", func() {
+			It("Expect corresponding serviceExport created target group's targets change as well", func() {
 
-		When("Delete ServiceExport, while corresponding K8sService do NOT exists", func() {
-			It("Expect targetGroup not found", func() {
-				testFramework.ExpectDeletedThenNotFound(ctx, service)
-				time.Sleep(5 * time.Second)
-				testFramework.ExpectDeletedThenNotFound(ctx, serviceExport)
-				testFramework.VerifyTargetGroupNotFound(targetGroup)
+				//Get lattice targets before change deployment Replicas number
+				retrievedTargets, err := testFramework.LatticeClient.ListTargetsAsList(ctx, &vpclattice.ListTargetsInput{TargetGroupIdentifier: targetGroup.Id})
+				Expect(err).To(BeNil())
+				enpoints := v1.Endpoints{}
+				testFramework.Get(ctx, client.ObjectKeyFromObject(service), &enpoints)
+
+				Expect(len(retrievedTargets)).To(Equal(2))
+				Expect(len(enpoints.Subsets[0].Addresses)).To(Equal(2))
+				ipsFromK8sEndpoints := utils.SliceMap(enpoints.Subsets[0].Addresses, func(addr v1.EndpointAddress) string { return addr.IP })
+				ipsFromLatticeTargets := utils.SliceMap(retrievedTargets, func(target *vpclattice.TargetSummary) string { return *target.Id })
+				Expect(ipsFromK8sEndpoints).To(ConsistOf(ipsFromLatticeTargets))
+
+				//Update Deployment Replicas number to 3
+				testFramework.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
+				deployment.Spec.Replicas = lo.ToPtr(int32(3))
+				testFramework.ExpectUpdated(ctx, deployment)
+
+				Eventually(func(g Gomega) {
+					//Get lattice targets again
+					retrievedTargets, err := testFramework.LatticeClient.ListTargetsAsList(ctx, &vpclattice.ListTargetsInput{TargetGroupIdentifier: targetGroup.Id})
+					Expect(err).To(BeNil())
+					testFramework.Get(ctx, client.ObjectKeyFromObject(service), &enpoints)
+
+					g.Expect(len(retrievedTargets)).To(Equal(3))
+					g.Expect(len(enpoints.Subsets[0].Addresses)).To(Equal(3))
+					ipsFromK8sEndpoints = utils.SliceMap(enpoints.Subsets[0].Addresses, func(addr v1.EndpointAddress) string { return addr.IP })
+					ipsFromLatticeTargets = utils.SliceMap(retrievedTargets, func(target *vpclattice.TargetSummary) string { return *target.Id })
+					g.Expect(ipsFromK8sEndpoints).To(ConsistOf(ipsFromLatticeTargets))
+				}).Should(Succeed())
+
+			})
+
+			When("Delete ServiceExport, while corresponding K8sService exists", func() {
+				It("Expect targetGroup not found", func() {
+					testFramework.ExpectDeletedThenNotFound(ctx, serviceExport)
+					testFramework.VerifyTargetGroupNotFound(targetGroup)
+				})
+			})
+
+			When("Delete ServiceExport, while corresponding K8sService do NOT exists", func() {
+				It("Expect targetGroup not found", func() {
+					testFramework.ExpectDeletedThenNotFound(ctx, service)
+					time.Sleep(5 * time.Second)
+					testFramework.ExpectDeletedThenNotFound(ctx, serviceExport)
+					testFramework.VerifyTargetGroupNotFound(targetGroup)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**


**Which issue does this PR fix**: #477 



**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:

Added a new e2e test, new test can pass


Did following manual test:

1. kubectl apply -f examples/inventory-ver2.yaml (which includes a Deployment and a Service)
2. kubectl apply -f examples/inventory-ver2-export.yaml (which includes a ServiceExport)
3. VPC Lattice target group and its targets created as expected
4. do `kubectl get endpoints inventory-ver2`, all endpoints IP addresses == target group's targets IP addresses
5. do `kubectl rollout restart deployment inventory-ver2` to re-create all pods of inventory-ver2
6. do kubectl get endpoints inventory-ver2, all endpoints IP addresses change to new ones
7. serviceexport_controller could detect this endpoints change event, and register new and deregister old targets



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.