### PR TITLE
Doc: Update Target Group Policy documentation

### DIFF
--- a/config/crds/bases/application-networking.k8s.aws_targetgrouppolicies.yaml
+++ b/config/crds/bases/application-networking.k8s.aws_targetgrouppolicies.yaml
@@ -178,11 +178,11 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Programmed
-                description: "Conditions describe the current conditions of the AccessLogPolicy.
+                description: "Conditions describe the current conditions of the TargetGroupPolicy.
                   \n Implementations should prefer to express Policy conditions using
                   the `PolicyConditionType` and `PolicyConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe AccessLogPolicy state. \n Known condition types are:
+                  to describe TargetGroupPolicy state. \n Known condition types are:
                   \n * \"Accepted\" * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1524,7 +1524,7 @@ HealthCheckConfig
 (<em>Appears on:</em><a href="#application-networking.k8s.aws/v1alpha1.TargetGroupPolicy">TargetGroupPolicy</a>)
 </p>
 <div>
-<p>TargetGroupPolicyStatus defines the observed state of AccessLogPolicy.</p>
+<p>TargetGroupPolicyStatus defines the observed state of TargetGroupPolicy.</p>
 </div>
 <table>
 <thead>

--- a/examples/deploy-v0.0.18.yaml
+++ b/examples/deploy-v0.0.18.yaml
@@ -7022,7 +7022,7 @@ spec:
             - targetRef
             type: object
           status:
-            description: TargetGroupPolicyStatus defines the observed state of AccessLogPolicy.
+            description: TargetGroupPolicyStatus defines the observed state of TargetGroupPolicy.
             properties:
               conditions:
                 default:
@@ -7036,11 +7036,11 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Programmed
-                description: "Conditions describe the current conditions of the AccessLogPolicy.
+                description: "Conditions describe the current conditions of the TargetGroupPolicy.
                   \n Implementations should prefer to express Policy conditions using
                   the `PolicyConditionType` and `PolicyConditionReason` constants
                   so that operators and tools can converge on a common vocabulary
-                  to describe AccessLogPolicy state. \n Known condition types are:
+                  to describe TargetGroupPolicy state. \n Known condition types are:
                   \n * \"Accepted\" * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current

--- a/pkg/apis/applicationnetworking/v1alpha1/targetgrouppolicy_types.go
+++ b/pkg/apis/applicationnetworking/v1alpha1/targetgrouppolicy_types.go
@@ -122,14 +122,14 @@ type HealthCheckConfig struct {
 	ProtocolVersion *HealthCheckProtocolVersion `json:"protocolVersion,omitempty"`
 }
 
-// TargetGroupPolicyStatus defines the observed state of AccessLogPolicy.
+// TargetGroupPolicyStatus defines the observed state of TargetGroup.
 type TargetGroupPolicyStatus struct {
-	// Conditions describe the current conditions of the AccessLogPolicy.
+	// Conditions describe the current conditions of the TargetGroup.
 	//
 	// Implementations should prefer to express Policy conditions
 	// using the `PolicyConditionType` and `PolicyConditionReason`
 	// constants so that operators and tools can converge on a common
-	// vocabulary to describe AccessLogPolicy state.
+	// vocabulary to describe TargetGroup state.
 	//
 	// Known condition types are:
 	//


### PR DESCRIPTION
**What type of PR is this?**
documentation


**What does this PR do / Why do we need it**:
Fixes a typo in TargetGroupPolicy that accidentally referred to AccessLogPolicy


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.