### PR TITLE
Provide default gateway setup

### DIFF
--- a/controllers/vpcassociationpolicy_controller.go
+++ b/controllers/vpcassociationpolicy_controller.go
@@ -38,6 +38,7 @@ func RegisterVpcAssociationPolicyController(log gwlog.Logger, mgr ctrl.Manager, 
 		cloud:   cloud,
 		manager: deploy.NewDefaultServiceNetworkManager(log, cloud),
 	}
+
 	eh := eventhandlers.NewPolicyEventHandler(log, mgr.GetClient(), &anv1alpha1.VpcAssociationPolicy{})
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&anv1alpha1.VpcAssociationPolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/docs/configure/environment.md
+++ b/docs/configure/environment.md
@@ -55,84 +55,23 @@ When set as "debug", the AWS Gateway API Controller will emit debug level logs.
 
 ---
 
-#### `CLUSTER_LOCAL_GATEWAY`
+#### `DEFAULT_SERVICE_NETWORK`
 
 Type: string
 
-Default: "NO_DEFAULT_SERVICE_NETWORK"
+Default: ""
 
-When it is set to something different from "NO_DEFAULT_SERVICE_NETWORK", the AWS Gateway API Controller will associate its correspoding Lattice Service Network to cluster's VPC.
-Also, all HTTPRoutes will automatically have an additional parentref to this `CLUSTER_LOCAL_GATEWAY`.
+When set as a non-empty value, creates a service network with that name.
+The created service network will be also associated with cluster VPC.
 
 ---
 
-#### `TARGET_GROUP_NAME_LEN_MODE`
+#### `ENABLE_NETWORK_OVERRIDE`
 
 Type: string
 
-Default:  "short"
+Default: ""
 
-When set to "long", the controller will create Lattice TargetGroup as follows.
-
-For Kubernetes Service as BackendRef:
-
-`k8s-(k8s service name)-(k8s service namespace)-(k8s httproute name)-(VPC ID)-(protocol)-(protocol version)`
-
-For ServiceExport of a Kubernetes Service:
-
-`k8s-(k8s service name)-(k8s service namespace)-(VPC-ID)-(protocol)-(protocol version)`
-
-By default, the controller will create Lattice TargetGroup as follows
-
-For Kubernetes Service as BackendRef:
-
-`k8s-(k8s service name)-(k8s service namespace)-(protocol)-(protocol version)`
-
-For ServiceExport of a Kubernetes Service:
-
-`k8s-(k8s service name)-(k8s service namespace)-(protocol)-(protocol version)`
-
-
-```
-# for  examples/inventory-route.yaml 
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: HTTPRoute
-metadata:
-  name: inventory
-spec:
-  parentRefs:
-  - name: my-hotel
-    sectionName: http
-  rules:
-  - backendRefs:
-    - name: inventory-ver1
-      kind: Service
-      port: 8090
-      weight: 10
-
- # by default, lattice target group name 
- k8s-inventory-ver1-default
-
-
- # when TARGET_GROUP_NAME_LEN_MODE = "long", lattice target group name, e.g.
-
- k8s-inventory-ver1-default-inventory-vpc-05c7322a3df3f255a
-
-```
-
-```
-# for examples/parking-ver2-export.yaml 
-apiVersion: application-networking.k8s.aws/v1alpha1
-kind: ServiceExport
-metadata:
-  name: parking-ver2
-  annotations:
-    application-networking.k8s.aws/federation: "amazon-vpc-lattice"
-
-# by default, lattice target group name is
-k8s-parking-ver2-default
-
-# when TARGET_GROUP_NAME_LEN_MODE = "long", lattice target group name, e.g.
-k8s-parking-ver2-default-vpc-05c7322a3df3f255a
-
-```
+When set as "true", the controller will run in "single service network" mode that will override all gateways
+to point to default service network, instead of searching for service network with the same name.
+Can be used for small setups and conformance tests.

--- a/docs/configure/environment.md
+++ b/docs/configure/environment.md
@@ -66,7 +66,7 @@ The created service network will be also associated with cluster VPC.
 
 ---
 
-#### `ENABLE_NETWORK_OVERRIDE`
+#### `ENABLE_SERVICE_NETWORK_OVERRIDE`
 
 Type: string
 

--- a/docs/conformance-test.md
+++ b/docs/conformance-test.md
@@ -54,7 +54,7 @@
 ```
 # run controller in following mode
 
-REGION=us-west-2 DEFAULT_SERVICE_NETWORK=my-cluster-default ENABLE_NETWORK_OVERRIDE=true \
+REGION=us-west-2 DEFAULT_SERVICE_NETWORK=my-cluster-default ENABLE_SERVICE_NETWORK_OVERRIDE=true \
 make run
 ```
 

--- a/docs/conformance-test.md
+++ b/docs/conformance-test.md
@@ -52,12 +52,9 @@
 ### Running controller from cloud desktop
 
 ```
-# create a gateway first in the cluster
-kubectl apply -f examples/my-hotel-gateway.yaml
-
 # run controller in following mode
 
-REGION=us-west-2 CLUSTER_LOCAL_GATEWAY=my-hotel TARGET_GROUP_NAME_LEN_MODE="long" \
+REGION=us-west-2 DEFAULT_SERVICE_NETWORK=my-cluster-default ENABLE_NETWORK_OVERRIDE=true \
 make run
 ```
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -110,6 +110,8 @@ And use "EnvFile" GoLand plugin to read the env variables from the generated `.e
 ## End-to-End Testing
 
 For larger changes it's recommended to run e2e suites on your local cluster.
+E2E tests require a service network named `test-gateway` with cluster VPC associated to run.
+You can either setup service network manually or use DEFAULT_SERVICE_NETWORK option when running controller locally. (e.g. `DEFAULT_SERVICE_NETWORK=test-gateway make run`)
 
 ```
 REGION=us-west-2 make e2e-test
