### PR TITLE
e2e test framework minor change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ run: ## Run in development mode
 
 
 .PHONY: presubmit
-presubmit: manifest vet lint test ## Run all commands before submitting code
+presubmit: vet manifest lint test ## Run all commands before submitting code
 
 .PHONY: vet
 vet: ## Vet the code and dependencies
@@ -123,7 +123,8 @@ e2e-test: ## Run e2e tests against cluster pointed to by ~/.kube/config
 		-v \
 		./suites/integration/... \
 		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.skip="${SKIP}"
+		--ginkgo.skip="${SKIP}" \
+		--ginkgo.v
 
 .SILENT:
 .PHONY: e2e-clean

--- a/docs/contributing/developer.md
+++ b/docs/contributing/developer.md
@@ -133,6 +133,7 @@ You can create an IAM Role, with a Trust Policy allowing the primary account to 
 
 ```
 export SECONDARY_ACCOUNT_TEST_ROLE_ARN=arn:aws:iam::000000000000:role/MyRole
+export FOCUS="RAM Share"
 REGION=us-west-2 make e2e-test
 ```
 

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -155,16 +155,17 @@ func (env *Framework) ExpectToBeClean(ctx context.Context) {
 		defer GinkgoRecover()
 		env.EventuallyExpectNoneFound(ctx, testObject.ListType)
 	})
-
+	tags := env.DefaultTags
+	tags[model.K8SServiceNamespaceKey] = aws.String(K8sNamespace)
 	Eventually(func(g Gomega) {
-		arns, err := env.TaggingClient.FindResourcesByTags(ctx, services.ResourceTypeService, env.DefaultTags)
+		arns, err := env.TaggingClient.FindResourcesByTags(ctx, services.ResourceTypeService, tags)
 		env.Log.Infow("Expecting no services created by the controller", "found", arns)
 		g.Expect(err).To(BeNil())
 		g.Expect(arns).To(BeEmpty())
 	}).Should(Succeed())
 
 	Eventually(func(g Gomega) {
-		arns, err := env.TaggingClient.FindResourcesByTags(ctx, services.ResourceTypeTargetGroup, env.DefaultTags)
+		arns, err := env.TaggingClient.FindResourcesByTags(ctx, services.ResourceTypeTargetGroup, tags)
 		env.Log.Infow("Expecting no target groups created by the controller", "found", arns)
 		g.Expect(err).To(BeNil())
 		g.Expect(arns).To(BeEmpty())


### PR DESCRIPTION
- e2e test framework minor change, in " BeforeSuite", don't check lattice tg and service in other k8s namespace.
- Add `--ginkgo.v` to make the test log show each test case name to make log more clear, we have it before, but removed it when adding the RAM share e2e test, not sure the reason
- Makefile minor change,  when helping  sesmaili@ to setup their local dev environment, we found, we need to do `make vet` first then `make manifest` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.