### PR TITLE
Access Log Policy Test Cleanup Robustness

### DIFF
--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -616,8 +616,8 @@ func (env *Framework) SleepForRouteUpdate() {
 	time.Sleep(10 * time.Second)
 }
 
-func (env *Framework) NewTestTags() map[string]*string {
+func (env *Framework) NewTestTags(testSuite string) map[string]*string {
 	return env.Cloud.DefaultTagsMergedWith(map[string]*string{
-		anaws.TagBase + "TestSuite": aws.String(K8sNamespace),
+		anaws.TagBase + "TestSuite": aws.String(testSuite),
 	})
 }

--- a/test/suites/integration/ram_share_test.go
+++ b/test/suites/integration/ram_share_test.go
@@ -37,6 +37,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 
 	const (
 		k8sResourceNamePrefix = "k8s-test-ram-"
+		testSuite             = "ram-share"
 	)
 
 	var (
@@ -165,7 +166,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 		// Create primary account's service network using randomName
 		createSNInput := &vpclattice.CreateServiceNetworkInput{
 			Name: aws.String(randomName),
-			Tags: testFramework.NewTestTags(),
+			Tags: testFramework.NewTestTags(testSuite),
 		}
 		_, err := clients.latticeClient1.CreateServiceNetworkWithContext(ctx, createSNInput)
 		Expect(err).NotTo(HaveOccurred())
@@ -223,7 +224,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 	AfterAll(func() {
 		// Find all AWS resources created in tests
 		var tagFilters []*resourcegroupstaggingapi.TagFilter
-		for key, value := range testFramework.NewTestTags() {
+		for key, value := range testFramework.NewTestTags(testSuite) {
 			tagFilters = append(tagFilters, &resourcegroupstaggingapi.TagFilter{
 				Key:    aws.String(key),
 				Values: []*string{value},
@@ -275,7 +276,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 })
 
 func createSharedServiceNetwork(serviceNetworkName string, clients *testClients) *vpclattice.GetServiceNetworkOutput {
-	tags := testFramework.NewTestTags()
+	tags := testFramework.NewTestTags("ram-share")
 
 	// Create secondary account's service network
 	createSNInput := &vpclattice.CreateServiceNetworkInput{

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -51,10 +51,8 @@ var _ = SynchronizedBeforeSuite(func() {
 
 	testFramework.Log.Infof("Expecting VPC %s and service network %s association", vpcId, *testServiceNetwork.Id)
 	Eventually(func(g Gomega) {
-		associated, snva, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
+		associated, _, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
 		g.Expect(associated).To(BeTrue())
-		managed, _ := testFramework.Cloud.IsArnManaged(ctx, *snva.Arn)
-		g.Expect(managed).To(BeTrue())
 	}).Should(Succeed())
 
 }, func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
cleanup

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
- Removes requirement for Cluster VPC Association to Gateway Service Network to be tagged with "ManagedBy"
    - Controller no longer manages this association, so the tag should not be expected to be there
- Changes the logic of resource naming in Access Log Policy e2e tests such that all AWS resources are created with a partially pseudo-random name
    - Prevents previously leaked resources from interfering with new test runs due to name conflicts
- Changes the logic of Access Log Policy e2e tests to tag all AWS resources with TestSuite=access-log-policy and then to clean up all AWS resources with that tag in the AfterAll block
    - Subsequent test runs can clean up resources missed in previously interrupted runs
- Adds new parameter to TestFramework.NewTestTags function to accept the test suite name
    - Allows for individual test suites to manage their own resource cleanup without interfering with each other when running in parallel
    - Makes it clear which test created a specific resource (e.g. in the event of a bug causing leaks)

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
Ran 13 of 61 Specs in 545.028 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 48 Skipped
--- PASS: TestIntegration (545.03s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   545.761s
```

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
Improved test cleanup.

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No.

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.