### PR TITLE
Fix helm chart config map default value issue #575 

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
     name: env-config
 data:
-    awsRegion: {{ .Values.awsRegion | quote }}
-    awsAccountId: {{ .Values.awsAccountId | quote }}
-    clusterVpcId: {{ .Values.clusterVpcId | quote }}
-    clusterName: {{ .Values.clusterName | quote }}
-    latticeEndpoint: {{ .Values.latticeEndpoint | quote }}
-    defaultServiceNetwork: {{ .Values.defaultServiceNetwork | quote }}
-    logLevel: {{ .Values.log.level | quote }}
+    awsRegion: {{ .Values.awsRegion | default "" | quote }}
+    awsAccountId: {{ .Values.awsAccountId | default ""| quote }}
+    clusterVpcId: {{ .Values.clusterVpcId | default "" | quote }}
+    clusterName: {{ .Values.clusterName | default "" | quote }}
+    latticeEndpoint: {{ .Values.latticeEndpoint | default "" | quote }}
+    defaultServiceNetwork: {{ .Values.defaultServiceNetwork  | default "" | quote }}
+    logLevel: {{ .Values.log.level | default "info" | quote }}


### PR DESCRIPTION
Fix the issue #575 

Reference: 
https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function



### Testing

Use the new code to create a new image version  [v1.0.3-rc.1](https://gallery.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart). Used the v1.0.3-rc.1 to test the upgrade:

1. Install an old version helm chart:
```
helm install gateway-api-controller \
      oci://public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart\
      --version=v1.0.2 \
      --set=serviceAccount.create=false --namespace aws-application-networking-system \
       --set=log.level=debug
```
Confirmed controller pods are in Running status, checked the controller logs , it's running good.

2. Upgrade to  v1.0.3-rc.1 :
```helm upgrade gateway-api-controller \
      oci://public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart\
      --version=v1.0.3-rc.1 \
      --set=serviceAccount.create=false --namespace aws-application-networking-system \
       --set=log.level=debug

```
Confirmed controller pods upgrade success and they are in Running status. And  env-config for  v1.0.3-rc.1 shows the correct data:
```
kubectl get configMap env-config  -n aws-application-networking-system -o yaml
apiVersion: v1
data:
  awsAccountId: ""
  awsRegion: ""
  clusterName: ""
  clusterVpcId: ""
  defaultServiceNetwork: ""
  latticeEndpoint: ""
  logLevel: debug
kind: ConfigMap
....
```
(If I don't pass `--set=log.level=debug` , the logLevel in configMap is `info` as expected)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.