### PR TITLE
Fix e2e tests and examples to be compatible w/ latest CRDs

### DIFF
--- a/examples/my-hotel-gateway-tls.yaml
+++ b/examples/my-hotel-gateway-tls.yaml
@@ -11,10 +11,9 @@ spec:
   - name: https
     protocol: HTTPS
     port: 443
-  - name: tls-with-customer-cert
-    protocol: HTTPS
-    port: 443
     tls:
       mode: Terminate
+      certificateRefs:
+      - name: unused
       options:
-        application-networking.k8s.aws/certificate-arn: arn:aws:acm:us-west-2:<account>:certificate/4555204d-07e1-43f0-a533-d02750f41545
+        application-networking.k8s.aws/certificate-arn: "" # arn:aws:acm:us-west-2:<account>:certificate/<certificate-id>

--- a/examples/parking-route-path.yaml
+++ b/examples/parking-route-path.yaml
@@ -10,6 +10,7 @@ spec:
   - backendRefs:
     - name: parking-ver1
       kind: Service
+      port: 80
     matches:
     - path:
         type: PathPrefix

--- a/examples/second-account-gw1-full-setup.yaml
+++ b/examples/second-account-gw1-full-setup.yaml
@@ -62,6 +62,7 @@ spec:
     - backendRefs:
         - name: second-account-gw1-svc
           kind: Service
+          port: 80
       matches:
         - path:
             type: PathPrefix

--- a/examples/tls-route-with-own-cert.yaml
+++ b/examples/tls-route-with-own-cert.yaml
@@ -7,7 +7,7 @@ spec:
   - tls-parking.my-test.com
   parentRefs:
   - name: my-hotel
-    sectionName: tls-with-customer-cert
+    sectionName: https
   rules:
   - backendRefs:
     - name: parking-ver3

