### PR TITLE
add log level env variable and update helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help: ## Display this help.
 
 .PHONY: run
 run: ## Run in development mode
-	go run cmd/aws-application-networking-k8s/main.go --debug
+	DEV_MODE=1 LOG_LEVEL=debug go run cmd/aws-application-networking-k8s/main.go
 
 
 .PHONY: presubmit

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help: ## Display this help.
 
 .PHONY: run
 run: ## Run in development mode
-	DEV_MODE=1 LOG_LEVEL=debug go run cmd/aws-application-networking-k8s/main.go
+	DEV_MODE=1 go run cmd/aws-application-networking-k8s/main.go
 
 
 .PHONY: presubmit

--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/go-logr/zapr"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/aws"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
@@ -91,17 +92,16 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var debug bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&debug, "debug", false, "enable debug mode")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	log := gwlog.NewLogger(debug)
+	logLevel := logLevel()
+	log := gwlog.NewLogger(logLevel)
 	ctrl.SetLogger(zapr.NewLogger(log.Desugar()).WithName("runtime"))
 
 	setupLog := log.Named("setup")
@@ -219,4 +219,18 @@ func main() {
 		os.Exit(1)
 	}
 
+}
+
+func logLevel() zapcore.Level {
+	level := os.Getenv("LOG_LEVEL")
+	switch level {
+	case "debug":
+		return zapcore.DebugLevel
+	case "error":
+		return zapcore.ErrorLevel
+	case "panic":
+		return zapcore.PanicLevel
+	default:
+		return zapcore.InfoLevel
+	}
 }

--- a/docs/guides/environment.md
+++ b/docs/guides/environment.md
@@ -44,7 +44,7 @@ When running AWS Gateway API Controller outside the Kubernetes Cluster, this spe
 
 ---
 
-#### `GATEWAY_API_CONTROLLER_LOGLEVEL`
+#### `LOG_LEVEL`
 
 Type: string
 

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -9,4 +9,4 @@ data:
     clusterName: {{ .Values.clusterName | quote }}
     latticeEndpoint: {{ .Values.latticeEndpoint | quote }}
     defaultServiceNetwork: {{ .Values.defaultServiceNetwork | quote }}
-
+    logLevel: {{ .Values.log.level | quote }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -97,6 +97,11 @@ spec:
               configMapKeyRef:
                 name: env-config
                 key: defaultServiceNetwork
+          - name: LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: env-config
+                key: logLevel
 
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,3 +77,4 @@ clusterVpcId:
 clusterName:
 defaultServiceNetwork:
 latticeEndpoint:
+logLevel:

--- a/pkg/utils/gwlog/gwlog.go
+++ b/pkg/utils/gwlog/gwlog.go
@@ -2,6 +2,7 @@ package gwlog
 
 import (
 	"log"
+	"os"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -9,16 +10,20 @@ import (
 
 type Logger = *zap.SugaredLogger
 
-func NewLogger(debug bool) Logger {
+func NewLogger(level zapcore.Level) Logger {
 	var zc zap.Config
-	if debug {
+
+	dev := os.Getenv("DEV_MODE")
+	if dev != "" {
 		zc = zap.NewDevelopmentConfig()
-		zc.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 	} else {
 		zc = zap.NewProductionConfig()
 		zc.DisableStacktrace = true
 		zc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	}
+
+	zc.Level = zap.NewAtomicLevelAt(level)
+
 	z, err := zc.Build()
 	if err != nil {
 		log.Fatal("cannot initialize zapr logger", err)
@@ -26,4 +31,4 @@ func NewLogger(debug bool) Logger {
 	return z.Sugar()
 }
 
-var FallbackLogger = NewLogger(true)
+var FallbackLogger = NewLogger(zap.DebugLevel)

--- a/scripts/load_env_variables.sh
+++ b/scripts/load_env_variables.sh
@@ -15,13 +15,11 @@ if [ -z "$KUBEBUILDER_ASSETS" ]; then
 fi
 echo "KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS" >> envFile
 
-
 # Set CLUSTER_NAME if not set
 if [ -z "$CLUSTER_NAME" ]; then
   CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
 fi
 echo "CLUSTER_NAME=$CLUSTER_NAME" >> envFile
-
 
 # Set CLUSTER_VPC_ID if not set
 if [ -z "$CLUSTER_VPC_ID" ]; then
@@ -40,7 +38,4 @@ if [ -z "$REGION" ]; then
 fi
 echo "REGION=$REGION" >> envFile
 
-
-GATEWAY_API_CONTROLLER_LOGLEVEL=debug
-echo "GATEWAY_API_CONTROLLER_LOGLEVEL=$GATEWAY_API_CONTROLLER_LOGLEVEL" >> envFile
-
+echo "LOG_LEVEL=debug" >> envFile

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -63,7 +64,7 @@ var _ = SynchronizedBeforeSuite(func() {
 
 func TestIntegration(t *testing.T) {
 	ctx = test.NewContext(t)
-	logger := gwlog.NewLogger(true)
+	logger := gwlog.NewLogger(zap.DebugLevel)
 	testFramework = test.NewFramework(ctx, logger, k8snamespace)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Integration")


### PR DESCRIPTION
Note:

- Decouple log-level from dev and prod logging config. Can use different logging levels for both.
- Add env variable to control log level. Introduce few levels: **info**, **debug**, **error**, **panic**. Default value is **info**. Still thinking about error and panic logs, probably redundant.
- Add DEV_MODE env variable to enable development logging format.

#530

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.