@@ -154,9 +156,6 @@ For larger, functional changes, run e2e tests:
 ```sh
 make e2e-test
 ```
-
-It is recommended to run `make e2e-test` in both environments where `DNSEndpoint` CRD exists and does not exist,
-as the controller is designed to support both use cases.
 
 ## Make Docker Image
 

--- a/pkg/aws/services/vpclattice.go
+++ b/pkg/aws/services/vpclattice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -310,6 +311,10 @@ func (d *defaultLattice) ListServiceNetworkServiceAssociationsAsList(ctx context
 }
 
 func (d *defaultLattice) FindServiceNetwork(ctx context.Context, name string, optionalAccountId string) (*ServiceNetworkInfo, error) {
+	// When default service network is provided, override for any kind of SN search
+	if config.NetworkOverrideMode {
+		name = config.DefaultServiceNetwork
+	}
 	input := vpclattice.ListServiceNetworksInput{}
 
 	var innerErr error

--- a/pkg/aws/services/vpclattice.go
+++ b/pkg/aws/services/vpclattice.go
@@ -312,7 +312,7 @@ func (d *defaultLattice) ListServiceNetworkServiceAssociationsAsList(ctx context
 
 func (d *defaultLattice) FindServiceNetwork(ctx context.Context, name string, optionalAccountId string) (*ServiceNetworkInfo, error) {
 	// When default service network is provided, override for any kind of SN search
-	if config.NetworkOverrideMode {
+	if config.ServiceNetworkOverrideMode {
 		name = config.DefaultServiceNetwork
 	}
 	input := vpclattice.ListServiceNetworksInput{}

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -18,12 +18,12 @@ const (
 )
 
 const (
-	REGION                  = "REGION"
-	CLUSTER_VPC_ID          = "CLUSTER_VPC_ID"
-	CLUSTER_NAME            = "CLUSTER_NAME"
-	DEFAULT_SERVICE_NETWORK = "DEFAULT_SERVICE_NETWORK"
-	ENABLE_NETWORK_OVERRIDE = "ENABLE_NETWORK_OVERRIDE"
-	AWS_ACCOUNT_ID          = "AWS_ACCOUNT_ID"
+	REGION                          = "REGION"
+	CLUSTER_VPC_ID                  = "CLUSTER_VPC_ID"
+	CLUSTER_NAME                    = "CLUSTER_NAME"
+	DEFAULT_SERVICE_NETWORK         = "DEFAULT_SERVICE_NETWORK"
+	ENABLE_SERVICE_NETWORK_OVERRIDE = "ENABLE_SERVICE_NETWORK_OVERRIDE"
+	AWS_ACCOUNT_ID                  = "AWS_ACCOUNT_ID"
 )
 
 var VpcID = ""
@@ -33,7 +33,7 @@ var logLevel = defaultLogLevel
 var DefaultServiceNetwork = ""
 var ClusterName = ""
 
-var NetworkOverrideMode = false
+var ServiceNetworkOverrideMode = false
 
 func ConfigInit() error {
 	sess, _ := session.NewSession()
@@ -74,9 +74,9 @@ func configInit(sess *session.Session, metadata EC2Metadata) error {
 	// DEFAULT_SERVICE_NETWORK
 	DefaultServiceNetwork = os.Getenv(DEFAULT_SERVICE_NETWORK)
 
-	networkOverride := os.Getenv(ENABLE_NETWORK_OVERRIDE)
-	if strings.ToLower(networkOverride) == "true" && DefaultServiceNetwork != "" {
-		NetworkOverrideMode = true
+	overrideFlag := os.Getenv(ENABLE_SERVICE_NETWORK_OVERRIDE)
+	if strings.ToLower(overrideFlag) == "true" && DefaultServiceNetwork != "" {
+		ServiceNetworkOverrideMode = true
 	}
 
 	// CLUSTER_NAME

--- a/pkg/config/controller_config_test.go
+++ b/pkg/config/controller_config_test.go
@@ -35,7 +35,7 @@ func Test_config_init_with_partial_env_var(t *testing.T) {
 
 	os.Setenv(REGION, testRegion)
 	os.Setenv(CLUSTER_VPC_ID, testClusterVpcId)
-	os.Setenv(CLUSTER_LOCAL_GATEWAY, testClusterLocalGateway)
+	os.Setenv(DEFAULT_SERVICE_NETWORK, testClusterLocalGateway)
 	os.Unsetenv(AWS_ACCOUNT_ID)
 	err := configInit(nil, ec2MetadataUnavailable())
 	assert.NotNil(t, err)
@@ -44,7 +44,7 @@ func Test_config_init_with_partial_env_var(t *testing.T) {
 func Test_config_init_no_env_var(t *testing.T) {
 	os.Unsetenv(REGION)
 	os.Unsetenv(CLUSTER_VPC_ID)
-	os.Unsetenv(CLUSTER_LOCAL_GATEWAY)
+	os.Unsetenv(DEFAULT_SERVICE_NETWORK)
 	os.Unsetenv(AWS_ACCOUNT_ID)
 	err := configInit(nil, ec2MetadataUnavailable())
 	assert.NotNil(t, err)
@@ -61,7 +61,7 @@ func Test_config_init_with_all_env_var(t *testing.T) {
 
 	os.Setenv(REGION, testRegion)
 	os.Setenv(CLUSTER_VPC_ID, testClusterVpcId)
-	os.Setenv(CLUSTER_LOCAL_GATEWAY, testClusterLocalGateway)
+	os.Setenv(DEFAULT_SERVICE_NETWORK, testClusterLocalGateway)
 	os.Setenv(AWS_ACCOUNT_ID, testAwsAccountId)
 	os.Setenv(CLUSTER_NAME, testClusterName)
 	configInit(nil, ec2MetadataUnavailable())

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -192,7 +192,7 @@ func (m *defaultServiceNetworkManager) CreateOrUpdate(ctx context.Context, servi
 			return model.ServiceNetworkStatus{}, err
 		}
 		if snva != nil {
-			m.log.Debugf("ServiceNetwork %s also has VPC association %s", serviceNetwork.Spec.Name, snva.Arn)
+			m.log.Debugf("ServiceNetwork %s already has VPC association %s", serviceNetwork.Spec.Name, snva.Arn)
 			return model.ServiceNetworkStatus{ServiceNetworkARN: serviceNetworkArn, ServiceNetworkID: serviceNetworkId}, nil
 		}
 	}

--- a/pkg/deploy/lattice/service_network_manager_mock.go
+++ b/pkg/deploy/lattice/service_network_manager_mock.go
@@ -50,20 +50,6 @@ func (mr *MockServiceNetworkManagerMockRecorder) CreateOrUpdate(arg0, arg1 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockServiceNetworkManager)(nil).CreateOrUpdate), arg0, arg1)
 }
 
-// Delete mocks base method.
-func (m *MockServiceNetworkManager) Delete(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockServiceNetworkManagerMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockServiceNetworkManager)(nil).Delete), arg0, arg1)
-}
-
 // DeleteVpcAssociation mocks base method.
 func (m *MockServiceNetworkManager) DeleteVpcAssociation(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -76,21 +62,6 @@ func (m *MockServiceNetworkManager) DeleteVpcAssociation(arg0 context.Context, a
 func (mr *MockServiceNetworkManagerMockRecorder) DeleteVpcAssociation(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcAssociation", reflect.TypeOf((*MockServiceNetworkManager)(nil).DeleteVpcAssociation), arg0, arg1)
-}
-
-// List mocks base method.
-func (m *MockServiceNetworkManager) List(arg0 context.Context) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// List indicates an expected call of List.
-func (mr *MockServiceNetworkManagerMockRecorder) List(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockServiceNetworkManager)(nil).List), arg0)
 }
 
 // UpsertVpcAssociation mocks base method.

--- a/pkg/deploy/lattice/service_network_manager_test.go
+++ b/pkg/deploy/lattice/service_network_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 
 	"github.com/golang/mock/gomock"
@@ -17,47 +16,8 @@ import (
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	"github.com/aws/aws-sdk-go/aws"
 )
-
-// ServiceNetwork does not exist before, happy case.
-func Test_CreateOrUpdateServiceNetwork_SnNotExist_NoNeedToAssociate(t *testing.T) {
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-
-	snCreateInput := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:           "test",
-			Account:        "123456789",
-			AssociateToVPC: false,
-		},
-		Status: &model.ServiceNetworkStatus{ServiceNetworkARN: "", ServiceNetworkID: ""},
-	}
-	arn := "12345678912345678912"
-	id := "12345678912345678912"
-	name := "test"
-	snCreateOutput := &vpclattice.CreateServiceNetworkOutput{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name,
-	}
-	createServiceNetworkInput := &vpclattice.CreateServiceNetworkInput{
-		Name: &name,
-		Tags: cloud.DefaultTags(),
-	}
-	createServiceNetworkInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-
-	mockLattice.EXPECT().CreateServiceNetworkWithContext(ctx, createServiceNetworkInput).Return(snCreateOutput, nil)
-	mockLattice.EXPECT().FindServiceNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &mocks.NotFoundError{}).Times(1)
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &snCreateInput)
-
-	assert.Nil(t, err)
-	assert.Equal(t, resp.ServiceNetworkARN, arn)
-	assert.Equal(t, resp.ServiceNetworkID, id)
-}
 
 func Test_CreateOrUpdateServiceNetwork_SnNotExist_NeedToAssociate(t *testing.T) {
 	c := gomock.NewController(t)
@@ -68,9 +28,8 @@ func Test_CreateOrUpdateServiceNetwork_SnNotExist_NeedToAssociate(t *testing.T) 
 
 	snCreateInput := model.ServiceNetwork{
 		Spec: model.ServiceNetworkSpec{
-			Name:           "test",
-			Account:        "123456789",
-			AssociateToVPC: true,
+			Name:    "test",
+			Account: "123456789",
 		},
 		Status: &model.ServiceNetworkStatus{ServiceNetworkARN: "", ServiceNetworkID: ""},
 	}
@@ -87,7 +46,6 @@ func Test_CreateOrUpdateServiceNetwork_SnNotExist_NeedToAssociate(t *testing.T) 
 		Name: &name,
 		Tags: cloud.DefaultTags(),
 	}
