### PR TITLE
Fix for leaking target groups on service delete

### DIFF
--- a/docs/contributing/developer.md
+++ b/docs/contributing/developer.md
@@ -93,7 +93,7 @@ make e2e-clean
 
 ## Local Development
 
-A minimal sanity check on changes can be done with make presubmit. This command will also run on PR.
+A minimal test of changes can be done with ```make presubmit```. This command will also run on PR.
 
 ```
 make presubmit

--- a/pkg/aws/services/vpclattice_mocks.go
+++ b/pkg/aws/services/vpclattice_mocks.go
@@ -1679,6 +1679,21 @@ func (mr *MockLatticeMockRecorder) ListListeners(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListListeners", reflect.TypeOf((*MockLattice)(nil).ListListeners), arg0)
 }
 
+// ListListenersAsList mocks base method.
+func (m *MockLattice) ListListenersAsList(arg0 context.Context, arg1 *vpclattice.ListListenersInput) ([]*vpclattice.ListenerSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListListenersAsList", arg0, arg1)
+	ret0, _ := ret[0].([]*vpclattice.ListenerSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListListenersAsList indicates an expected call of ListListenersAsList.
+func (mr *MockLatticeMockRecorder) ListListenersAsList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListListenersAsList", reflect.TypeOf((*MockLattice)(nil).ListListenersAsList), arg0, arg1)
+}
+
 // ListListenersPages mocks base method.
 func (m *MockLattice) ListListenersPages(arg0 *vpclattice.ListListenersInput, arg1 func(*vpclattice.ListListenersOutput, bool) bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/deploy/lattice/service_manager.go
+++ b/pkg/deploy/lattice/service_manager.go
@@ -311,6 +311,7 @@ func (m *defaultServiceManager) deleteAllListeners(ctx context.Context, svc *Svc
 	}
 	for _, listener := range listeners {
 		_, err = m.cloud.Lattice().DeleteListenerWithContext(ctx, &vpclattice.DeleteListenerInput{
+			ServiceIdentifier:  svc.Id,
 			ListenerIdentifier: listener.Id,
 		})
 		if err != nil {

--- a/pkg/deploy/lattice/service_manager_test.go
+++ b/pkg/deploy/lattice/service_manager_test.go
@@ -311,6 +311,23 @@ func TestServiceManagerInteg(t *testing.T) {
 			DeleteServiceWithContext(gomock.Any(), gomock.Any()).Return(nil, nil).
 			Times(1)
 
+		// assert we delete listeners
+		mockLattice.EXPECT().
+			ListListenersAsList(gomock.Any(), gomock.Any()).
+			Return([]*vpclattice.ListenerSummary{
+				{
+					Id: aws.String("L1"),
+				},
+				{
+					Id: aws.String("L2"),
+				},
+			}, nil)
+
+		mockLattice.EXPECT().
+			DeleteListenerWithContext(gomock.Any(), gomock.Any()).
+			Return(nil, nil).
+			Times(2)
+
 		err := m.Delete(ctx, svc)
 		assert.Nil(t, err)
 	})


### PR DESCRIPTION

**What type of PR is this?**
bug fix

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
Target group deletion following service deletion is hitting a race condition where the target group is still considered associated to the service via a listener. This PR removes listeners explicitly prior to service deletion, which should ensure TGs for the service are free to delete.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
Race condition sometimes occurs running GRPC end-to-end tests.

**Testing done on this change**:
updated unit tests

**Automation added to e2e**:
ran GRPC test

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.