### PR TITLE
Docs: Update Docs to reference IPv4 and IPv6 Prefix lists IDs directly when configuring Security Groups

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,18 +14,19 @@ Run through them again for a second cluster to use with the extended example sho
    ```bash
    eksctl create cluster --name $CLUSTER_NAME --region $AWS_REGION
    ```
-1. First, configure security group to receive traffic from the VPC Lattice fleet. You must set up security groups so that they allow all Pods communicating with VPC Lattice to allow traffic on all ports from the `169.254.171.0/24` address range.
+2. First, configure security group to receive traffic from the VPC Lattice network. You must set up security groups so that they allow all Pods communicating with VPC Lattice to allow traffic from the VPC Lattice managed prefix lists. Lattice has both an IPv4 and IPv6 prefix lists available.
     ```bash
-    PREFIX_LIST_ID=$(aws ec2 describe-managed-prefix-lists --query "PrefixLists[?PrefixListName=="\'com.amazonaws.$AWS_REGION.vpc-lattice\'"].PrefixListId" | jq -r '.[]')
-    MANAGED_PREFIX=$(aws ec2 get-managed-prefix-list-entries --prefix-list-id $PREFIX_LIST_ID --output json  | jq -r '.Entries[0].Cidr')
     CLUSTER_SG=$(aws eks describe-cluster --name $CLUSTER_NAME --output json| jq -r '.cluster.resourcesVpcConfig.clusterSecurityGroupId')
-    aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --cidr $MANAGED_PREFIX --protocol -1
+    PREFIX_LIST_ID=$(aws ec2 describe-managed-prefix-lists --query "PrefixLists[?PrefixListName=="\'com.amazonaws.$AWS_REGION.vpc-lattice\'"].PrefixListId" | jq -r '.[]')
+    aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --ip-permissions "PrefixListIds=[{PrefixListId=${PREFIX_LIST_ID}}],IpProtocol=-1"
+    PREFIX_LIST_ID_IPV6=$(aws ec2 describe-managed-prefix-lists --query "PrefixLists[?PrefixListName=="\'com.amazonaws.$AWS_REGION.ipv6.vpc-lattice\'"].PrefixListId" | jq -r '.[]')
+    aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --ip-permissions "PrefixListIds=[{PrefixListId=${PREFIX_LIST_ID_IPV6}}],IpProtocol=-1"
     ```