-	createServiceNetworkInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
 
 	mockLattice.EXPECT().CreateServiceNetworkWithContext(ctx, createServiceNetworkInput).Return(snCreateOutput, nil)
 	snId := "12345678912345678912"
@@ -264,7 +222,6 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 	snId := "12345678912345678912"
 	snArn := "12345678912345678912"
 	name := "test"
-	vpcId := config.VpcID
 	item := vpclattice.ServiceNetworkSummary{
 		Arn:  &snArn,
 		Id:   &snId,
@@ -286,15 +243,7 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 			SvcNetwork: item,
 			Tags:       nil,
 		}, nil)
-	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &name,
-		Status:             aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
-		VpcId:              &vpcId,
-	}, nil)
 	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
 
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
 	resp, err := snMgr.CreateOrUpdate(ctx, &snCreateInput)
@@ -304,298 +253,7 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 	assert.Equal(t, resp.ServiceNetworkID, snId)
 }
 
-func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_UpdateSNVASecurityGroups(t *testing.T) {
-	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
-	snCreateInput := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:             "test",
-			Account:          "123456789",
-			AssociateToVPC:   true,
-			SecurityGroupIds: securityGroupIds,
-		},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	vpcId := config.VpcID
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-
-	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	items := vpclattice.ServiceNetworkVpcAssociationSummary{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &snId,
-		Status:             &status,
-		VpcId:              &config.VpcID,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       nil,
-		}, nil)
-	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &name,
-		Status:             aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
-		VpcId:              &vpcId,
-		//SecurityGroupIds:   []*string{aws.String("sg-123456789"), aws.String("sg-987654321")},
-	}, nil)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).MaxTimes(0)
-	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.UpdateServiceNetworkVpcAssociationOutput{
-		Arn:              &snArn,
-		Id:               &snId,
-		SecurityGroupIds: securityGroupIds,
-		Status:           aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
-	}, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &snCreateInput)
-
-	assert.Equal(t, err, nil)
-	assert.Equal(t, resp.ServiceNetworkARN, snArn)
-	assert.Equal(t, resp.ServiceNetworkID, snId)
-	assert.Equal(t, resp.SnvaSecurityGroupIds, securityGroupIds)
-}
-
-func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_SecurityGroupsDoNotNeedToBeUpdated(t *testing.T) {
-	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
-	desiredSn := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:             "test",
-			Account:          "123456789",
-			AssociateToVPC:   true,
-			SecurityGroupIds: securityGroupIds,
-		},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	vpcId := config.VpcID
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-
-	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	items := vpclattice.ServiceNetworkVpcAssociationSummary{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &snId,
-		Status:             &status,
-		VpcId:              &config.VpcID,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       nil,
-		}, nil)
-	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &name,
-		Status:             &status,
-		VpcId:              &vpcId,
-		SecurityGroupIds:   securityGroupIds,
-	}, nil)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).Times(0)
-	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &desiredSn)
-
-	assert.Equal(t, err, nil)
-	assert.Equal(t, resp.ServiceNetworkARN, snArn)
-	assert.Equal(t, resp.ServiceNetworkID, snId)
-	assert.Equal(t, resp.SnvaSecurityGroupIds, securityGroupIds)
-}
-func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaCreateInProgress_WillNotInvokeLatticeUpdateSNVA(t *testing.T) {
-	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
-	desiredSn := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:             "test",
-			Account:          "123456789",
-			AssociateToVPC:   true,
-			SecurityGroupIds: securityGroupIds,
-		},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-
-	status := vpclattice.ServiceNetworkVpcAssociationStatusCreateInProgress
-	items := vpclattice.ServiceNetworkVpcAssociationSummary{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &snId,
-		Status:             &status,
-		VpcId:              &config.VpcID,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       nil,
-		}, nil)
-	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).Times(0)
-	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &desiredSn)
-
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-	assert.Equal(t, resp.ServiceNetworkARN, "")
-	assert.Equal(t, resp.ServiceNetworkID, "")
-}
-
-func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_CannotUpdateSecurityGroupsFromNonemptyToEmpty(t *testing.T) {
-	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
-	desiredSn := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:             "test",
-			Account:          "123456789",
-			AssociateToVPC:   true,
-			SecurityGroupIds: []*string{},
-		},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-
-	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	items := vpclattice.ServiceNetworkVpcAssociationSummary{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &snId,
-		Status:             &status,
-		VpcId:              &config.VpcID,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	mockCloud := pkg_aws.NewMockCloud(c)
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       nil,
-		}, nil)
-	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &name,
-		Status:             aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
-		VpcId:              &config.VpcID,
-		SecurityGroupIds:   securityGroupIds,
-	}, nil)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).Times(0)
-	updateSNVAError := errors.New("InvalidParameterException SecurityGroupIds cannot be empty")
-	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.UpdateServiceNetworkVpcAssociationOutput{}, updateSNVAError)
-
-	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, mockCloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &desiredSn)
-
-	assert.Equal(t, err, updateSNVAError)
-	assert.Equal(t, resp.ServiceNetworkARN, "")
-	assert.Equal(t, resp.ServiceNetworkID, "")
-}
-
-func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_AssociateToNotAssociate(t *testing.T) {
-	snCreateInput := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:           "test",
-			Account:        "123456789",
-			AssociateToVPC: false,
-		},
-		Status: &model.ServiceNetworkStatus{ServiceNetworkARN: "", ServiceNetworkID: ""},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-
-	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	items := vpclattice.ServiceNetworkVpcAssociationSummary{
-		ServiceNetworkArn:  &snArn,
-		ServiceNetworkId:   &snId,
-		ServiceNetworkName: &snId,
-		Status:             &status,
-		VpcId:              &config.VpcID,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       nil,
-		}, nil)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	deleteInProgressStatus := vpclattice.ServiceNetworkVpcAssociationStatusDeleteInProgress
-	deleteServiceNetworkVpcAssociationOutput := &vpclattice.DeleteServiceNetworkVpcAssociationOutput{Status: &deleteInProgressStatus}
-
-	mockLattice.EXPECT().DeleteServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(deleteServiceNetworkVpcAssociationOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	_, err := snMgr.CreateOrUpdate(ctx, &snCreateInput)
-
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-
-}
-
 // ServiceNetwork already exists, association is ServiceNetworkVpcAssociationStatusCreateFailed.
