### PR TITLE
Add TG garbage collector

### DIFF
--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -122,9 +122,10 @@ type DeleteUnusedResult struct {
 	Err error
 }
 
-// this method assumes all synthesis
-// returns list of deletion results, might include partial failures
-// if cannot produce list for deletion will return error
+// This method assumes all synthesis. Returns list of deletion results, might include partial
+// failures if cannot produce list for deletion will return error.
+//
+// TODO: we should do parallel deletion calls, preferably with bounded WorkGroup
 func (t *TargetGroupSynthesizer) SynthesizeUnusedDelete(ctx context.Context) ([]DeleteUnusedResult, error) {
 	tgsToDelete, err := t.calculateTargetGroupsToDelete(ctx)
 	if err != nil {

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -147,7 +147,7 @@ func Test_SynthesizeUnusedDeleteIgnoreNotManagedByController(t *testing.T) {
 
 	mockTGManager.EXPECT().List(ctx).Return(nonManagedTgs, nil)
 	synthesizer := NewTargetGroupSynthesizer(gwlog.FallbackLogger, nil, nil, mockTGManager, nil, nil, nil)
-	err := synthesizer.SynthesizeUnusedDelete(ctx)
+	_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 	assert.Nil(t, err)
 }
 
@@ -259,7 +259,7 @@ func Test_DoNotDeleteCases(t *testing.T) {
 	synthesizer := NewTargetGroupSynthesizer(
 		gwlog.FallbackLogger, nil, mockClient, mockTGManager, mockSvcExportTgBuilder, mockSvcBuilder, stack)
 
-	err := synthesizer.SynthesizeUnusedDelete(ctx)
+	_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 	assert.Nil(t, err)
 }
 
@@ -299,7 +299,7 @@ func Test_DeleteServiceExport_DeleteCases(t *testing.T) {
 		synthesizer := NewTargetGroupSynthesizer(
 			gwlog.FallbackLogger, nil, mockClient, mockTGManager, mockSvcExportTgBuilder, nil, nil)
 
-		err := synthesizer.SynthesizeUnusedDelete(ctx)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 		assert.Nil(t, err)
 	})
 
@@ -321,7 +321,7 @@ func Test_DeleteServiceExport_DeleteCases(t *testing.T) {
 		synthesizer := NewTargetGroupSynthesizer(
 			gwlog.FallbackLogger, nil, mockClient, mockTGManager, mockSvcExportTgBuilder, nil, nil)
 
-		err := synthesizer.SynthesizeUnusedDelete(ctx)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 		assert.Nil(t, err)
 	})
 
@@ -359,7 +359,7 @@ func Test_DeleteServiceExport_DeleteCases(t *testing.T) {
 		synthesizer := NewTargetGroupSynthesizer(
 			gwlog.FallbackLogger, nil, mockClient, mockTGManager, mockSvcExportTgBuilder, nil, nil)
 
-		err := synthesizer.SynthesizeUnusedDelete(ctx)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 		assert.Nil(t, err)
 	})
 }
@@ -402,7 +402,7 @@ func Test_DeleteRoute_DeleteCases(t *testing.T) {
 		synthesizer := NewTargetGroupSynthesizer(
 			gwlog.FallbackLogger, nil, mockClient, mockTGManager, nil, mockSvcBuilder, nil)
 
-		err := synthesizer.SynthesizeUnusedDelete(ctx)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 		assert.Nil(t, err)
 	})
 
@@ -424,7 +424,7 @@ func Test_DeleteRoute_DeleteCases(t *testing.T) {
 		synthesizer := NewTargetGroupSynthesizer(
 			gwlog.FallbackLogger, nil, mockClient, mockTGManager, nil, mockSvcBuilder, nil)
 
-		err := synthesizer.SynthesizeUnusedDelete(ctx)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 		assert.Nil(t, err)
 	})
 
