### PR TITLE
Fix target group leaking and e2etest

### DIFF
--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -193,7 +193,7 @@ func main() {
 		setupLog.Fatalf("iam auth policy controller setup failed: %s", err)
 	}
 
-	err = controllers.RegisterVpcAssociationPolicyController(ctrlLog.Named("vpc-association-policy"), mgr, cloud)
+	err = controllers.RegisterVpcAssociationPolicyController(ctrlLog.Named("vpc-association-policy"), cloud, finalizerManager, mgr)
 	if err != nil {
 		setupLog.Fatalf("vpc association policy controller setup failed: %s", err)
 	}

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -186,21 +186,13 @@ func (m *defaultServiceNetworkManager) CreateOrUpdate(ctx context.Context, servi
 		m.log.Debugf("ServiceNetwork %s exists, checking its VPC association", serviceNetwork.Spec.Name)
 		serviceNetworkId = aws.StringValue(foundSnSummary.SvcNetwork.Id)
 		serviceNetworkArn = aws.StringValue(foundSnSummary.SvcNetwork.Arn)
-
-		snva, err := m.getActiveVpcAssociation(ctx, serviceNetworkId)
-		if err != nil {
-			return model.ServiceNetworkStatus{}, err
-		}
-		if snva != nil {
-			m.log.Debugf("ServiceNetwork %s already has VPC association %s", serviceNetwork.Spec.Name, snva.Arn)
-			return model.ServiceNetworkStatus{ServiceNetworkARN: serviceNetworkArn, ServiceNetworkID: serviceNetworkId}, nil
-		}
 	}
 
 	m.log.Debugf("Creating association between ServiceNetwork %s and VPC %s", serviceNetworkId, config.VpcID)
 	createServiceNetworkVpcAssociationInput := vpclattice.CreateServiceNetworkVpcAssociationInput{
 		ServiceNetworkIdentifier: &serviceNetworkId,
 		VpcIdentifier:            &config.VpcID,
+		Tags:                     m.cloud.DefaultTags(),
 	}
 	_, err = vpcLatticeSess.CreateServiceNetworkVpcAssociationWithContext(ctx, &createServiceNetworkVpcAssociationInput)
 	if err != nil {

--- a/pkg/deploy/lattice/service_network_manager_test.go
+++ b/pkg/deploy/lattice/service_network_manager_test.go
@@ -52,6 +52,7 @@ func Test_CreateOrUpdateServiceNetwork_SnNotExist_NeedToAssociate(t *testing.T) 
 	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
 		ServiceNetworkIdentifier: &snId,
 		VpcIdentifier:            &config.VpcID,
+		Tags:                     cloud.DefaultTags(),
 	}
 	associationStatus := vpclattice.ServiceNetworkVpcAssociationStatusActive
 	createServiceNetworkVPCAssociationOutput := &vpclattice.CreateServiceNetworkVpcAssociationOutput{
@@ -286,10 +287,6 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 	createServiceNetworkVPCAssociationOutput := &vpclattice.CreateServiceNetworkVpcAssociationOutput{
 		Status: &associationStatus,
 	}
-	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
-		ServiceNetworkIdentifier: &snId,
-		VpcIdentifier:            &config.VpcID,
-	}
 
 	c := gomock.NewController(t)
 	defer c.Finish()
@@ -305,6 +302,12 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 			SvcNetwork: item,
 			Tags:       snTagsOuput.Tags,
 		}, nil)
+
+	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
+		ServiceNetworkIdentifier: &snId,
+		VpcIdentifier:            &config.VpcID,
+		Tags:                     cloud.DefaultTags(),
+	}
 	mockLattice.EXPECT().CreateServiceNetworkVpcAssociationWithContext(ctx, createServiceNetworkVpcAssociationInput).Return(createServiceNetworkVPCAssociationOutput, nil)
 
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
@@ -349,10 +352,6 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_SnAssociatedWithOtherVPC(t
 	createServiceNetworkVPCAssociationOutput := &vpclattice.CreateServiceNetworkVpcAssociationOutput{
 		Status: &associationStatus,
 	}
-	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
-		ServiceNetworkIdentifier: &snId,
-		VpcIdentifier:            &config.VpcID,
-	}
 
 	c := gomock.NewController(t)
 	defer c.Finish()
