### PR TITLE
Fix target group discovery logic

### DIFF
--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
-	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"reflect"
@@ -256,11 +255,7 @@ func (s *defaultTargetGroupManager) List(ctx context.Context) ([]tgListOutput, e
 	if len(resp) == 0 {
 		return nil, nil
 	}
-	validTgs := utils.SliceFilter(resp, func(tg *vpclattice.TargetGroupSummary) bool {
-		return aws.StringValue(tg.VpcIdentifier) == config.VpcID &&
-			aws.StringValue(tg.Type) == vpclattice.TargetGroupTypeIp
-	})
-	tgArns := utils.SliceMap(validTgs, func(tg *vpclattice.TargetGroupSummary) string {
+	tgArns := utils.SliceMap(resp, func(tg *vpclattice.TargetGroupSummary) string {
 		return aws.StringValue(tg.Arn)
 	})
 	tgArnToTagsMap, err := s.cloud.Tagging().GetTagsForArns(ctx, tgArns)
@@ -268,7 +263,7 @@ func (s *defaultTargetGroupManager) List(ctx context.Context) ([]tgListOutput, e
 	if err != nil {
 		return nil, err
 	}
-	for _, tg := range validTgs {
+	for _, tg := range resp {
 		tgList = append(tgList, tgListOutput{
 			tgSummary: tg,
 			tags:      tgArnToTagsMap[*tg.Arn],

--- a/pkg/deploy/lattice/target_group_manager_test.go
+++ b/pkg/deploy/lattice/target_group_manager_test.go
@@ -778,6 +778,8 @@ func Test_ListTG_TGsExist(t *testing.T) {
 	id := "123456789"
 	name1 := "test1"
 	config.VpcID = "vpc-id"
+	externalVpc := "external-vpc-id"
+
 	config.ClusterName = "cluster-name"
 	tgType := vpclattice.TargetGroupTypeIp
 	tg1 := &vpclattice.TargetGroupSummary{
@@ -792,7 +794,7 @@ func Test_ListTG_TGsExist(t *testing.T) {
 		Arn:           &arn,
 		Id:            &id,
 		Name:          &name2,
-		VpcIdentifier: &config.VpcID,
+		VpcIdentifier: &externalVpc,
 		Type:          &tgType,
 	}
 	listTGOutput := []*vpclattice.TargetGroupSummary{tg1, tg2}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Fixes target group discovery logic that may cause service exports from other clusters are not shown.

I think this VPC-based filtering logic got into during the TG performance optimization. I don't think this adds a lot of performance value anyways so I completely removed it. List() call is currently used in two places:
* Unused target group cleanup. This filters result by VPC regardless.
* ServiceExport detection. This will now be fixed.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:

Unit testing and manual cross-cluster testing that verifies traffic.

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.