@@ -474,7 +474,7 @@ func Test_DeleteRoute_DeleteCases(t *testing.T) {
 		synthesizer := NewTargetGroupSynthesizer(
 			gwlog.FallbackLogger, nil, mockClient, mockTGManager, nil, mockSvcBuilder, nil)
 
-		err := synthesizer.SynthesizeUnusedDelete(ctx)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
 		assert.Nil(t, err)
 	})
 }

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -82,7 +82,7 @@ func NewLatticeServiceStackDeploy(
 		tgGcFn := NewTgGcFn(tgGcSynth)
 		tgGc = &TgGc{
 			lock:    sync.Mutex{},
-			log:     log.Named("gc"),
+			log:     log.Named("tg-gc"),
 			ctx:     context.TODO(),
 			isDone:  atomic.Bool{},
 			ivl:     TG_GC_IVL,
@@ -189,6 +189,11 @@ func (d *latticeServiceStackDeployer) Deploy(ctx context.Context, stack core.Sta
 	listenerSynthesizer := lattice.NewListenerSynthesizer(d.log, d.listenerManager, stack)
 	ruleSynthesizer := lattice.NewRuleSynthesizer(d.log, d.ruleManager, d.targetGroupManager, stack)
 
+	// we need to block GC when we deploy stack
+	// stack deployer first creates TG and then associate TG with Service
+	// if GC will run in between it can delete newly created TG before it associated
+	// this lock also prevents concurrent deployments, only one deployment cat run at the time
+	// TODO: This place can become a contention. May be add debug log with waiting time for lock?
 	defer func() {
 		tgGc.lock.Unlock()
 	}()

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -3,16 +3,22 @@ package deploy
 import (
 	"context"
 	"fmt"
-
-	"github.com/aws/aws-application-networking-k8s/pkg/gateway"
-	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	"github.com/aws/aws-application-networking-k8s/pkg/deploy/externaldns"
 	"github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
+	"github.com/aws/aws-application-networking-k8s/pkg/gateway"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+)
+
+const (
+	TG_GC_IVL = time.Second * 30
 )
 
 type StackDeployer interface {
@@ -54,6 +60,9 @@ type latticeServiceStackDeployer struct {
 	svcBuilder            gateway.LatticeServiceBuilder
 }
 
+var tgGcOnce sync.Once
+var tgGc *TgGc
+
 func NewLatticeServiceStackDeploy(
 	log gwlog.Logger,
 	cloud pkg_aws.Cloud,
@@ -61,19 +70,116 @@ func NewLatticeServiceStackDeploy(
 ) *latticeServiceStackDeployer {
 	brTgBuilder := gateway.NewBackendRefTargetGroupBuilder(log, k8sClient)
 
+	tgMgr := lattice.NewTargetGroupManager(log, cloud)
+	tgSvcExpBuilder := gateway.NewSvcExportTargetGroupBuilder(log, k8sClient)
+	svcBuilder := gateway.NewLatticeServiceBuilder(log, k8sClient, brTgBuilder)
+
+	tgGcOnce.Do(func() {
+		// TODO: need to refactor TG synthesizer. Remove stack from constructor
+		// arguments and use it as Synth argument. That will help with Synth
+		// reuse for GC purposes
+		tgGcSynth := lattice.NewTargetGroupSynthesizer(log, cloud, k8sClient, tgMgr, tgSvcExpBuilder, svcBuilder, nil)
+		tgGcFn := NewTgGcFn(tgGcSynth)
+		tgGc = &TgGc{
+			lock:    sync.Mutex{},
+			log:     log.Named("gc"),
+			ctx:     context.TODO(),
+			isDone:  atomic.Bool{},
+			ivl:     TG_GC_IVL,
+			cycleFn: tgGcFn,
+		}
+		tgGc.start()
+	})
+
 	return &latticeServiceStackDeployer{
 		log:                   log,
 		cloud:                 cloud,
 		k8sClient:             k8sClient,
 		latticeServiceManager: lattice.NewServiceManager(log, cloud),
-		targetGroupManager:    lattice.NewTargetGroupManager(log, cloud),
+		targetGroupManager:    tgMgr,
 		targetsManager:        lattice.NewTargetsManager(log, cloud),
 		listenerManager:       lattice.NewListenerManager(log, cloud),
 		ruleManager:           lattice.NewRuleManager(log, cloud),
 		dnsEndpointManager:    externaldns.NewDnsEndpointManager(log, k8sClient),
-		svcExportTgBuilder:    gateway.NewSvcExportTargetGroupBuilder(log, k8sClient),
-		svcBuilder:            gateway.NewLatticeServiceBuilder(log, k8sClient, brTgBuilder),
+		svcExportTgBuilder:    tgSvcExpBuilder,
+		svcBuilder:            svcBuilder,
 	}
+}
+
+type TgGcCycleFn = func(context.Context) (TgGcResult, error)
+
+func NewTgGcFn(tgSynth *lattice.TargetGroupSynthesizer) TgGcCycleFn {
+	return func(ctx context.Context) (TgGcResult, error) {
+		t0 := time.Now()
+		results, err := tgSynth.SynthesizeUnusedDelete(ctx)
+		if err != nil {
+			return TgGcResult{}, err
+		}
+		succ := 0
+		for _, res := range results {
+			if res.Err == nil {
+				succ += 1
+			}
+		}
+		return TgGcResult{
+			att:      len(results),
+			succ:     succ,
+			duration: time.Since(t0),
+		}, nil
+	}
+}
+
+type TgGc struct {
+	lock    sync.Mutex
+	log     gwlog.Logger
+	ctx     context.Context
+	isDone  atomic.Bool
+	ivl     time.Duration
+	cycleFn TgGcCycleFn
+}
+
+type TgGcResult struct {
+	// number deletion attempts
+	att int
+	// number of successful deletions
+	succ int
+	// cycle duration
+	duration time.Duration
+}
+
+func (gc *TgGc) start() {
+	ticker := time.NewTicker(gc.ivl)
+	go func() {
+		for {
+			select {
+			case <-gc.ctx.Done():
+				gc.log.Info("stop GC, ctx is done")
+				gc.isDone.Store(true)
+				return
+			case <-ticker.C:
+				gc.cycle()
+			}
+		}
+	}()
+}
+
+func (gc *TgGc) cycle() {
+	defer func() {
+		if r := recover(); r != nil {
+			gc.log.Errorf("gc cycle panic: %s", r)
+		}
+		gc.lock.Unlock()
+	}()
+	gc.lock.Lock()
+	res, err := gc.cycleFn(gc.ctx)
+	if err != nil {
+		gc.log.Debugf("gc cycle error: %s", err)
+	}
+	gc.log.Debugw("tg gc result",
+		"delete_attempts", res.att,
+		"delete_success", res.succ,
+		"duration", res.duration,
+	)
 }
 
 func (d *latticeServiceStackDeployer) Deploy(ctx context.Context, stack core.Stack) error {
@@ -82,6 +188,11 @@ func (d *latticeServiceStackDeployer) Deploy(ctx context.Context, stack core.Sta
 	serviceSynthesizer := lattice.NewServiceSynthesizer(d.log, d.latticeServiceManager, d.dnsEndpointManager, stack)
 	listenerSynthesizer := lattice.NewListenerSynthesizer(d.log, d.listenerManager, stack)
 	ruleSynthesizer := lattice.NewRuleSynthesizer(d.log, d.ruleManager, d.targetGroupManager, stack)
+
+	defer func() {
+		tgGc.lock.Unlock()
+	}()
+	tgGc.lock.Lock()
 
 	//Handle targetGroups creation request
 	if err := targetGroupSynthesizer.SynthesizeCreate(ctx); err != nil {
@@ -111,12 +222,6 @@ func (d *latticeServiceStackDeployer) Deploy(ctx context.Context, stack core.Sta
 	//Handle targetGroup deletion request
 	if err := targetGroupSynthesizer.SynthesizeDelete(ctx); err != nil {
 		return fmt.Errorf("error during tg delete synthesis %w", err)
-	}
-
-	// Do garbage collection for not-in-use targetGroups
-	//TODO: run SynthesizeSDKTargetGroups(ctx) as a global garbage collector scheduled background task (i.e., run it as a goroutine in main.go)
-	if err := targetGroupSynthesizer.SynthesizeUnusedDelete(ctx); err != nil {
-		return fmt.Errorf("error during tg unused delete synthesis %w", err)
 	}
 
 	return nil

--- a/pkg/deploy/stack_deployer_test.go
+++ b/pkg/deploy/stack_deployer_test.go
@@ -1,0 +1,74 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTgGc(t *testing.T) {
+
+	type test struct {
+		name string
+		gcFn TgGcCycleFn
+	}
+
+	tests := []test{
+		{
+			name: "empty cycle",
+			gcFn: func(context.Context) (TgGcResult, error) { return TgGcResult{}, nil },
+		},
+		{
+			name: "cycle with results",
+			gcFn: func(context.Context) (TgGcResult, error) {
+				return TgGcResult{
+					att:      10,
+					succ:     10,
+					duration: time.Second,
+				}, nil
+			},
+		},
+		{
+			name: "cycle panic",
+			gcFn: func(context.Context) (TgGcResult, error) { panic("") },
+		},
+		{
+			name: "cycle error",
+			gcFn: func(context.Context) (TgGcResult, error) { return TgGcResult{}, errors.New("") },
+		},
+	}
+
+	nCycles := 10 // run each test at least 10 cycles
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			n := 0
+			f := func(ctx context.Context) (TgGcResult, error) {
+				defer func() {
+					n += 1
+					if n >= nCycles {
+						cancel()
+					}
+				}()
+				return tt.gcFn(ctx)
+			}
+			ivl := time.Millisecond * 10
+			tgGc := &TgGc{
+				log:     gwlog.FallbackLogger,
+				ctx:     ctx,
+				ivl:     ivl,
+				cycleFn: f,
+			}
+			tgGc.start()
+			time.Sleep(ivl * (time.Duration(nCycles) + 2)) // sleep enough cycles to terminate
+			assert.Equal(t, nCycles, n, fmt.Sprintf("should run only %d cycles", nCycles))
+			assert.True(t, tgGc.isDone.Load(), "gc must terminate")
+		})
+	}
+}


### PR DESCRIPTION
Note:
Address performance issue for unused target group cleanup. Implemented background garbage collector, that runs every X seconds. Might need to tune timers after. 

e2e tests pass:

```
Ran 58 of 58 Specs in 2358.172 seconds
SUCCESS! -- 58 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (2358.17s)
```
close #552