### PR TITLE
Return 404 for invalid backendRefs

### DIFF
--- a/pkg/deploy/lattice/listener_synthesizer_test.go
+++ b/pkg/deploy/lattice/listener_synthesizer_test.go
@@ -44,37 +44,6 @@ func Test_SynthesizeListenerCreate(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_SynthesizeListenerDeleteNoOp(t *testing.T) {
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockListenerMgr := NewMockListenerManager(c)
-
-	stack := core.NewDefaultStack(core.StackID{Name: "foo", Namespace: "bar"})
-
-	svc := &model.Service{
-		ResourceMeta: core.NewResourceMeta(stack, "AWS:VPCServiceNetwork::Service", "stack-svc-id"),
-		Status:       &model.ServiceStatus{Id: "svc-id"},
-	}
-	assert.NoError(t, stack.AddResource(svc))
-
-	l := &model.Listener{
-		ResourceMeta: core.NewResourceMeta(stack, "AWS:VPCServiceNetwork::Listener", "l-id"),
-		Spec: model.ListenerSpec{
-			StackServiceId: "stack-svc-id",
-		},
-		IsDeleted: true, // <-- the bit that matters
-	}
-	assert.NoError(t, stack.AddResource(l))
-
-	// since we aren't returning any resources, we interpret that to mean the listener is already deleted
-	mockListenerMgr.EXPECT().List(ctx, gomock.Any()).Return([]*vpclattice.ListenerSummary{}, nil)
-
-	ls := NewListenerSynthesizer(gwlog.FallbackLogger, mockListenerMgr, stack)
-	err := ls.Synthesize(ctx)
-	assert.Nil(t, err)
-}
-
 func Test_SynthesizeListenerCreateWithReconcile(t *testing.T) {
 	c := gomock.NewController(t)
 	defer c.Finish()

--- a/pkg/deploy/lattice/rule_synthesizer.go
+++ b/pkg/deploy/lattice/rule_synthesizer.go
@@ -49,6 +49,12 @@ func (r *ruleSynthesizer) resolveRuleTgIds(ctx context.Context, modelRule *model
 		}
 
 		if rtg.StackTargetGroupId != "" {
+			if rtg.StackTargetGroupId == model.InvalidBackendRefTgId {
+				r.log.Debugf("Rule TG has an invalid backendref, setting TG id to invalid")
+				rtg.LatticeTgId = model.InvalidBackendRefTgId
+				continue
+			}
+
 			r.log.Debugf("Fetching TG %d from the stack (ID %s)", i, rtg.StackTargetGroupId)
 
 			stackTg := &model.TargetGroup{}

--- a/pkg/deploy/lattice/rule_synthesizer_test.go
+++ b/pkg/deploy/lattice/rule_synthesizer_test.go
@@ -166,6 +166,9 @@ func Test_resolveRuleTgs(t *testing.T) {
 					{
 						StackTargetGroupId: "stack-tg-id",
 					},
+					{
+						StackTargetGroupId: model.InvalidBackendRefTgId,
+					},
 				},
 			},
 		},
@@ -197,4 +200,5 @@ func Test_resolveRuleTgs(t *testing.T) {
 
 	assert.Equal(t, "svc-export-tg-id", r.Spec.Action.TargetGroups[0].LatticeTgId)
 	assert.Equal(t, "tg-id", r.Spec.Action.TargetGroups[1].LatticeTgId)
+	assert.Equal(t, model.InvalidBackendRefTgId, r.Spec.Action.TargetGroups[2].LatticeTgId)
 }

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -24,6 +24,15 @@ import (
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 )
 
+type InvalidBackendRefError struct {
+	BackendRef core.BackendRef
+	Reason     string
+}
+
+func (e *InvalidBackendRefError) Error() string {
+	return e.Reason
+}
+
 type SvcExportTargetGroupModelBuilder interface {
 	// used during standard model build
 	Build(ctx context.Context, svcExport *anv1alpha1.ServiceExport) (core.Stack, error)
@@ -247,7 +256,7 @@ func (t *backendRefTargetGroupModelBuildTask) buildTargetGroup(ctx context.Conte
 	}
 	t.log.Debugf("Added target group for backendRef %s to the stack %s", t.backendRef.Name(), stackTG.ID())
 
-	stackTG.IsDeleted = !t.route.DeletionTimestamp().IsZero()
+	stackTG.IsDeleted = !t.route.DeletionTimestamp().IsZero() // should always be false
 	if !stackTG.IsDeleted {
 		t.buildTargets(ctx, stackTG.ID())
 	}
@@ -260,16 +269,10 @@ func (t *backendRefTargetGroupModelBuildTask) buildTargets(ctx context.Context, 
 		t.log.Debugf("Service import does not manage targets, returning")
 		return nil
 	}
-
 	backendRefNsName := getBackendRefNsName(t.route, t.backendRef)
 	svc := &corev1.Service{}
 	if err := t.client.Get(ctx, backendRefNsName, svc); err != nil {
-		if apierrors.IsNotFound(err) && !t.route.DeletionTimestamp().IsZero() {
-			t.log.Infof("Ignoring not found error for service %s on deleted route %s",
-				t.backendRef.Name(), t.route.Name())
-		} else {
-			return fmt.Errorf("error finding backend service %s due to %s", backendRefNsName, err)
-		}
+		return fmt.Errorf("error finding backend service %s due to %s", backendRefNsName, err)
 	}
 
 	targetsBuilder := NewTargetsBuilder(t.log, t.client, t.stack)
@@ -283,20 +286,21 @@ func (t *backendRefTargetGroupModelBuildTask) buildTargets(ctx context.Context, 
 
 // Now, Only k8sService and serviceImport creation deletion use this function to build TargetGroupSpec, serviceExport does not use this function to create TargetGroupSpec
 func (t *backendRefTargetGroupModelBuildTask) buildTargetGroupSpec(ctx context.Context) (model.TargetGroupSpec, error) {
+	// note we only build target groups for backendRefs on non-deleted routes
 	backendKind := string(*t.backendRef.Kind())
 	t.log.Debugf("buildTargetGroupSpec, kind %s", backendKind)
 
 	vpc := config.VpcID
 	eksCluster := config.ClusterName
-	routeIsDeleted := !t.route.DeletionTimestamp().IsZero()
-
 	backendRefNsName := getBackendRefNsName(t.route, t.backendRef)
 	svc := &corev1.Service{}
 	if err := t.client.Get(ctx, backendRefNsName, svc); err != nil {
-		if routeIsDeleted && apierrors.IsNotFound(err) {
-			t.log.Infof("Ignoring not found error for service %s on deleted route %s",
-				t.backendRef.Name(), t.route.Name())
-		} else if !routeIsDeleted {
+		if apierrors.IsNotFound(err) {
+			return model.TargetGroupSpec{}, &InvalidBackendRefError{
+				BackendRef: t.backendRef,
+				Reason:     fmt.Sprintf("service %s on route %s not found, backendRef invalid", backendRefNsName.Name, t.route.Name()),
+			}
+		} else {
 			return model.TargetGroupSpec{},
 				fmt.Errorf("error finding backend service %s due to %s", backendRefNsName, err)
 		}
@@ -307,14 +311,7 @@ func (t *backendRefTargetGroupModelBuildTask) buildTargetGroupSpec(ctx context.C
 	if svc != nil {
 		ipAddressType, err = buildTargetGroupIpAddressType(svc)
 		if err != nil {
-			if routeIsDeleted {
-				// Ignore error for deletion request
-				t.log.Debugf("Unable to determine IP address type for deleted route, using default")
-				ipAddressType = vpclattice.IpAddressTypeIpv4
-			} else {
-				// we care that there's an error if we are not deleting
-				return model.TargetGroupSpec{}, err
-			}
+			return model.TargetGroupSpec{}, err
 		}
 	}
 

--- a/pkg/model/lattice/listener.go
+++ b/pkg/model/lattice/listener.go
@@ -8,7 +8,6 @@ type Listener struct {
 	core.ResourceMeta `json:"-"`
 	Spec              ListenerSpec    `json:"spec"`
 	Status            *ListenerStatus `json:"status,omitempty"`
-	IsDeleted         bool            `json:"isdeleted"`
 }
 
 type ListenerSpec struct {

--- a/pkg/model/lattice/rule.go
+++ b/pkg/model/lattice/rule.go
@@ -14,7 +14,8 @@ type Rule struct {
 }
 
 const (
-	MaxRulePriority = 100
+	MaxRulePriority       = 100
+	InvalidBackendRefTgId = "INVALID"
 )
 
 type RuleSpec struct {

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -467,9 +467,9 @@ func (env *Framework) GetTargets(ctx context.Context, targetGroup *vpclattice.Ta
 					*target.Status == vpclattice.TargetStatusHealthy)
 		})
 
-		g.Expect(retrievedTargets).Should(HaveLen(len(targetIps)))
+		g.Expect(targetIps).Should(HaveLen(len(podIps)))
 		found = retrievedTargets
-	}).WithPolling(time.Minute).WithTimeout(7 * time.Minute).Should(Succeed())
+	}).WithPolling(15 * time.Second).WithTimeout(7 * time.Minute).Should(Succeed())
 	return found
 }
 
@@ -478,7 +478,7 @@ func (env *Framework) GetAllTargets(ctx context.Context, targetGroup *vpclattice
 }
 
 func GetTargets(targetGroup *vpclattice.TargetGroupSummary, deployment *appsv1.Deployment, env *Framework, ctx context.Context) ([]string, []*vpclattice.TargetSummary) {
-	env.Log.Infoln("Trying to retrieve registered targets for targetGroup", targetGroup.Name)
+	env.Log.Infoln("Trying to retrieve registered targets for targetGroup", *targetGroup.Name)
 	env.Log.Infoln("deployment.Spec.Selector.MatchLabels:", deployment.Spec.Selector.MatchLabels)
 	podList := &corev1.PodList{}
 	expectedMatchingLabels := make(map[string]string, len(deployment.Spec.Selector.MatchLabels))


### PR DESCRIPTION
**What type of PR is this?**
bug fix

**Which issue does this PR fix**:
#493 

**What does this PR do / Why do we need it**:
First, this PR aligns the implementation more with the gateway spec for invalid backendRefs. With this change, invalid backendRefs will either be omitted when another backendRef exists that is valid or will configure the rule to return a 404. 

Second, when building listener model objects, we will no longer create model objects for deleted listeners. As I was making this change, I simplified the listener logic that was tracking deletes. Since we never actually delete listeners and they are deleted when the service is deleted, I've removed the unneeded code.

**Testing done on this change**:

***Manual Testing***
The following shows adding a route with an invalid backendRef, then adding the service (so the backendRef is valid), then deleting the service again (returns to an invalid backendRef).

First, the backendRef results in a fixedResponse 404
```
└─[$] <git:(tg-svc-fix*)> [laptop] kubectl apply -f examples/my-hotel-gateway.yaml
└─[$] <git:(tg-svc-fix*)> [laptop] kubectl apply -f examples/inventory-route.yaml
└─[$] <git:(tg-svc-fix*)> [laptop] aws vpc-lattice get-rule --service-identifier svc-X --listener-identifier listener-X --rule-identifier rule-X
{
    "action": {
        "fixedResponse": {
            "statusCode": 404
        }
    },
    "arn": "arn:aws:vpc-lattice:...",
...
    "priority": 1
}

```

Next, we get a real target group after creating the service
```
└─[$] <git:(tg-svc-fix*)> [laptop] kubectl apply -f examples/inventory-ver1.yaml
└─[$] <git:(tg-svc-fix*)> [laptop] aws vpc-lattice get-rule --service-identifier svc-X --listener-identifier listener-X --rule-identifier rule-X
{
    "action": {
        "forward": {
            "targetGroups": [
                {
                    "targetGroupIdentifier": "tg-X",
                    "weight": 10
                }
            ]
        }
    },
    "arn": "arn:aws:vpc-lattice:...",
...
}
```

Then we delete the service and get a fixed response again
```
└─[$] <git:(tg-svc-fix*)> [laptop] kubectl delete -f examples/inventory-ver1.yaml
└─[$] <git:(tg-svc-fix*)> [laptop] aws vpc-lattice get-rule --service-identifier svc-X --listener-identifier listener-X --rule-identifier rule-X
{
    "action": {
        "fixedResponse": {
            "statusCode": 404
        }
    },
    "arn": "arn:aws:vpc-lattice:...",
    ...
}
```


**Automation added to e2e**:
Changed ```deregister_targets_test.go``` to ```delete_target_groups_test.go```. What we actually want are target groups for a service to be deleted when that service is deleted. So I've updated the test to reflect this.

I also saw some issues in validating targets for target groups in ```https_listener_weighted_rule_with_service_export_import_test.go``` so fixed the logic that was checking the wrong lengths in ```framework.go```


**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
```release-note
Reconciliation is now more tolerant of invalid backendRefs. Deleted services or incorrect references will no longer block route reconciliation.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.