-
 func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociationStatusCreateFailed(t *testing.T) {
 	snCreateInput := model.ServiceNetwork{
 		Spec: model.ServiceNetworkSpec{
@@ -642,7 +300,6 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 	snTagsOuput := &vpclattice.ListTagsForResourceOutput{
 		Tags: make(map[string]*string),
 	}
-	snTagsOuput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
 	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
 		&mocks.ServiceNetworkInfo{
 			SvcNetwork: item,
@@ -706,8 +363,6 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_SnAssociatedWithOtherVPC(t
 	snTagsOuput := &vpclattice.ListTagsForResourceOutput{
 		Tags: make(map[string]*string),
 	}
-	dummy_vpc := "dummy-vpc-id"
-	snTagsOuput.Tags[model.K8SServiceNetworkOwnedByVPC] = &dummy_vpc
 	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
 		&mocks.ServiceNetworkInfo{
 			SvcNetwork: item,
@@ -721,161 +376,6 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_SnAssociatedWithOtherVPC(t
 	assert.Nil(t, err)
 	assert.Equal(t, resp.ServiceNetworkARN, snArn)
 	assert.Equal(t, resp.ServiceNetworkID, snId)
-}
-
-// ServiceNetwork does not exists, association is ServiceNetworkVpcAssociationStatusFailed.
-func Test_CreateOrUpdateServiceNetwork_SnNotExist_ServiceNetworkVpcAssociationStatusFailed(t *testing.T) {
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-
-	CreateInput := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:           "test",
-			Account:        "123456789",
-			AssociateToVPC: true,
-		},
-		Status: &model.ServiceNetworkStatus{ServiceNetworkARN: "", ServiceNetworkID: ""},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusCreateFailed
-	createServiceNetworkVPCAssociationOutput := &vpclattice.CreateServiceNetworkVpcAssociationOutput{
-		Status: &associationStatus,
-	}
-	snCreateOutput := &vpclattice.CreateServiceNetworkOutput{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-	snCreateInput := &vpclattice.CreateServiceNetworkInput{
-		Name: &name,
-		Tags: cloud.DefaultTags(),
-	}
-	snCreateInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-
-	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
-		ServiceNetworkIdentifier: &snId,
-		VpcIdentifier:            &config.VpcID,
-	}
-
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(nil, nil)
-	mockLattice.EXPECT().CreateServiceNetworkWithContext(ctx, snCreateInput).Return(snCreateOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkVpcAssociationWithContext(ctx, createServiceNetworkVpcAssociationInput).Return(createServiceNetworkVPCAssociationOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &CreateInput)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-	assert.Equal(t, resp.ServiceNetworkARN, "")
-	assert.Equal(t, resp.ServiceNetworkID, "")
-}
-
-// ServiceNetwork does not exists, association is ServiceNetworkVpcAssociationStatusCreateInProgress.
-func Test_CreateOrUpdateServiceNetwork_SnNOTExist_ServiceNetworkVpcAssociationStatusCreateInProgress(t *testing.T) {
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-
-	CreateInput := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:           "test",
-			Account:        "123456789",
-			AssociateToVPC: true,
-		},
-		Status: &model.ServiceNetworkStatus{ServiceNetworkARN: "", ServiceNetworkID: ""},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusCreateInProgress
-	createServiceNetworkVPCAssociationOutput := &vpclattice.CreateServiceNetworkVpcAssociationOutput{
-		Status: &associationStatus,
-	}
-	snCreateOutput := &vpclattice.CreateServiceNetworkOutput{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-	snCreateInput := &vpclattice.CreateServiceNetworkInput{
-		Name: &name,
-		Tags: cloud.DefaultTags(),
-	}
-	snCreateInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
-		ServiceNetworkIdentifier: &snId,
-		VpcIdentifier:            &config.VpcID,
-	}
-
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(nil, nil)
-	mockLattice.EXPECT().CreateServiceNetworkWithContext(ctx, snCreateInput).Return(snCreateOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkVpcAssociationWithContext(ctx, createServiceNetworkVpcAssociationInput).Return(createServiceNetworkVPCAssociationOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &CreateInput)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-	assert.Equal(t, resp.ServiceNetworkARN, "")
-	assert.Equal(t, resp.ServiceNetworkID, "")
-}
-
-// ServiceNetwork does not exists, association is ServiceNetworkVpcAssociationStatusDeleteInProgress.
-func Test_CreateOrUpdateServiceNetwork_SnNotExist_ServiceNetworkVpcAssociationStatusDeleteInProgress(t *testing.T) {
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-
-	CreateInput := model.ServiceNetwork{
-		Spec: model.ServiceNetworkSpec{
-			Name:           "test",
-			Account:        "123456789",
-			AssociateToVPC: true,
-		},
-		Status: &model.ServiceNetworkStatus{ServiceNetworkARN: "", ServiceNetworkID: ""},
-	}
-	snId := "12345678912345678912"
-	snArn := "12345678912345678912"
-	name := "test"
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusDeleteInProgress
-	createServiceNetworkVPCAssociationOutput := &vpclattice.CreateServiceNetworkVpcAssociationOutput{
-		Status: &associationStatus,
-	}
-	snCreateOutput := &vpclattice.CreateServiceNetworkOutput{
-		Arn:  &snArn,
-		Id:   &snId,
-		Name: &name,
-	}
-	snCreateInput := &vpclattice.CreateServiceNetworkInput{
-		Name: &name,
-		Tags: cloud.DefaultTags(),
-	}
-	snCreateInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
-		ServiceNetworkIdentifier: &snId,
-		VpcIdentifier:            &config.VpcID,
-	}
-
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(nil, nil)
-	mockLattice.EXPECT().CreateServiceNetworkWithContext(ctx, snCreateInput).Return(snCreateOutput, nil)
-	mockLattice.EXPECT().CreateServiceNetworkVpcAssociationWithContext(ctx, createServiceNetworkVpcAssociationInput).Return(createServiceNetworkVPCAssociationOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	resp, err := snMgr.CreateOrUpdate(ctx, &CreateInput)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-	assert.Equal(t, resp.ServiceNetworkARN, "")
-	assert.Equal(t, resp.ServiceNetworkID, "")
 }
 
 // ServiceNetwork does not exists, association returns Error.
@@ -907,7 +407,6 @@ func Test_CreateOrUpdateServiceNetwork_SnNotExist_ServiceNetworkVpcAssociationRe
 		Name: &name,
 		Tags: cloud.DefaultTags(),
 	}
-	snCreateInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
 	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
 		ServiceNetworkIdentifier: &snId,
 		VpcIdentifier:            &config.VpcID,
@@ -954,8 +453,6 @@ func Test_CreateSn_SnNotExist_SnCreateFailed(t *testing.T) {
 		Tags: cloud.DefaultTags(),
 	}
 
-	snCreateInput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-
 	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockLattice.EXPECT().CreateServiceNetworkWithContext(ctx, snCreateInput).Return(snCreateOutput, errors.New("ERROR"))
 
@@ -968,191 +465,30 @@ func Test_CreateSn_SnNotExist_SnCreateFailed(t *testing.T) {
 	assert.Equal(t, resp.ServiceNetworkID, "")
 }
 
-func Test_DeleteSn_SnNotExist(t *testing.T) {
+func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_UpdateSNVASecurityGroups(t *testing.T) {
+	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
 
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(nil, &mocks.NotFoundError{})
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	err := snMgr.Delete(ctx, "test")
-
-	assert.Nil(t, err)
-}
-
-// delete a service network, which has no association and also was created by this VPC
-func Test_DeleteSn_SnExistsNoAssociation(t *testing.T) {
-	arn := "123456789"
-	id := "123456789"
+	snId := "12345678912345678912"
+	snArn := "12345678912345678912"
+	snvaArn := "12345678912345678912"
 	name := "test"
+	vpcId := config.VpcID
 	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
+		Arn:  &snArn,
+		Id:   &snId,
 		Name: &name,
 	}
 
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{}
-
-	deleteSnOutput := &vpclattice.DeleteServiceNetworkOutput{}
-	deleteSnInout := &vpclattice.DeleteServiceNetworkInput{ServiceNetworkIdentifier: &id}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-
-	snTagsOuput := &vpclattice.ListTagsForResourceOutput{
-		Tags: make(map[string]*string),
+	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
+	items := vpclattice.ServiceNetworkVpcAssociationSummary{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &snId,
+		Status:             &status,
+		VpcId:              &config.VpcID,
+		Arn:                &snvaArn,
 	}
-	snTagsOuput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       snTagsOuput.Tags,
-		}, nil)
-	mockLattice.EXPECT().DeleteServiceNetworkWithContext(ctx, deleteSnInout).Return(deleteSnOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	err := snMgr.Delete(ctx, "test")
-
-	assert.Nil(t, err)
-}
-
-// Deleting a service netwrok, when
-// * the service network is associated with current VPC
-// * and it is this VPC creates this service network
-func Test_DeleteSn_SnExistsAssociatedWithVPC_Deleting(t *testing.T) {
-	arn := "123456789"
-	id := "123456789"
-	name := "test"
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name,
-	}
-
-	associationArn := "123456789"
-	associationID := "123456789"
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	associationVPCId := config.VpcID
-	itemAssociation := vpclattice.ServiceNetworkVpcAssociationSummary{
-		Arn:                &associationArn,
-		Id:                 &associationID,
-		ServiceNetworkArn:  &arn,
-		ServiceNetworkId:   &id,
-		ServiceNetworkName: &name,
-		Status:             &associationStatus,
-		VpcId:              &associationVPCId,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&itemAssociation}
-
-	deleteInProgressStatus := vpclattice.ServiceNetworkVpcAssociationStatusDeleteInProgress
-	deleteServiceNetworkVpcAssociationOutput := &vpclattice.DeleteServiceNetworkVpcAssociationOutput{Status: &deleteInProgressStatus}
-	deleteServiceNetworkVpcAssociationInput := &vpclattice.DeleteServiceNetworkVpcAssociationInput{ServiceNetworkVpcAssociationIdentifier: &associationID}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-
-	snTagsOuput := &vpclattice.ListTagsForResourceOutput{
-		Tags: make(map[string]*string),
-	}
-	snTagsOuput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       snTagsOuput.Tags,
-		}, nil)
-	mockLattice.EXPECT().DeleteServiceNetworkVpcAssociationWithContext(ctx, deleteServiceNetworkVpcAssociationInput).Return(deleteServiceNetworkVpcAssociationOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	err := snMgr.Delete(ctx, "test")
-
-	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-}
-
-func Test_DeleteSn_SnExistsAssociatedWithOtherVPC(t *testing.T) {
-	arn := "123456789"
-	id := "123456789"
-	name := "test"
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name,
-	}
-
-	associationArn := "123456789"
-	associationID := "123456789"
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	associationVPCId := "other-vpc-id"
-	itemAssociation := vpclattice.ServiceNetworkVpcAssociationSummary{
-		Arn:                &associationArn,
-		Id:                 &associationID,
-		ServiceNetworkArn:  &arn,
-		ServiceNetworkId:   &id,
-		ServiceNetworkName: &name,
-		Status:             &associationStatus,
-		VpcId:              &associationVPCId,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&itemAssociation}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-
-	snTagsOuput := &vpclattice.ListTagsForResourceOutput{
-		Tags: make(map[string]*string),
-	}
-	snTagsOuput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
-	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: item,
-			Tags:       snTagsOuput.Tags,
-		}, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	err := snMgr.Delete(ctx, "test")
-
-	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
-}
-
-func Test_DeleteSn_SnExistsAssociatedWithOtherVPC_NotCreatedByVPC(t *testing.T) {
-	arn := "123456789"
-	id := "123456789"
-	name := "test"
-	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name,
-	}
-
-	associationArn := "123456789"
-	associationID := "123456789"
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	associationVPCId := "123456789"
-	itemAssociation := vpclattice.ServiceNetworkVpcAssociationSummary{
-		Arn:                &associationArn,
-		Id:                 &associationID,
-		ServiceNetworkArn:  &arn,
-		ServiceNetworkId:   &id,
-		ServiceNetworkName: &name,
-		Status:             &associationStatus,
-		VpcId:              &associationVPCId,
-	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&itemAssociation}
+	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
 
 	c := gomock.NewController(t)
 	defer c.Finish()
@@ -1164,106 +500,183 @@ func Test_DeleteSn_SnExistsAssociatedWithOtherVPC_NotCreatedByVPC(t *testing.T) 
 			SvcNetwork: item,
 			Tags:       nil,
 		}, nil)