@@ -368,6 +367,12 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_SnAssociatedWithOtherVPC(t
 			SvcNetwork: item,
 			Tags:       snTagsOuput.Tags,
 		}, nil)
+
+	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
+		ServiceNetworkIdentifier: &snId,
+		VpcIdentifier:            &config.VpcID,
+		Tags:                     cloud.DefaultTags(),
+	}
 	mockLattice.EXPECT().CreateServiceNetworkVpcAssociationWithContext(ctx, createServiceNetworkVpcAssociationInput).Return(createServiceNetworkVPCAssociationOutput, nil)
 
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
@@ -410,6 +415,7 @@ func Test_CreateOrUpdateServiceNetwork_SnNotExist_ServiceNetworkVpcAssociationRe
 	createServiceNetworkVpcAssociationInput := &vpclattice.CreateServiceNetworkVpcAssociationInput{
 		ServiceNetworkIdentifier: &snId,
 		VpcIdentifier:            &config.VpcID,
+		Tags:                     cloud.DefaultTags(),
 	}
 
 	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any(), gomock.Any()).Return(nil, nil)

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -248,10 +248,7 @@ type tgListOutput struct {
 func (s *defaultTargetGroupManager) List(ctx context.Context) ([]tgListOutput, error) {
 	lattice := s.cloud.Lattice()
 	var tgList []tgListOutput
-	targetGroupListInput := vpclattice.ListTargetGroupsInput{
-		VpcIdentifier:   aws.String(config.VpcID),
-		TargetGroupType: aws.String(vpclattice.TargetGroupTypeIp),
-	}
+	targetGroupListInput := vpclattice.ListTargetGroupsInput{}
 	resp, err := lattice.ListTargetGroupsAsList(ctx, &targetGroupListInput)
 	if err != nil {
 		return nil, err
@@ -259,7 +256,11 @@ func (s *defaultTargetGroupManager) List(ctx context.Context) ([]tgListOutput, e
 	if len(resp) == 0 {
 		return nil, nil
 	}
-	tgArns := utils.SliceMap(resp, func(tg *vpclattice.TargetGroupSummary) string {
+	validTgs := utils.SliceFilter(resp, func(tg *vpclattice.TargetGroupSummary) bool {
+		return aws.StringValue(tg.VpcIdentifier) == config.VpcID &&
+			aws.StringValue(tg.Type) == vpclattice.TargetGroupTypeIp
+	})
+	tgArns := utils.SliceMap(validTgs, func(tg *vpclattice.TargetGroupSummary) string {
 		return aws.StringValue(tg.Arn)
 	})
 	tgArnToTagsMap, err := s.cloud.Tagging().GetTagsForArns(ctx, tgArns)
@@ -267,7 +268,7 @@ func (s *defaultTargetGroupManager) List(ctx context.Context) ([]tgListOutput, e
 	if err != nil {
 		return nil, err
 	}
-	for _, tg := range resp {
+	for _, tg := range validTgs {
 		tgList = append(tgList, tgListOutput{
 			tgSummary: tg,
 			tags:      tgArnToTagsMap[*tg.Arn],
@@ -288,44 +289,43 @@ func (s *defaultTargetGroupManager) findTargetGroup(
 	if len(arns) == 0 {
 		return nil, nil
 	}
-	// Tag fields guarantee one result, as there can be only one target group for one service/route combination.
-	// We move forward but log this situation to help troubleshooting
-	if len(arns) > 1 {
-		s.log.Warnw("Target groups with conflicting tags found", "arns", arns)
-	}
-	arn := arns[0]
 
-	latticeTg, err := s.cloud.Lattice().GetTargetGroupWithContext(ctx, &vpclattice.GetTargetGroupInput{
-		TargetGroupIdentifier: &arn,
-	})
-	if err != nil {
-		return nil, services.IgnoreNotFound(err)
-	}
+	for _, arn := range arns {
+		latticeTg, err := s.cloud.Lattice().GetTargetGroupWithContext(ctx, &vpclattice.GetTargetGroupInput{
+			TargetGroupIdentifier: &arn,
+		})
+		if err != nil {
+			if services.IsNotFoundError(err) {
+				continue
+			}
+			return nil, err
+		}
 
-	// we ignore create failed status, so may as well check for it first
-	status := aws.StringValue(latticeTg.Status)
-	if status == vpclattice.TargetGroupStatusCreateFailed {
-		return nil, nil
-	}
+		// we ignore create failed status, so may as well check for it first
+		status := aws.StringValue(latticeTg.Status)
+		if status == vpclattice.TargetGroupStatusCreateFailed {
+			continue
+		}
 
-	// Double-check the immutable fields to ensure TG is valid
-	match, err := s.IsTargetGroupMatch(ctx, modelTargetGroup, &vpclattice.TargetGroupSummary{
-		Arn:           latticeTg.Arn,
-		Port:          latticeTg.Config.Port,
-		Protocol:      latticeTg.Config.Protocol,
-		IpAddressType: latticeTg.Config.IpAddressType,
-		Type:          latticeTg.Type,
-		VpcIdentifier: latticeTg.Config.VpcIdentifier,
-	}, nil) // we already know that tags match
-	if err != nil {
-		return nil, err
-	}
-	if match {
-		switch status {
-		case vpclattice.TargetGroupStatusCreateInProgress, vpclattice.TargetGroupStatusDeleteInProgress:
-			return nil, errors.New(LATTICE_RETRY)
-		case vpclattice.TargetGroupStatusDeleteFailed, vpclattice.TargetGroupStatusActive:
-			return latticeTg, nil
+		// Check the immutable fields to ensure TG is valid
+		match, err := s.IsTargetGroupMatch(ctx, modelTargetGroup, &vpclattice.TargetGroupSummary{
+			Arn:           latticeTg.Arn,
+			Port:          latticeTg.Config.Port,
+			Protocol:      latticeTg.Config.Protocol,
+			IpAddressType: latticeTg.Config.IpAddressType,
+			Type:          latticeTg.Type,
+			VpcIdentifier: latticeTg.Config.VpcIdentifier,
+		}, nil) // we already know that tags match
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			switch status {
+			case vpclattice.TargetGroupStatusCreateInProgress, vpclattice.TargetGroupStatusDeleteInProgress:
+				return nil, errors.New(LATTICE_RETRY)
+			case vpclattice.TargetGroupStatusDeleteFailed, vpclattice.TargetGroupStatusActive:
+				return latticeTg, nil
+			}
 		}
 	}
 

--- a/pkg/deploy/lattice/target_group_manager_test.go
+++ b/pkg/deploy/lattice/target_group_manager_test.go
@@ -777,16 +777,23 @@ func Test_ListTG_TGsExist(t *testing.T) {
 	arn := "123456789"
 	id := "123456789"
 	name1 := "test1"
+	config.VpcID = "vpc-id"
+	config.ClusterName = "cluster-name"
+	tgType := vpclattice.TargetGroupTypeIp
 	tg1 := &vpclattice.TargetGroupSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name1,
+		Arn:           &arn,
+		Id:            &id,
+		Name:          &name1,
+		VpcIdentifier: &config.VpcID,
+		Type:          &tgType,
 	}
 	name2 := "test2"
 	tg2 := &vpclattice.TargetGroupSummary{
-		Arn:  &arn,
-		Id:   &id,
-		Name: &name2,
+		Arn:           &arn,
+		Id:            &id,
+		Name:          &name2,
+		VpcIdentifier: &config.VpcID,
+		Type:          &tgType,
 	}
 	listTGOutput := []*vpclattice.TargetGroupSummary{tg1, tg2}
 

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -193,6 +193,9 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 
 func objectsInfo(objs []client.Object) string {
 	objInfos := utils.SliceMap(objs, func(obj client.Object) string {
+		if obj == nil || reflect.ValueOf(obj).IsNil() {
+			return fmt.Sprintf("%T/nil", obj)
+		}
 		return fmt.Sprintf("%T/%s", obj, obj.GetName())
 	})
 	return strings.Join(objInfos, ", ")

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -154,16 +154,18 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 		for _, service := range retrievedServices {
 			env.Log.Infof("Found service, checking if created by current EKS Cluster: %v", service)
 			managed, err := env.Cloud.IsArnManaged(ctx, *service.Arn)
-			if err == nil { // for err != nil, it is possible that this service own by other account, and it is shared to current account by RAM
+			if err == nil { // ignore error as they can be a shared resource.
 				g.Expect(managed).To(BeFalse())
 			}
 		}
 
-		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{})
+		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{
+			VpcIdentifier: &config.VpcID,
+		})
 		for _, tg := range retrievedTargetGroups {
 			env.Log.Infof("Found TargetGroup: %s, checking if created by current EKS Cluster", *tg.Id)
 			managed, err := env.Cloud.IsArnManaged(ctx, *tg.Arn)
-			if err == nil { // for err != nil, it is possible that this service own by other account, and it is shared to current account by RAM
+			if err == nil { // ignore error as they can be a shared resource.
 				g.Expect(managed).To(BeFalse())
 			}
 		}

--- a/test/suites/integration/byoc_test.go
+++ b/test/suites/integration/byoc_test.go
@@ -292,7 +292,11 @@ func findHostedZone(client *route53.Route53, name string) (*route53.HostedZone, 
 	if len(out.HostedZones) == 0 {
 		return nil, nil
 	}
-	return out.HostedZones[0], nil
+	hz := out.HostedZones[0]
+	if aws.StringValue(hz.Name) != name {
+		return nil, nil
+	}
+	return hz, nil
 }
 
 func createHostedZone(client *route53.Route53, name string) (*route53.HostedZone, error) {

--- a/test/suites/integration/defined_target_ports_test.go
+++ b/test/suites/integration/defined_target_ports_test.go
@@ -6,17 +6,17 @@ import (
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
-	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ = Describe("Defined Target Ports", func() {
+var _ = Describe("Defined Target Ports", Ordered, func() {
 	var (
 		deployment        *appsv1.Deployment
 		service           *v1.Service
@@ -26,18 +26,27 @@ var _ = Describe("Defined Target Ports", func() {
 		definedPorts      []int64
 	)
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		deployment, service = testFramework.NewNginxApp(test.ElasticSearchOptions{
-			Name:      "http",
+			Name:      "target-port-definition",
 			Port:      8080,
 			Port2:     8081,
 			Namespace: k8snamespace,
 		})
 		serviceExport = testFramework.CreateServiceExport(service)
 		httpRoute = testFramework.NewHttpRoute(testGateway, service, "Service")
+
+		definedPorts = []int64{int64(service.Spec.Ports[0].TargetPort.IntVal)}
+		testFramework.ExpectCreated(
+			ctx,
+			service,
+			deployment,
+			httpRoute,
+			serviceExport,
+		)
 	})
 
-	AfterEach(func() {
+	AfterAll(func() {
 		testFramework.ExpectDeletedThenNotFound(ctx,
 			httpRoute,
 			serviceExport,
@@ -47,24 +56,10 @@ var _ = Describe("Defined Target Ports", func() {
 	})
 
 	It("take effect when on port annotation of ServiceExport", func() {
-		testFramework.ExpectCreated(
-			ctx,
-			service,
-			deployment,
-			serviceExport,
-		)
-		definedPorts = []int64{int64(service.Spec.Ports[0].TargetPort.IntVal)}
 		performVerification(service, deployment, definedPorts)
 	})
 
 	It("take effect when on HttpRoute BackendRef", func() {
-		testFramework.ExpectCreated(
-			ctx,
-			service,
-			deployment,
-			httpRoute,
-		)
-		definedPorts = []int64{int64(service.Spec.Ports[0].TargetPort.IntVal)}
 		// Verify VPC Lattice Service exists
 		route, _ := core.NewRoute(httpRoute)
 		vpcLatticeService = testFramework.GetVpcLatticeService(ctx, route)

--- a/test/suites/integration/httproute_creation_test.go
+++ b/test/suites/integration/httproute_creation_test.go
@@ -17,7 +17,7 @@ import (
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-var _ = Describe("HTTPRoute Creation", func() {
+var _ = Describe("HTTPRoute Creation", Ordered, func() {
 
 	var (
 		deployment    *appsv1.Deployment

--- a/test/suites/integration/httproute_header_match_test.go
+++ b/test/suites/integration/httproute_header_match_test.go
@@ -28,7 +28,7 @@ var _ = Describe("HTTPRoute header matches", func() {
 	)
 
 	It("Create a HttpRoute with a header match rule, http traffic should work if pass the correct headers", func() {
-		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3", Namespace: k8snamespace})
+		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "header-match-test-v3", Namespace: k8snamespace})
 		headerMatchHttpRoute = testFramework.NewHeaderMatchHttpRoute(testGateway, []*v1.Service{service})
 
 		testFramework.ExpectCreated(ctx,

--- a/test/suites/integration/httproute_mutation_do_not_leak_target_group_test.go
+++ b/test/suites/integration/httproute_mutation_do_not_leak_target_group_test.go
@@ -30,9 +30,9 @@ var _ = Describe("HTTPRoute Mutation", func() {
 
 	It("Create a HTTPRoute that backendref to service1 and service2 first, tg1 and tg2 should be created, tg3 should not be created. "+
 		"Then, update the HTTPRoute to backendref to service1 and service3, tg1 should still exist, tg2 should be deleted, tg3 should be created", func() {
-		deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: k8snamespace})
-		deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: k8snamespace})
-		deployment3, service3 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v3", Namespace: k8snamespace})
+		deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "leak-tg-test-v1", Namespace: k8snamespace})
+		deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "leak-tg-test-v2", Namespace: k8snamespace})
+		deployment3, service3 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "leak-tg-test-v3", Namespace: k8snamespace})
 
 		pathMatchHttpRoute = testFramework.NewPathMatchHttpRoute(testGateway, []client.Object{service1, service2}, "http",
 			"", k8snamespace)

--- a/test/suites/integration/httproute_path_match_test.go
+++ b/test/suites/integration/httproute_path_match_test.go
@@ -30,8 +30,8 @@ var _ = Describe("HTTPRoute path matches", func() {
 	)
 
 	It("HTTPRoute should support multiple path matches", func() {
-		deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: k8snamespace})
-		deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v2", Namespace: k8snamespace})
+		deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "path-match-test-v1", Namespace: k8snamespace})
+		deployment2, service2 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "path-match-test-v2", Namespace: k8snamespace})
 		pathMatchHttpRoute = testFramework.NewPathMatchHttpRoute(testGateway, []client.Object{service1, service2}, "http",
 			"", k8snamespace)
 

--- a/test/suites/integration/httproute_update_test.go
+++ b/test/suites/integration/httproute_update_test.go
@@ -30,7 +30,7 @@ var _ = Describe("HTTPRoute Update", func() {
 
 	Context("BackendRefs to the same service use different target groups", func() {
 		It("Target groups for the same service are different for different routes", func() {
-			deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "test-v1", Namespace: k8snamespace})
+			deployment1, service1 = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "update-test-v1", Namespace: k8snamespace})
 			route1 = testFramework.NewPathMatchHttpRoute(testGateway, []client.Object{service1}, "http",
 				"route-one", k8snamespace)
 			route2 = testFramework.NewPathMatchHttpRoute(testGateway, []client.Object{service1}, "http",

--- a/test/suites/integration/iamauthpolicy_test.go
+++ b/test/suites/integration/iamauthpolicy_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/aws/aws-application-networking-k8s/controllers"
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
-	"github.com/aws/aws-application-networking-k8s/pkg/utils"
-
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
@@ -21,8 +19,10 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 var _ = Describe("IAM Auth Policy", Ordered, func() {
@@ -177,7 +177,7 @@ var _ = Describe("IAM Auth Policy", Ordered, func() {
 
 	It("accepted, applied, and removed from HTTPRoute", func() {
 		policy := newPolicy("http", "HTTPRoute", SvcName)
-		svc, _ := lattice.FindService(context.TODO(), utils.LatticeServiceName(SvcName, k8snamespace))
+		svc := testFramework.GetVpcLatticeService(ctx, core.NewHTTPRoute(gwv1beta1.HTTPRoute(*httpRoute)))
 		svcId := *svc.Id
 
 		// accepted

--- a/test/suites/integration/serviceexport_mutation_test.go
+++ b/test/suites/integration/serviceexport_mutation_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 )
 
-var _ = Describe("ServiceExport Mutation Test", func() {
+var _ = Describe("ServiceExport Mutation Test", Ordered, func() {
 	Context("Test ServiceExport Deletion", func() {
 		var (
 			deployment    *appsv1.Deployment
@@ -29,7 +29,7 @@ var _ = Describe("ServiceExport Mutation Test", func() {
 
 		BeforeEach(func() {
 			deployment, service = testFramework.NewNginxApp(test.ElasticSearchOptions{
-				Name:      "http",
+				Name:      "serviceexport-mutation",
 				Port:      8080,
 				Port2:     8081,
 				Namespace: k8snamespace,

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -55,6 +55,7 @@ var _ = SynchronizedBeforeSuite(func() {
 }, func() {
 	testGateway = testFramework.NewGateway("test-gateway", k8snamespace)
 	testServiceNetwork = testFramework.GetServiceNetwork(ctx, testGateway)
+	testFramework.GrpcurlRunner = test.NewGrpcurlRunnerPod("grpc-runner", k8snamespace)
 })
 
 func TestIntegration(t *testing.T) {

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -26,7 +26,7 @@ var testFramework *test.Framework
 var ctx context.Context
 var testGateway *gwv1.Gateway
 var testServiceNetwork *vpclattice.ServiceNetworkSummary
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
 	vpcId := os.Getenv("CLUSTER_VPC_ID")
 	if vpcId == "" {
 		Fail("CLUSTER_VPC_ID environment variable must be set to run integration tests")
@@ -52,6 +52,9 @@ var _ = BeforeSuite(func() {
 		associated, _, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
 		g.Expect(associated).To(BeTrue())
 	}).Should(Succeed())
+}, func() {
+	testGateway = testFramework.NewGateway("test-gateway", k8snamespace)
+	testServiceNetwork = testFramework.GetServiceNetwork(ctx, testGateway)
 })
 
 func TestIntegration(t *testing.T) {
@@ -62,6 +65,6 @@ func TestIntegration(t *testing.T) {
 	RunSpecs(t, "Integration")
 }
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {}, func() {
 	testFramework.ExpectDeletedThenNotFound(ctx, testGateway, testFramework.GrpcurlRunner)
 })

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -51,7 +51,10 @@ var _ = SynchronizedBeforeSuite(func() {
 	Eventually(func(g Gomega) {
 		associated, _, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
 		g.Expect(associated).To(BeTrue())
+		managed, _ := testFramework.Cloud.IsArnManaged(ctx, *testServiceNetwork.Arn)
+		g.Expect(managed).To(BeTrue())
 	}).Should(Succeed())
+
 }, func() {
 	testGateway = testFramework.NewGateway("test-gateway", k8snamespace)
 	testServiceNetwork = testFramework.GetServiceNetwork(ctx, testGateway)

--- a/test/suites/integration/target_group_policy_test.go
+++ b/test/suites/integration/target_group_policy_test.go
@@ -70,8 +70,6 @@ var _ = Describe("Target Group Policy Tests", Ordered, func() {
 
 		testFramework.ExpectCreated(ctx, policy)
 
-		// time.Sleep(10 * time.Second)
-
 		Eventually(func(g Gomega) {
 			tgSummary := testFramework.GetTargetGroup(ctx, service)
 
@@ -81,7 +79,7 @@ var _ = Describe("Target Group Policy Tests", Ordered, func() {
 			g.Expect(*tg.Config.HealthCheck.Protocol).To(Equal(vpclattice.TargetGroupProtocolHttp))
 			g.Expect(*tg.Config.HealthCheck.HealthCheckIntervalSeconds).To(BeEquivalentTo(7))
 			g.Expect(*tg.Config.HealthCheck.Matcher.HttpCode).To(Equal("200,204"))
-		}).Within(10 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
+		}).Within(60 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
 
 		testFramework.ExpectDeletedThenNotFound(ctx, policy)
 
@@ -104,7 +102,7 @@ var _ = Describe("Target Group Policy Tests", Ordered, func() {
 					HttpCode: aws.String("200"),
 				},
 			}))
-		}).Within(10 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
+		}).Within(60 * time.Second).WithPolling(1 * time.Second).Should(Succeed())
 	})
 
 	It("Delete Target Group Policy create HTTP and HTTP1 Target Group", func() {

--- a/test/suites/integration/target_group_policy_test.go
+++ b/test/suites/integration/target_group_policy_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Target Group Policy Tests", Ordered, func() {
 		testFramework.ExpectCreated(ctx, deployment, service, httpRoute)
 	})
 
-	It("Update Protocol creates new Target Group", func() {
+	It("Update Protocol replaces the Target Group with new one", func() {
 		policy = testFramework.CreateTargetGroupPolicy(service, &test.TargetGroupPolicyConfig{
 			PolicyName: "test-policy",
 			Protocol:   aws.String(vpclattice.TargetGroupProtocolHttp),
@@ -50,6 +50,7 @@ var _ = Describe("Target Group Policy Tests", Ordered, func() {
 		})
 
 		testFramework.ExpectUpdated(ctx, policy)
+		testFramework.VerifyTargetGroupNotFound(tg)
 
 		httpsTG := testFramework.GetTargetGroupWithProtocol(ctx, service, "https", "http1")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

* Use strongly consistent list call on ListTargetGroups, fixes target group leaking issue (which seems to happen more often when we have a lot of existing target groups)
* Correctly handle when there are multiple target groups matching tags in findTargetGroup(). This can happen in the middle of TG protocol update, etc. Target groups only become unique after matching more fields including protocol. Changed related e2e test to make sure unused target groups are getting replaced by this logic.
* Fix wrong e2e test cases on delete_target_group_test, deleting a deployment still results in target deregistration as it does not delete service.
* Fix bug where e2e test will pick up existing other hosted zone and delete it
* Made a few tests ordered. We are running tests sequentially anyways, and even in parallel execution we will likely keep one file per worker.
* Made a few tweaks to be ready for parallel execution, it seems working with 2 procs but not sure if it is reliable.

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
`make e2e-test`

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.