### PR TITLE
add more assertions to iam auth policy e2e test

### DIFF
--- a/controllers/iamauthpolicy_controller.go
+++ b/controllers/iamauthpolicy_controller.go
@@ -135,6 +135,11 @@ func (c *IAMAuthPolicyController) reconcileUpsert(ctx context.Context, k8sPolicy
 	var statusPolicy model.IAMAuthPolicyStatus
 	if validationErr == nil {
 		modelPolicy := model.NewIAMAuthPolicy(k8sPolicy)
+		c.addFinalizer(k8sPolicy)
+		err = c.client.Update(ctx, k8sPolicy)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		statusPolicy, err = c.policyMgr.Put(ctx, modelPolicy)
 		if err != nil {
 			return reconcile.Result{}, services.IgnoreNotFound(err)
@@ -145,7 +150,6 @@ func (c *IAMAuthPolicyController) reconcileUpsert(ctx context.Context, k8sPolicy
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	c.addFinalizer(k8sPolicy)
 	return ctrl.Result{}, nil
 }
 

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -311,7 +311,7 @@ func (env *Framework) ExpectDeleted(ctx context.Context, objects ...client.Objec
 }
 
 func (env *Framework) ExpectDeleteAllToSucceed(ctx context.Context, object client.Object, namespace string) {
-	Expect(env.DeleteAllOf(ctx, object, client.InNamespace(namespace), client.HasLabels([]string{DiscoveryLabel}))).WithOffset(1).To(Succeed())
+	Expect(env.DeleteAllOf(ctx, object, client.InNamespace(namespace))).WithOffset(1).To(Succeed())
 }
 
 func (env *Framework) EventuallyExpectNotFound(ctx context.Context, objects ...client.Object) {


### PR DESCRIPTION
Note:
- add finalizer to iam auth policy before calling lattice
- add more assertions to e2e tests
  - k8s annotations
  - lattice auth type and policy are set to correct values

```sh
------------------------------
IAM Auth Policy GroupName Error
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/iamauthpolicy_test.go:128
2023-11-10T14:22:24.877-0800	INFO	test/framework.go:223	Creating objects: *v1.Deployment/ratme-1-tnntyy59m5, *v1.Service/iam-auth-http, *v1beta1.HTTPRoute/iam-auth-http
• [1.191 seconds]
------------------------------
IAM Auth Policy Kind Error
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/iamauthpolicy_test.go:134
• [1.140 seconds]
------------------------------
IAM Auth Policy TargetRef Not Found
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/iamauthpolicy_test.go:140
• [0.101 seconds]
------------------------------
IAM Auth Policy TargetRef Conflict
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/iamauthpolicy_test.go:146
2023-11-10T14:22:28.430-0800	INFO	test/framework.go:301	Deleting objects: *v1alpha1.IAMAuthPolicy/conflict-1, *v1alpha1.IAMAuthPolicy/conflict-2
2023-11-10T14:22:28.471-0800	INFO	test/framework.go:318	Waiting for NotFound, objects: *v1alpha1.IAMAuthPolicy/conflict-1, *v1alpha1.IAMAuthPolicy/conflict-2
• [2.231 seconds]
------------------------------
IAM Auth Policy accepted, applied, and removed from Gateway
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/iamauthpolicy_test.go:154
2023-11-10T14:22:41.222-0800	INFO	iam-auth-policy	integration/iamauthpolicy_test.go:166	policy accepted: {statusReason:Accepted annotationResType:ServiceNetwork annotationResId:sn-0ece5abe68025ac3c}
2023-11-10T14:22:41.431-0800	INFO	iam-auth-policy	integration/iamauthpolicy_test.go:170	policy applied for SN=sn-0ece5abe68025ac3c
2023-11-10T14:22:41.432-0800	INFO	test/framework.go:301	Deleting objects: *v1alpha1.IAMAuthPolicy/gw
2023-11-10T14:22:41.463-0800	INFO	test/framework.go:318	Waiting for NotFound, objects: *v1alpha1.IAMAuthPolicy/gw
2023-11-10T14:22:42.713-0800	INFO	iam-auth-policy	integration/iamauthpolicy_test.go:175	policy removed from SN=sn-0ece5abe68025ac3c
• [13.173 seconds]
------------------------------
IAM Auth Policy accepted, applied, and removed from HTTPRoute
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/iamauthpolicy_test.go:178
2023-11-10T14:22:43.914-0800	INFO	iam-auth-policy	integration/iamauthpolicy_test.go:190	policy accepted: {statusReason:Accepted annotationResType:Service annotationResId:svc-0875340a6730ed4e8}
2023-11-10T14:22:44.116-0800	INFO	iam-auth-policy	integration/iamauthpolicy_test.go:194	policy applied for Svc=svc-0875340a6730ed4e8
2023-11-10T14:22:44.116-0800	INFO	test/framework.go:301	Deleting objects: *v1alpha1.IAMAuthPolicy/http
2023-11-10T14:22:44.175-0800	INFO	test/framework.go:318	Waiting for NotFound, objects: *v1alpha1.IAMAuthPolicy/http
2023-11-10T14:22:55.806-0800	INFO	iam-auth-policy	integration/iamauthpolicy_test.go:199	policy removed from Svc=svc-0875340a6730ed4e8
2023-11-10T14:22:55.806-0800	INFO	test/framework.go:256	Found 1 route objects
2023-11-10T14:22:55.837-0800	INFO	test/framework.go:275	Clearing http route rules for iam-auth-http
2023-11-10T14:23:05.877-0800	INFO	test/framework.go:301	Deleting objects: *v1.Deployment/ratme-1-tnntyy59m5, *v1.Service/iam-auth-http, *v1beta1.HTTPRoute/iam-auth-http
2023-11-10T14:23:05.946-0800	INFO	test/framework.go:318	Waiting for NotFound, objects: *v1.Deployment/ratme-1-tnntyy59m5, *v1.Service/iam-auth-http, *v1beta1.HTTPRoute/iam-auth-http
• [26.397 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[AfterSuite]
/Users/mhlbrz/workplace/aws-application-networking-k8s/test/suites/integration/suite_test.go:65
2023-11-10T14:23:09.112-0800	INFO	test/framework.go:301	Deleting objects: *v1beta1.Gateway/test-gateway, *v1.Pod/grpc-runner
2023-11-10T14:23:09.170-0800	INFO	test/framework.go:318	Waiting for NotFound, objects: *v1beta1.Gateway/test-gateway, *v1.Pod/grpc-runner
[AfterSuite] PASSED [31.088 seconds]
------------------------------

Ran 6 of 58 Specs in 96.271 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 52 Skipped
--- PASS: TestIntegration (97.30s)
PASS
```