+	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &name,
+		Status:             aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
+		VpcId:              &vpcId,
+		//SecurityGroupIds:   []*string{aws.String("sg-123456789"), aws.String("sg-987654321")},
+	}, nil)
 	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
+	mockLattice.EXPECT().ListTagsForResourceWithContext(ctx, gomock.Any()).Return(&vpclattice.ListTagsForResourceOutput{
+		Tags: cloud.DefaultTags(),
+	}, nil)
+	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).MaxTimes(0)
+	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.UpdateServiceNetworkVpcAssociationOutput{
+		Arn:              &snArn,
+		Id:               &snId,
+		SecurityGroupIds: securityGroupIds,
+		Status:           aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
+	}, nil)
 
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	err := snMgr.Delete(ctx, "test")
+	resp, err := snMgr.UpsertVpcAssociation(ctx, name, securityGroupIds)
 
-	assert.Nil(t, err)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, resp, snArn)
 }
 
-func Test_DeleteSn_SnExistsAssociatedWithOtherVPC_CreatedByVPC(t *testing.T) {
-	arn := "123456789"
-	id := "123456789"
+func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_SecurityGroupsDoNotNeedToBeUpdated(t *testing.T) {
+	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
+	snId := "12345678912345678912"
+	snArn := "12345678912345678912"
+	snvaArn := "12345678912345678912"
 	name := "test"
+	vpcId := config.VpcID
 	item := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
+		Arn:  &snArn,
+		Id:   &snId,
 		Name: &name,
 	}
 
-	associationArn := "123456789"
-	associationID := "123456789"
-	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusActive
-	associationVPCId := "123456789"
-	itemAssociation := vpclattice.ServiceNetworkVpcAssociationSummary{
-		Arn:                &associationArn,
-		Id:                 &associationID,
-		ServiceNetworkArn:  &arn,
-		ServiceNetworkId:   &id,
-		ServiceNetworkName: &name,
-		Status:             &associationStatus,
-		VpcId:              &associationVPCId,
+	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
+	items := vpclattice.ServiceNetworkVpcAssociationSummary{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &snId,
+		Status:             &status,
+		VpcId:              &config.VpcID,
+		Arn:                &snvaArn,
 	}
-	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&itemAssociation}
+	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
 
 	c := gomock.NewController(t)
 	defer c.Finish()
 	ctx := context.TODO()
 	mockLattice := mocks.NewMockLattice(c)
 	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
-	snTagsOutput := &vpclattice.ListTagsForResourceOutput{
-		Tags: make(map[string]*string),
-	}
-	snTagsOutput.Tags[model.K8SServiceNetworkOwnedByVPC] = &config.VpcID
 	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
 		&mocks.ServiceNetworkInfo{
 			SvcNetwork: item,
-			Tags:       snTagsOutput.Tags,
+			Tags:       nil,
 		}, nil)
