### PR TITLE
In service_manager, if tags of an association cannot be fetched, skip instead of error

### DIFF
--- a/pkg/deploy/lattice/service_manager.go
+++ b/pkg/deploy/lattice/service_manager.go
@@ -204,29 +204,28 @@ func (m *defaultServiceManager) getAllAssociations(ctx context.Context, svcSum *
 func (m *defaultServiceManager) updateAssociations(ctx context.Context, svc *Service, svcSum *SvcSummary) error {
 	assocs, err := m.getAllAssociations(ctx, svcSum)
 	if err != nil {
-		return err
+		return fmt.Errorf("in updateAssociations, getAllAssociations failed with %w", err)
 	}
 
 	toCreate, toDelete, err := associationsDiff(svc, assocs)
 	if err != nil {
-		return err
+		return fmt.Errorf("in updateAssociations, associationsDiff failed with %w", err)
 	}
 	for _, snName := range toCreate {
 		err := m.createAssociation(ctx, svcSum.Id, snName)
 		if err != nil {
-			return err
+			return fmt.Errorf("in updateAssociations, createAssociations failed with %w", err)
 		}
 	}
 
 	for _, assoc := range toDelete {
 		isManaged, err := m.cloud.IsArnManaged(ctx, *assoc.Arn)
 		if err != nil {
-			return err
-		}
-		if isManaged {
+			m.log.Errorf("in updateAssociations failed when attempting IsArnManaged check. Skipping delete association. service: %s, association: %s, %s", svc.LatticeServiceName(), assoc.Arn, err)
+		} else if isManaged {
 			err = m.deleteAssociation(ctx, assoc.Arn)
 			if err != nil {
-				return err
+				return fmt.Errorf("in updateAssociations, deleteAssociation failed with %w", err)
 			}
 		}
 	}

--- a/pkg/deploy/lattice/service_synthesizer.go
+++ b/pkg/deploy/lattice/service_synthesizer.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/utils"
+
 	"github.com/aws/aws-application-networking-k8s/pkg/deploy/externaldns"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
@@ -38,7 +40,7 @@ func (s *serviceSynthesizer) Synthesize(ctx context.Context) error {
 
 	var svcErr error
 	for _, resService := range resServices {
-		svcName := fmt.Sprintf("%s-%s", resService.Spec.RouteName, resService.Spec.RouteNamespace)
+		svcName := utils.LatticeServiceName(resService.Spec.RouteName, resService.Spec.RouteNamespace)
 		s.log.Debugf("Synthesizing service: %s", svcName)
 		if resService.IsDeleted {
 			err := s.serviceManager.Delete(ctx, resService)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug 

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
In the scenario where
- account A is managed by the lattice controller
- account A shares a service to account B
- account B associates this service to its own service network

Account A can be in a situation where does not have permissions to read the tags of that association

Therefore this results in an error during route reconciliation. 

```
error during service synthesis failed ServiceManager.Upsert xxx due to NotFoundException: Resource was not found
	status code: 404, request id: a400c824-64e3-4694-94ce-1b5698e1ee35
```


**What does this PR do / Why do we need it**:

if the get tags of a service network association request fails, instead of erroring, skip deleting the association and log.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

see above scenario

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

tested the fix in a staging environment (on top of most recent master) but open to suggestions on how test it via unit tests (looks like current tests don't touch on this scenario).

sample error message:
```
{"level":"warn","ts":"2024-02-26T01:47:25.568Z","logger":"controller.route","caller":"lattice/service_manager.go:232","msg":"skippin
g update associations  service: xxx, association:xxx, error: NotFoundException: Resource was not found\n\tstatus code: 404, request id: 086c
ba48-4421-4eda-bcae-c543acd81a85"}
```



**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no, yes

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
* fix reconciling lattice services that have service network associations created in a different account (via RAM)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.