### PR TITLE
Bugfix: Remove deleting 5 min old and older TG logic

### DIFF
--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
@@ -342,15 +341,6 @@ func (t *TargetGroupSynthesizer) shouldDeleteRouteTg(
 			*latticeTg.getTargetGroupOutput.Arn, *latticeTg.getTargetGroupOutput.Name)
 
 		return true // safe to delete
-	}
-
-	// here we just delete anything more than X minutes old - worst case we'll have to recreate
-	// the target group - note this case is only theoretically possible at this point
-	fiveMinsAgo := time.Now().Add(-time.Minute * 5)
-	if fiveMinsAgo.After(aws.TimeValue(latticeTg.getTargetGroupOutput.CreatedAt)) {
-		t.log.Debugf("Will delete TargetGroup %s (%s) - TG is more than 5 minutes old",
-			*latticeTg.getTargetGroupOutput.Arn, *latticeTg.getTargetGroupOutput.Name)
-		return true
 	}
 
 	return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->


Remove deleting 5 min and older target group logic in the `calculateTargetGroupsToDelete()`

This code is originally used as a kind of backward compatible change for the Lattice Target Group naming breaking change(Target Group Ownership change), however, this code cause a bug when doing the performance test: 

When the controller is trying to synthesize lots of lattice services and target groups, in the middle of reconciliation, it has one time that many target groups are created but don't have lattice service's route reference it. This code logic could wrongly recognize  that this target group need to be deleted, but actually should not.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.