+	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &name,
+		Status:             &status,
+		VpcId:              &vpcId,
+		SecurityGroupIds:   securityGroupIds,
+	}, nil)
+	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
+	mockLattice.EXPECT().ListTagsForResourceWithContext(ctx, gomock.Any()).Return(&vpclattice.ListTagsForResourceOutput{
+		Tags: cloud.DefaultTags(),
+	}, nil)
+	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).Times(0)
+	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
 
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	err := snMgr.Delete(ctx, "test")
+	resp, err := snMgr.UpsertVpcAssociation(ctx, name, securityGroupIds)
 
-	assert.NotNil(t, err)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, resp, snArn)
+}
+func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaCreateInProgress_WillNotInvokeLatticeUpdateSNVA(t *testing.T) {
+	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
+	snId := "12345678912345678912"
+	snArn := "12345678912345678912"
+	snvaArn := "12345678912345678912"
+	name := "test"
+	item := vpclattice.ServiceNetworkSummary{
+		Arn:  &snArn,
+		Id:   &snId,
+		Name: &name,
+	}
+
+	status := vpclattice.ServiceNetworkVpcAssociationStatusCreateInProgress
+	items := vpclattice.ServiceNetworkVpcAssociationSummary{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &snId,
+		Status:             &status,
+		VpcId:              &config.VpcID,
+		Arn:                &snvaArn,
+	}
+	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+	mockLattice := mocks.NewMockLattice(c)
+	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
+	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: item,
+			Tags:       nil,
+		}, nil)
+	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
+	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
+	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).Times(0)
+	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Times(0)
+
+	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
+	_, err := snMgr.UpsertVpcAssociation(ctx, name, securityGroupIds)
+
 	assert.Equal(t, err, errors.New(LATTICE_RETRY))
 }
 
