### PR TITLE
Shift from buildah to docker build so that people could more easier release image in their local macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ go.work*
 
 # gomock generated prog.go
 pkg/aws/services/gomock_reflect_*
+
+# Image build tarballed bundles
+*.tgz

--- a/scripts/lib/login.sh
+++ b/scripts/lib/login.sh
@@ -5,20 +5,20 @@
 # helm.sh, because those files ensure binaries(ex: kind) that are not
 # really needed for simple actions like repository login.
 # A future refactor can make those files more modular and then login
-# functions can be refactored in tool specific file like buildah.sh
+# functions can be refactored in tool specific file like docker.sh
 # and helm.sh
 
-perform_buildah_and_helm_login() {
+perform_docker_and_helm_login() {
   #ecr-public only exists in us-east-1 so use that region specifically
   local __pw=$(aws ecr-public get-login-password --region us-east-1)
-  echo "$__pw" | buildah login -u AWS --password-stdin public.ecr.aws
+  echo "$__pw" | docker login -u AWS --password-stdin public.ecr.aws
   export HELM_EXPERIMENTAL_OCI=1
   echo "$__pw" | helm registry login -u AWS --password-stdin public.ecr.aws
 }
 
 ensure_binaries() {
     check_is_installed "aws"
-    check_is_installed "buildah" "See https://github.com/containers/buildah/blob/main/install.md"
+    check_is_installed "docker"
     check_is_installed "helm"
 }
 


### PR DESCRIPTION
## Changes  
- Shift from buildah to `docker build` so that people could be more easier to release image in their macOS, (docker build also work in linux in the image release ec2 instance) (buildah only have linux but no macOS version, and [aws-load-balancer-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/Makefile#L100) also use the docker build) (at least, for me, do image release in my macOS save 15 min time)
- Hard code the ECR_PUBLISH_ROLE_ARN in release-controller.sh, as the "public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller" ECR repo only exists in 606627242267, and people who do image release must assume this role

## Test
Use the new release-controller.sh, manually changed all image version to `v0.0.0-release-test`, run the `release-controller.sh` **in my macOS** and push the artificts to ECR repo:
aws-application-networking-k8s/aws-gateway-controller
aws-application-networking-k8s/aws-gateway-controller-chart
successfully: 
https://gallery.ecr.aws/aws-application-networking-k8s?page=1

Deployed this built helm chart in my EKS cluster, it's running good:
```
helm install gateway-api-controller \
      oci://public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart\
      --version=v0.0.0-release-test \
      --set=serviceAccount.create=false --namespace aws-application-networking-system


 kubectl --namespace aws-application-networking-system get pods -l "app.kubernetes.io/instance=gateway-api-controller"

NAME                                                              READY   STATUS    RESTARTS   AGE
gateway-api-controller-aws-gateway-controller-chart-bfbfddjmvz9   1/1     Running   0          12s
gateway-api-controller-aws-gateway-controller-chart-bfbfddscvwg   1/1     Running   0          13s

kubectl logs -n aws-application-networking-system gateway-api-controller-aws-gateway-controller-chart-bfbfddjmvz9

logs look good:

{"level":"info","ts":"2023-12-13T17:52:27.429Z","logger":"setup","caller":"workspace/main.go:112","msg":"init config","VpcId":"vpc-0c9c66ebcf3b99ae2","Region":"us-west-2","AccountId":"348739612106","DefaultServiceNetwork":"","ClusterName":"my-cluster-sec-2","LogLevel":"info"}
{"level":"info","ts":"2023-12-13T17:52:27.470Z","logger":"setup","caller":"workspace/main.go:217","msg":"starting manager"}
{"level":"info","ts":"2023-12-13T17:52:27.471Z","logger":"runtime.controller-runtime.metrics","caller":"server/server.go:185","msg":"Starting metrics server"}
{"level":"info","ts":"2023-12-13T17:52:27.471Z","logger":"runtime.controller-runtime.metrics","caller":"server/server.go:224","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2023-12-13T17:52:27.471Z","logger":"runtime","caller":"manager/server.go:50","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
I1213 17:52:27.471617       1 leaderelection.go:250] attempting to acquire leader lease aws-application-networking-system/amazon-vpc-lattice.io...
zijunw@bcd07446e0d4 aws-application-networking-k8s % kubectl logs -n aws-application-networking-system gateway-api-controller-aws-gateway-controller-chart-bfbfddscvwg 
{"level":"info","ts":"2023-12-13T17:52:27.340Z","logger":"setup","caller":"workspace/main.go:112","msg":"init config","VpcId":"vpc-0c9c66ebcf3b99ae2","Region":"us-west-2","AccountId":"348739612106","DefaultServiceNetwork":"","ClusterName":"my-cluster-sec-2","LogLevel":"info"}
{"level":"info","ts":"2023-12-13T17:52:27.376Z","logger":"setup","caller":"workspace/main.go:217","msg":"starting manager"}
{"level":"info","ts":"2023-12-13T17:52:27.376Z","logger":"runtime.controller-runtime.metrics","caller":"server/server.go:185","msg":"Starting metrics server"}
{"level":"info","ts":"2023-12-13T17:52:27.376Z","logger":"runtime.controller-runtime.metrics","caller":"server/server.go:224","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2023-12-13T17:52:27.376Z","logger":"runtime","caller":"manager/server.go:50","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
I1213 17:52:27.376875       1 leaderelection.go:250] attempting to acquire leader lease aws-application-networking-system/amazon-vpc-lattice.io...
I1213 17:52:43.506080       1 leaderelection.go:260] successfully acquired lease aws-application-networking-system/amazon-vpc-lattice.io
{"level":"info","ts":"2023-12-13T17:52:43.506Z","logger":"runtime","caller":"controller/controller.go:178","msg":"Starting EventSource","controller":"pod","controllerGroup":"","controllerKind":"Pod","source":"kind source: *v1.Pod"}
{"level":"info","ts":"2023-12-13T17:52:43.506Z","logger":"runtime","caller":"controller/controller.go:186","msg":"Starting Controller","controller":"pod","controllerGroup":"","controllerKind":"Pod"}
{"level":"info","ts":"2023-12-13T17:52:43.506Z","logger":"runtime","caller":"controller/controller.go:178","msg":"Starting EventSource","controller":"gatewayclass","controllerGroup":"gateway.networking.k8s.io","controllerKind":"GatewayClass","source":"kind source: *v1beta1.GatewayClass"}
{"level":"info","ts":"2023-12-13T17:52:43.506Z","logger":"runtime","caller":"controller/controller.go:186","msg":"Starting Controller","controller":"gatewayclass","controllerGroup":"gateway.networking.k8s.io","controllerKind":"GatewayClass"}
....
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.