### PR TITLE
ci: Use specific commit of mattn/goveralls instead of shogo821/goveralls

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -30,6 +30,7 @@ jobs:
         key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
     - run: make toolchain
     - run: make presubmit
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        path-to-profile: coverage.out
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: goveralls -coverprofile=coverage.out -service=github

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -18,6 +18,7 @@ tools() {
     go install github.com/golang/mock/mockgen@v1.6.0
     go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220421205612-c162794a9b12
+    go install github.com/mattn/goveralls@b031368
 }
 
 kubebuilder() {


### PR DESCRIPTION
Fixes #N/A

**Description**

    * Update to use https://github.com/mattn/goveralls directly

**How was this change tested?**

    * `make presubmit`

**Does this change impact docs?**

    * [ ]  Yes, PR includes docs updates
    * [ ]  Yes, issue opened: #
    * [x]  No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
