### PR TITLE
Update target-group-policy.md

### DIFF
--- a/docs/api-types/target-group-policy.md
+++ b/docs/api-types/target-group-policy.md
@@ -54,6 +54,6 @@ spec:
         path: "/healthcheck"
         port: 80
         protocol: HTTP
-        protocolVersion: HTTP
+        protocolVersion: HTTP1
         statusMatch: "200"
 ```


### PR DESCRIPTION
Missing the `1` at the end of this protocolVersion.

**What type of PR is this?**
documentation

**Which issue does this PR fix**:
None

**What does this PR do / Why do we need it**:
Resource example yaml had a typo

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
None just a typo

**Testing done on this change**:
Intense visual scrutiny

**Automation added to e2e**:
None

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
No

```release-note
Just need the extra 1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.