### PR TITLE
Pass defaultServiceNetwork env variable

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -94,8 +94,7 @@ Run through them again for a second cluster to use with the extended example sho
       --set=clusterVpcId= \
       --set=clusterName= \
       --set=awsAccountId= \
-      # You need to pass defaultServiceNetwork if you want the default service network feature, you could check environment.md for more its details
-      --set=defaultServiceNetwork= \
+      --set=defaultServiceNetwork= \ # check environment.md for more its details
       # latticeEndpoint is required for the case where the VPC Lattice endpoint is being overridden
       --set=latticeEndpoint= \
       

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -94,8 +94,11 @@ Run through them again for a second cluster to use with the extended example sho
       --set=clusterVpcId= \
       --set=clusterName= \
       --set=awsAccountId= \
+      # You need to pass defaultServiceNetwork if you want the default service network feature, you could check environment.md for more its details
+      --set=defaultServiceNetwork= \
       # latticeEndpoint is required for the case where the VPC Lattice endpoint is being overridden
       --set=latticeEndpoint= \
+      
    
    ```
 9. Create the `amazon-vpc-lattice` GatewayClass:

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -8,4 +8,5 @@ data:
     clusterVpcId: {{ .Values.clusterVpcId | quote }}
     clusterName: {{ .Values.clusterName | quote }}
     latticeEndpoint: {{ .Values.latticeEndpoint | quote }}
+    defaultServiceNetwork: {{ .Values.defaultServiceNetwork | quote }}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -92,6 +92,11 @@ spec:
               configMapKeyRef:
                 name: env-config
                 key: latticeEndpoint
+          - name: DEFAULT_SERVICE_NETWORK
+            valueFrom:
+              configMapKeyRef:
+                name: env-config
+                key: defaultServiceNetwork
 
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -75,4 +75,5 @@ awsRegion:
 awsAccountId:
 clusterVpcId:
 clusterName:
+defaultServiceNetwork:
 latticeEndpoint:

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -49,9 +49,9 @@ var _ = SynchronizedBeforeSuite(func() {
 
 	testFramework.Log.Infof("Expecting VPC %s and service network %s association", vpcId, *testServiceNetwork.Id)
 	Eventually(func(g Gomega) {
-		associated, _, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
+		associated, snva, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
 		g.Expect(associated).To(BeTrue())
-		managed, _ := testFramework.Cloud.IsArnManaged(ctx, *testServiceNetwork.Arn)
+		managed, _ := testFramework.Cloud.IsArnManaged(ctx, *snva.Arn)
 		g.Expect(managed).To(BeTrue())
 	}).Should(Succeed())
 


### PR DESCRIPTION
- fix e2e test issue

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.