-func Test_ListSn_SnExists(t *testing.T) {
-	arn := "123456789"
-	id := "123456789"
-	name1 := "test1"
-	item1 := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name1,
+func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_CannotUpdateSecurityGroupsFromNonemptyToEmpty(t *testing.T) {
+	securityGroupIds := []*string{aws.String("sg-123456789"), aws.String("sg-987654321")}
+	snId := "12345678912345678912"
+	snArn := "12345678912345678912"
+	snvaArn := "12345678912345678912"
+	name := "test"
+	item := vpclattice.ServiceNetworkSummary{
+		Arn:  &snArn,
+		Id:   &snId,
+		Name: &name,
 	}
-	name2 := "test2"
-	item2 := vpclattice.ServiceNetworkSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name2,
+
+	status := vpclattice.ServiceNetworkVpcAssociationStatusActive
+	items := vpclattice.ServiceNetworkVpcAssociationSummary{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &snId,
+		Status:             &status,
+		VpcId:              &config.VpcID,
+		Arn:                &snvaArn,
 	}
-	listServiceNetworkOutput := []*vpclattice.ServiceNetworkSummary{&item1, &item2}
+	statusServiceNetworkVPCOutput := []*vpclattice.ServiceNetworkVpcAssociationSummary{&items}
 
 	c := gomock.NewController(t)
 	defer c.Finish()
 	ctx := context.TODO()
 	mockLattice := mocks.NewMockLattice(c)
 	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().ListServiceNetworksAsList(ctx, gomock.Any()).Return(listServiceNetworkOutput, nil)
+	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: item,
+			Tags:       nil,
+		}, nil)
+	mockLattice.EXPECT().GetServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.GetServiceNetworkVpcAssociationOutput{
+		ServiceNetworkArn:  &snArn,
+		ServiceNetworkId:   &snId,
+		ServiceNetworkName: &name,
+		Status:             aws.String(vpclattice.ServiceNetworkVpcAssociationStatusActive),
+		VpcId:              &config.VpcID,
+		SecurityGroupIds:   securityGroupIds,
+	}, nil)
+	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(statusServiceNetworkVPCOutput, nil)
+	mockLattice.EXPECT().ListTagsForResourceWithContext(ctx, gomock.Any()).Return(&vpclattice.ListTagsForResourceOutput{
+		Tags: cloud.DefaultTags(),
+	}, nil)
+	mockLattice.EXPECT().CreateServiceNetworkServiceAssociationWithContext(ctx, gomock.Any()).Times(0)
+	updateSNVAError := errors.New("InvalidParameterException SecurityGroupIds cannot be empty")
+	mockLattice.EXPECT().UpdateServiceNetworkVpcAssociationWithContext(ctx, gomock.Any()).Return(&vpclattice.UpdateServiceNetworkVpcAssociationOutput{}, updateSNVAError)
 
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	snList, err := snMgr.List(ctx)
+	_, err := snMgr.UpsertVpcAssociation(ctx, name, []*string{})
 