--- a/pkg/aws/services/tagging.go
+++ b/pkg/aws/services/tagging.go
@@ -17,6 +17,7 @@ const (
 	resourceTypePrefix = "vpc-lattice:"
 
 	ResourceTypeTargetGroup ResourceType = resourceTypePrefix + "targetgroup"
+	ResourceTypeService     ResourceType = resourceTypePrefix + "service"
 
 	// https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#API_GetResources_RequestSyntax
 	maxArnsPerGetResourcesApi = 100

--- a/pkg/gateway/model_build_rule.go
+++ b/pkg/gateway/model_build_rule.go
@@ -61,6 +61,13 @@ func (t *latticeServiceModelBuildTask) buildRules(ctx context.Context, stackList
 			if err := t.updateRuleSpecWithHeaderMatches(match, &ruleSpec); err != nil {
 				return err
 			}
+		} else {
+			// Match every traffic on no matches
+			ruleSpec.PathMatchValue = "/"
+			ruleSpec.PathMatchPrefix = true
+			if _, ok := rule.(*core.GRPCRouteRule); ok {
+				ruleSpec.Method = string(gwv1.HTTPMethodPost)
+			}
 		}
 
 		ruleTgList, err := t.getTargetGroupsForRuleAction(ctx, rule)

--- a/pkg/gateway/model_build_rule_test.go
+++ b/pkg/gateway/model_build_rule_test.go
@@ -153,6 +153,8 @@ func Test_RuleModelBuild(t *testing.T) {
 			expectedSpec: []model.RuleSpec{ // note priority is only calculated at synthesis b/c it requires access to existing rules
 				{
 					StackListenerId: "listener-id",
+					PathMatchPrefix: true,
+					PathMatchValue:  "/",
 					Action: model.RuleAction{
 						TargetGroups: []*model.RuleTargetGroup{
 							{
@@ -195,6 +197,8 @@ func Test_RuleModelBuild(t *testing.T) {
 			expectedSpec: []model.RuleSpec{
 				{
 					StackListenerId: "listener-id",
+					PathMatchPrefix: true,
+					PathMatchValue:  "/",
 					Action: model.RuleAction{
 						TargetGroups: []*model.RuleTargetGroup{
 							{
@@ -243,6 +247,8 @@ func Test_RuleModelBuild(t *testing.T) {
 			expectedSpec: []model.RuleSpec{
 				{
 					StackListenerId: "listener-id",
+					PathMatchPrefix: true,
+					PathMatchValue:  "/",
 					Action: model.RuleAction{
 						TargetGroups: []*model.RuleTargetGroup{
 							{
@@ -564,6 +570,9 @@ func Test_RuleModelBuild(t *testing.T) {
 			expectedSpec: []model.RuleSpec{
 				{
 					StackListenerId: "listener-id",
+					Method:          string(httpPost),
+					PathMatchPrefix: true,
+					PathMatchValue:  "/",
 					Action: model.RuleAction{
 						TargetGroups: []*model.RuleTargetGroup{
 							{
@@ -1407,6 +1416,8 @@ func Test_RuleModelBuild(t *testing.T) {
 			expectedSpec: []model.RuleSpec{
 				{
 					StackListenerId: "listener-id",
+					PathMatchPrefix: true,
+					PathMatchValue:  "/",
 					Action: model.RuleAction{
 						TargetGroups: []*model.RuleTargetGroup{
 							{
@@ -1453,6 +1464,8 @@ func Test_RuleModelBuild(t *testing.T) {
 			expectedSpec: []model.RuleSpec{
 				{
 					StackListenerId: "listener-id",
+					PathMatchPrefix: true,
+					PathMatchValue:  "/",
 					Action: model.RuleAction{
 						TargetGroups: []*model.RuleTargetGroup{
 							{

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -180,11 +180,7 @@ func objectsInfo(objs []client.Object) string {
 func (env *Framework) ExpectCreated(ctx context.Context, objects ...client.Object) {
 	env.Log.Infof("Creating objects: %s", objectsInfo(objects))
 	parallel.ForEach(objects, func(obj client.Object, _ int) {
-		err := env.Create(ctx, obj)
-		if err != nil {
-			env.Log.Infof("%s", err.Error())
-		}
-		Expect(err).To(BeNil())
+		Expect(env.Create(ctx, obj)).WithOffset(1).To(Succeed())
 	})
 }
 

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -107,6 +107,7 @@ type Framework struct {
 	controllerRuntimeConfig *rest.Config
 	Log                     gwlog.Logger
 	LatticeClient           services.Lattice
+	TaggingClient           services.Tagging
 	Ec2Client               *ec2.EC2
 	GrpcurlRunner           *corev1.Pod
 	DefaultTags             services.Tags
@@ -123,10 +124,12 @@ func NewFramework(ctx context.Context, log gwlog.Logger, testNamespace string) *
 		Region:      config.Region,
 		ClusterName: config.ClusterName,
 	}
+	sess := session.Must(session.NewSession())
 	framework := &Framework{
 		Client:                  lo.Must(client.New(controllerRuntimeConfig, client.Options{Scheme: testScheme})),
-		LatticeClient:           services.NewDefaultLattice(session.Must(session.NewSession()), config.Region), // region is currently hardcoded
-		Ec2Client:               ec2.New(session.Must(session.NewSession(&aws.Config{Region: aws.String(config.Region)}))),
+		LatticeClient:           services.NewDefaultLattice(sess, config.Region),
+		TaggingClient:           services.NewDefaultTagging(sess, config.Region),
+		Ec2Client:               ec2.New(sess, &aws.Config{Region: aws.String(config.Region)}),
 		GrpcurlRunner:           &corev1.Pod{},
 		ctx:                     ctx,
 		Log:                     log,
@@ -150,25 +153,17 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 	})
 
 	Eventually(func(g Gomega) {
-		retrievedServices, _ := env.LatticeClient.ListServicesAsList(ctx, &vpclattice.ListServicesInput{})
-		for _, service := range retrievedServices {
-			env.Log.Infof("Found service, checking if created by current EKS Cluster: %v", service)
-			managed, err := env.Cloud.IsArnManaged(ctx, *service.Arn)
-			if err == nil { // ignore error as they can be a shared resource.
-				g.Expect(managed).To(BeFalse())
-			}
-		}
+		arns, err := env.TaggingClient.FindResourcesByTags(ctx, services.ResourceTypeService, env.DefaultTags)
+		env.Log.Infow("Expecting no services created by the controller", "found", arns)
+		g.Expect(err).To(BeNil())
+		g.Expect(arns).To(BeEmpty())
+	}).Should(Succeed())
 
-		retrievedTargetGroups, _ := env.LatticeClient.ListTargetGroupsAsList(ctx, &vpclattice.ListTargetGroupsInput{
-			VpcIdentifier: &config.VpcID,
-		})
-		for _, tg := range retrievedTargetGroups {
-			env.Log.Infof("Found TargetGroup: %s, checking if created by current EKS Cluster", *tg.Id)
-			managed, err := env.Cloud.IsArnManaged(ctx, *tg.Arn)
-			if err == nil { // ignore error as they can be a shared resource.
-				g.Expect(managed).To(BeFalse())
-			}
-		}
+	Eventually(func(g Gomega) {
+		arns, err := env.TaggingClient.FindResourcesByTags(ctx, services.ResourceTypeTargetGroup, env.DefaultTags)
+		env.Log.Infow("Expecting no target groups created by the controller", "found", arns)
+		g.Expect(err).To(BeNil())
+		g.Expect(arns).To(BeEmpty())
 	}).Should(Succeed())
 }
 
@@ -185,7 +180,11 @@ func objectsInfo(objs []client.Object) string {
 func (env *Framework) ExpectCreated(ctx context.Context, objects ...client.Object) {
 	env.Log.Infof("Creating objects: %s", objectsInfo(objects))
 	parallel.ForEach(objects, func(obj client.Object, _ int) {
-		Expect(env.Create(ctx, obj)).WithOffset(1).To(Succeed())
+		err := env.Create(ctx, obj)
+		if err != nil {
+			env.Log.Infof("%s", err.Error())
+		}
+		Expect(err).To(BeNil())
 	})
 }
 

--- a/test/pkg/test/gateway.go
+++ b/test/pkg/test/gateway.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -27,6 +28,14 @@ func (env *Framework) NewGateway(name string, namespace string) *gwv1.Gateway {
 						Name:     "https",
 						Protocol: gwv1.HTTPSProtocolType,
 						Port:     443,
+						TLS: &gwv1.GatewayTLSConfig{
+							Mode: lo.ToPtr(gwv1.TLSModeTerminate),
+							CertificateRefs: []gwv1.SecretObjectReference{
+								{
+									Name: "dummy",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/test/pkg/test/header_match_httproute.go
+++ b/test/pkg/test/header_match_httproute.go
@@ -16,6 +16,7 @@ func (env *Framework) NewHeaderMatchHttpRoute(parentRefsGateway *gwv1.Gateway, s
 					BackendObjectReference: gwv1.BackendObjectReference{
 						Name: gwv1.ObjectName(service.Name),
 						Kind: lo.ToPtr(gwv1.Kind("Service")),
+						Port: (*gwv1.PortNumber)(&service.Spec.Ports[0].Port),
 					},
 				},
 			}},

--- a/test/pkg/test/method_match_httproute.go
+++ b/test/pkg/test/method_match_httproute.go
@@ -16,6 +16,7 @@ func (env *Framework) NewMethodMatchHttpRoute(parentRefsGateway *gwv1.Gateway, g
 				BackendObjectReference: gwv1.BackendObjectReference{
 					Name: gwv1.ObjectName(getService.Name),
 					Kind: lo.ToPtr(gwv1.Kind("Service")),
+					Port: (*gwv1.PortNumber)(&postService.Spec.Ports[0].Port),
 				},
 			},
 		}},
@@ -32,6 +33,7 @@ func (env *Framework) NewMethodMatchHttpRoute(parentRefsGateway *gwv1.Gateway, g
 				BackendObjectReference: gwv1.BackendObjectReference{
 					Name: gwv1.ObjectName(postService.Name),
 					Kind: lo.ToPtr(gwv1.Kind("Service")),
+					Port: (*gwv1.PortNumber)(&postService.Spec.Ports[0].Port),
 				},
 			},
 		}},

--- a/test/pkg/test/path_match_httproute.go
+++ b/test/pkg/test/path_match_httproute.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -20,6 +21,11 @@ func (env *Framework) NewPathMatchHttpRoute(parentRefsGateway *gwv1.Gateway, bac
 		httpns = &namespace
 	}
 	for i, object := range backendRefObjects {
+		var port *gwv1.PortNumber
+		if svc, ok := object.(*corev1.Service); ok {
+			pv := gwv1.PortNumber(svc.Spec.Ports[0].Port)
+			port = &pv
+		}
 		rule := gwv1.HTTPRouteRule{
 			BackendRefs: []gwv1.HTTPBackendRef{{
 				BackendRef: gwv1.BackendRef{
@@ -27,6 +33,7 @@ func (env *Framework) NewPathMatchHttpRoute(parentRefsGateway *gwv1.Gateway, bac
 						Name:      gwv1.ObjectName(object.GetName()),
 						Namespace: (*gwv1.Namespace)(httpns),
 						Kind:      lo.ToPtr(gwv1.Kind(object.GetObjectKind().GroupVersionKind().Kind)),
+						Port:      port,
 					},
 				},
 			}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Partially - #469 

**What does this PR do / Why do we need it**:

Changed behavior for empty matches in rules. They had default value in the past but they don't right now.
https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule
https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.GRPCRouteRule

Fixed our examples to be compatible with latest GWAPI CRDs.
* HTTPRoute/GRPCRoute - All Service backendRefs require ports
* Gateway - HTTPS listeners must have TLS section
* Gateway - TLS section must include at least one cert when mode is `Terminate`
  * This is a tricky part, I had to add dummy fields on our examples. It looks ugly but probably okay.
* Gateway - Listeners must be unique on name/port/hostname

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
`make e2e-test` all pass

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.