### PR TITLE
Improve github-release.sh

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -49,11 +49,9 @@ function sed_inplace() {
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS uses BSD sed
-        echo "sed -i '' \"s|$pattern|$replacement|g\" \"$file\""
         sed -i '' "s|$pattern|$replacement|g" "$file"
     else
         # Assuming Linux uses GNU sed
-        echo "sed -i \"s|$pattern|$replacement|g\" \"$file\""
         sed -i "s|$pattern|$replacement|g" "$file"
     fi
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -49,9 +49,11 @@ function sed_inplace() {
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS uses BSD sed
+        echo "sed -i '' \"s|$pattern|$replacement|g\" \"$file\""
         sed -i '' "s|$pattern|$replacement|g" "$file"
     else
         # Assuming Linux uses GNU sed
+        echo "sed -i \"s|$pattern|$replacement|g\" \"$file\""
         sed -i "s|$pattern|$replacement|g" "$file"
     fi
 }


### PR DESCRIPTION
Improve github-release.sh, delete local release branch/ tag if it exist, show error message if release branch/ tag  exists remotely

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.