-	assert.Nil(t, err)
-	assert.Equal(t, snList, []string{"test1", "test2"})
-}
-
-func Test_ListSn_NoSn(t *testing.T) {
-	listServiceNetworkOutput := []*vpclattice.ServiceNetworkSummary{}
-
-	c := gomock.NewController(t)
-	defer c.Finish()
-	ctx := context.TODO()
-	mockLattice := mocks.NewMockLattice(c)
-	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
-	mockLattice.EXPECT().ListServiceNetworksAsList(ctx, gomock.Any()).Return(listServiceNetworkOutput, nil)
-
-	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
-	snList, err := snMgr.List(ctx)
-
-	assert.Nil(t, err)
-	assert.Equal(t, snList, []string{})
+	assert.Equal(t, err, updateSNVAError)
 }

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -110,7 +110,7 @@ func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) 
 	for _, parentRef := range t.route.Spec().ParentRefs() {
 		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, string(parentRef.Name))
 	}
-	if config.NetworkOverrideMode {
+	if config.ServiceNetworkOverrideMode {
 		spec.ServiceNetworkNames = []string{config.DefaultServiceNetwork}
 	}
 

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -110,9 +110,8 @@ func (t *latticeServiceModelBuildTask) buildLatticeService(ctx context.Context) 
 	for _, parentRef := range t.route.Spec().ParentRefs() {
 		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, string(parentRef.Name))
 	}
-	defaultGateway, err := config.GetClusterLocalGateway()
-	if err == nil {
-		spec.ServiceNetworkNames = append(spec.ServiceNetworkNames, defaultGateway)
+	if config.NetworkOverrideMode {
+		spec.ServiceNetworkNames = []string{config.DefaultServiceNetwork}
 	}
 
 	if len(t.route.Spec().Hostnames()) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

feature

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

* Add DEFAULT_SERVICE_NETWORK env variable, on cluster startup create service network and associate VPC
* Keeps CLUSTER_LOCAL_GATEWAY behavior (for conformance test) with new network override mode, unlike CLUSTER_LOCAL_GATEWAY, register all gateways to the same default service network.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.