-1. Create an IAM OIDC provider: See [Creating an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for details.
+3. Create an IAM OIDC provider: See [Creating an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) for details.
    ```bash
    eksctl utils associate-iam-oidc-provider --cluster $CLUSTER_NAME --approve --region $AWS_REGION
    ```
-1. Create a policy (`recommended-inline-policy.json`) in IAM with the following content that can invoke the gateway API and copy the policy arn for later use:
+4. Create a policy (`recommended-inline-policy.json`) in IAM with the following content that can invoke the gateway API and copy the policy arn for later use:
    ```bash
    {
        "Version": "2012-10-17",
@@ -55,15 +56,15 @@ Run through them again for a second cluster to use with the extended example sho
       --policy-name VPCLatticeControllerIAMPolicy \
       --policy-document file://examples/recommended-inline-policy.json
    ```
-1. Create the `aws-application-networking-system` namespace:
+5. Create the `aws-application-networking-system` namespace:
    ```bash
    kubectl apply -f examples/deploy-namesystem.yaml
    ```
-1. Retrieve the policy ARN:
+6. Retrieve the policy ARN:
    ```bash
    export VPCLatticeControllerIAMPolicyArn=$(aws iam list-policies --query 'Policies[?PolicyName==`VPCLatticeControllerIAMPolicy`].Arn' --output text)
    ```
-1. Create an iamserviceaccount for pod level permission:
+7. Create an iamserviceaccount for pod level permission:
    ```bash
    eksctl create iamserviceaccount \
       --cluster=$CLUSTER_NAME \
@@ -74,7 +75,7 @@ Run through them again for a second cluster to use with the extended example sho
       --region $AWS_REGION \
       --approve
    ```
-1. Run either `kubectl` or `helm` to deploy the controller:
+8. Run either `kubectl` or `helm` to deploy the controller:
    ```bash
    kubectl apply -f examples/deploy-v0.0.17.yaml
    ```
@@ -96,7 +97,7 @@ Run through them again for a second cluster to use with the extended example sho
       --set=latticeEndpoint= \
    
    ```
-1. Create the `amazon-vpc-lattice` GatewayClass:
+9. Create the `amazon-vpc-lattice` GatewayClass:
    ```bash
    kubectl apply -f examples/gatewayclass.yaml
    ```

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -38,12 +38,11 @@ Create an EKS cluster and allow Lattice traffic into cluster.
 ```bash
 eksctl create cluster --name $CLUSTER_NAME --region $AWS_REGION
 
-/ update security group to allow lattice traffic
-PREFIX_LIST_ID=$(aws ec2 describe-managed-prefix-lists --query "PrefixLists[?PrefixListName=="\'com.amazonaws.$AWS_REGION.vpc-lattice\'"].PrefixListId" | jq -r '.[]')
-MANAGED_PREFIX=$(aws ec2 get-managed-prefix-list-entries --prefix-list-id $PREFIX_LIST_ID --output json  | jq -r '.Entries[0].Cidr')
 CLUSTER_SG=$(aws eks describe-cluster --name $CLUSTER_NAME --output json| jq -r '.cluster.resourcesVpcConfig.clusterSecurityGroupId')
-aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --cidr $MANAGED_PREFIX --protocol -1
-
+PREFIX_LIST_ID=$(aws ec2 describe-managed-prefix-lists --query "PrefixLists[?PrefixListName=="\'com.amazonaws.$AWS_REGION.vpc-lattice\'"].PrefixListId" | jq -r '.[]')
+aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --ip-permissions "PrefixListIds=[{PrefixListId=${PREFIX_LIST_ID}}],IpProtocol=-1"
+PREFIX_LIST_ID_IPV6=$(aws ec2 describe-managed-prefix-lists --query "PrefixLists[?PrefixListName=="\'com.amazonaws.$AWS_REGION.ipv6.vpc-lattice\'"].PrefixListId" | jq -r '.[]')
+aws ec2 authorize-security-group-ingress --group-id $CLUSTER_SG --ip-permissions "PrefixListIds=[{PrefixListId=${PREFIX_LIST_ID_IPV6}}],IpProtocol=-1"
 eksctl utils associate-iam-oidc-provider --cluster $CLUSTER_NAME --approve --region $AWS_REGION
 
 aws iam create-policy \

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -1,0 +1,36 @@
+run:
+  timeout: 30m
+  skip-files:
+  - "^zz_generated.*"
+
+issues:
+  max-same-issues: 0
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+  # exclude ineffassing linter for generated files for conversion
+  - path: conversion\.go
+    linters:
+    - ineffassign
+
+linters:
+  disable-all: true
+  enable:
+  - govet
+  - ineffassign
+  - staticcheck
+  - tenv
+
+linters-settings: # please keep this alphabetized
+  staticcheck:
+    go: "1.20"
+    checks: [
+      "all",
+      "-ST1000",  # Incorrect or missing package comment
+      "-ST1003",  # Poorly chosen identifier
+      "-ST1005",  # Incorrectly formatted error string
+      "-ST1006",  # Poorly chosen receiver name
+      "-ST1012",  # Poorly chosen name for error variable
+      "-ST1016",  # Use consistent method receiver names
+      "-SA1019",  # Using a deprecated function, variable, constant or field
+    ]
+


### PR DESCRIPTION
**What type of PR is this?**
documentation

This change to the documentation references the prefix list ID directly when configuring Security Groups so they can be dynamically updated when the prefix list entries in them change.

**Which issue does this PR fix**: #455 

**What does this PR do / Why do we need it**:
If the underlying IP range changes, traffic will be impacted to security groups that are not referencing the prefix list ID on the security group.


**Testing done on this change**:
Run a fresh controller deployment using the documentation


**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
This change to the documentation references the prefix list ID directly when configuring Security Groups so they can be dynamically updated when the prefix list entries in them change.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.