### PR TITLE
Listen to endpointslice event

### DIFF
--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -48,6 +48,7 @@ import (
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -63,6 +64,7 @@ func init() {
 	utilruntime.Must(gwv1alpha2.AddToScheme(scheme))
 	utilruntime.Must(gwv1beta1.AddToScheme(scheme))
 	utilruntime.Must(anv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(discoveryv1.AddToScheme(scheme))
 	addOptionalCRDs(scheme)
 }
 

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -33,6 +33,26 @@ rules:
   - patch
   - update
 - apiGroups:
+    - "discovery.k8s.io"
+  resources:
+    - endpointslices
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - "discovery.k8s.io"
+  resources:
+    - endpointslices/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -48,6 +48,26 @@ rules:
   - patch
   - update
 - apiGroups:
+    - "discovery.k8s.io"
+  resources:
+    - endpointslices
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - "discovery.k8s.io"
+  resources:
+    - endpointslices/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/pkg/controllers/eventhandlers/mapper.go
+++ b/pkg/controllers/eventhandlers/mapper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s/policyhelper"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 type resourceMapper struct {
@@ -63,6 +64,21 @@ func (r *resourceMapper) EndpointsToService(ctx context.Context, ep *corev1.Endp
 		return nil
 	}
 	return svc
+}
+
+func (r *resourceMapper) EndpointSliceToService(ctx context.Context, epSlice *discoveryv1.EndpointSlice) *corev1.Service {
+	if epSlice == nil {
+		return nil
+	}
+	svcName, ok := epSlice.Labels[discoveryv1.LabelServiceName]
+	if ok {
+		svc := &corev1.Service{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: svcName, Namespace: epSlice.Namespace}, svc); err != nil {
+			return nil
+		}
+		return svc
+	}
+	return nil
 }
 
 func (r *resourceMapper) TargetGroupPolicyToService(ctx context.Context, tgp *anv1alpha1.TargetGroupPolicy) *corev1.Service {

--- a/pkg/controllers/eventhandlers/service.go
+++ b/pkg/controllers/eventhandlers/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -58,6 +59,8 @@ func (h *serviceEventHandler) mapToService(ctx context.Context, obj client.Objec
 		return h.mapper.TargetGroupPolicyToService(ctx, typed)
 	case *corev1.Endpoints:
 		return h.mapper.EndpointsToService(ctx, typed)
+	case *discoveryv1.EndpointSlice:
+		return h.mapper.EndpointSliceToService(ctx, typed)
 	}
 	return nil
 }

--- a/pkg/controllers/route_controller.go
+++ b/pkg/controllers/route_controller.go
@@ -51,6 +51,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	k8sutils "github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 var routeTypeToFinalizer = map[core.RouteType]string{
@@ -115,7 +116,7 @@ func RegisterAllRouteControllers(
 			Watches(&gwv1beta1.Gateway{}, gwEventHandler).
 			Watches(&corev1.Service{}, svcEventHandler.MapToRoute(routeInfo.routeType)).
 			Watches(&anv1alpha1.ServiceImport{}, svcImportEventHandler.MapToRoute(routeInfo.routeType)).
-			Watches(&corev1.Endpoints{}, svcEventHandler.MapToRoute(routeInfo.routeType))
+			Watches(&discoveryv1.EndpointSlice{}, svcEventHandler.MapToRoute(routeInfo.routeType))
 
 		if ok, err := k8s.IsGVKSupported(mgr, anv1alpha1.GroupVersion.String(), anv1alpha1.TargetGroupPolicyKind); ok {
 			builder.Watches(&anv1alpha1.TargetGroupPolicy{}, svcEventHandler.MapToRoute(routeInfo.routeType))

--- a/pkg/controllers/serviceexport_controller.go
+++ b/pkg/controllers/serviceexport_controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 type serviceExportReconciler struct {
@@ -82,7 +83,7 @@ func RegisterServiceExportController(
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&anv1alpha1.ServiceExport{}).
 		Watches(&corev1.Service{}, svcEventHandler.MapToServiceExport()).
-		Watches(&corev1.Endpoints{}, svcEventHandler.MapToServiceExport())
+		Watches(&discoveryv1.EndpointSlice{}, svcEventHandler.MapToServiceExport())
 
 	if ok, err := k8s.IsGVKSupported(mgr, anv1alpha1.GroupVersion.String(), anv1alpha1.TargetGroupPolicyKind); ok {
 		builder.Watches(&anv1alpha1.TargetGroupPolicy{}, svcEventHandler.MapToServiceExport())

--- a/pkg/deploy/lattice/targets_manager.go
+++ b/pkg/deploy/lattice/targets_manager.go
@@ -50,6 +50,12 @@ func (s *defaultTargetsManager) Update(ctx context.Context, modelTargets *model.
 			modelTg.ID(), modelTargets.Spec.StackTargetGroupId)
 	}
 
+	// Only take care of pods that are ready, for backwards compatibility.
+	// TODO: Pod readiness support.
+	modelTargets.Spec.TargetList = utils.SliceFilter(modelTargets.Spec.TargetList, func(t model.Target) bool {
+		return t.Ready
+	})
+
 	s.log.Debugf("Creating targets for target group %s", modelTg.Status.Id)
 
 	lattice := s.cloud.Lattice()

--- a/pkg/deploy/lattice/targets_manager_test.go
+++ b/pkg/deploy/lattice/targets_manager_test.go
@@ -23,6 +23,7 @@ func TestTargetsManager(t *testing.T) {
 	targets := model.Target{
 		TargetIP: "192.0.2.10",
 		Port:     int64(8080),
+		Ready:    true,
 	}
 	targetsSpec := model.TargetsSpec{
 		StackTargetGroupId: "tg-stack-id",
@@ -194,14 +195,17 @@ func TestTargetsManager(t *testing.T) {
 		mt1 := model.Target{
 			TargetIP: "192.0.2.10",
 			Port:     int64(8080),
+			Ready:    true,
 		}
 		mt2 := model.Target{
 			TargetIP: "192.0.2.20",
 			Port:     int64(8080),
+			Ready:    true,
 		}
 		mt3 := model.Target{
 			TargetIP: "192.0.2.30",
 			Port:     int64(8080),
+			Ready:    true,
 		}
 
 		existingTargets := []*vpclattice.TargetSummary{
@@ -294,6 +298,7 @@ func TestTargetsManager(t *testing.T) {
 			extraTargets = append(extraTargets, model.Target{
 				TargetIP: "192.0.3." + strconv.Itoa(i+1),
 				Port:     int64(8080),
+				Ready:    true,
 			})
 		}
 		modelTargets.Spec.TargetList = extraTargets

--- a/pkg/gateway/model_build_targets_test.go
+++ b/pkg/gateway/model_build_targets_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	"github.com/aws/aws-sdk-go/aws"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 func Test_Targets(t *testing.T) {
@@ -35,7 +37,7 @@ func Test_Targets(t *testing.T) {
 	tests := []struct {
 		name               string
 		port               int32
-		endPoints          []corev1.Endpoints
+		endpointSlice      []discoveryv1.EndpointSlice
 		svc                corev1.Service
 		serviceExport      anv1alpha1.ServiceExport
 		refByServiceExport bool
@@ -46,16 +48,22 @@ func Test_Targets(t *testing.T) {
 		{
 			name: "Add all endpoints to build spec",
 			port: 0,
-			endPoints: []corev1.Endpoints{
+			endpointSlice: []discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns1",
 						Name:      "export1",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "export1"},
 					},
-					Subsets: []corev1.EndpointSubset{
+					Ports: []discoveryv1.EndpointPort{
+						{Port: aws.Int32(8675)},
+					},
+					Endpoints: []discoveryv1.Endpoint{
 						{
-							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Port: 8675}},
+							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(true),
+							},
 						},
 					},
 				},
@@ -73,26 +81,41 @@ func Test_Targets(t *testing.T) {
 				{
 					TargetIP: "10.10.1.1",
 					Port:     8675,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.2.2",
 					Port:     8675,
+					Ready:    true,
 				},
 			},
 		},
 		{
 			name: "Add endpoints with matching service port to build spec",
 			port: 80,
-			endPoints: []corev1.Endpoints{
+			endpointSlice: []discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns1",
 						Name:      "export1",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "export1"},
 					},
-					Subsets: []corev1.EndpointSubset{
+					Ports: []discoveryv1.EndpointPort{
 						{
-							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+							Name: aws.String("a"),
+							Port: aws.Int32(8675),
+						},
+						{
+							Name: aws.String("b"),
+							Port: aws.Int32(309),
+						},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(true),
+							},
 						},
 					},
 				},
@@ -124,26 +147,41 @@ func Test_Targets(t *testing.T) {
 				{
 					TargetIP: "10.10.1.1",
 					Port:     8675,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.2.2",
 					Port:     8675,
+					Ready:    true,
 				},
 			},
 		},
 		{
 			name: "Add all endpoints to build spec with port annotation",
 			port: 3090,
-			endPoints: []corev1.Endpoints{
+			endpointSlice: []discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns1",
 						Name:      "export1",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "export1"},
 					},
-					Subsets: []corev1.EndpointSubset{
+					Ports: []discoveryv1.EndpointPort{
 						{
-							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 3090}},
+							Name: aws.String("a"),
+							Port: aws.Int32(8675),
+						},
+						{
+							Name: aws.String("b"),
+							Port: aws.Int32(3090),
+						},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(true),
+							},
 						},
 					},
 				},
@@ -183,10 +221,12 @@ func Test_Targets(t *testing.T) {
 				{
 					TargetIP: "10.10.1.1",
 					Port:     3090,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.2.2",
 					Port:     3090,
+					Ready:    true,
 				},
 			},
 		},
@@ -206,16 +246,29 @@ func Test_Targets(t *testing.T) {
 		{
 			name: "Add all endpoints to build spec",
 			port: 0,
-			endPoints: []corev1.Endpoints{
+			endpointSlice: []discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns1",
 						Name:      "export5",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "export5"},
 					},
-					Subsets: []corev1.EndpointSubset{
+					Ports: []discoveryv1.EndpointPort{
 						{
-							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+							Name: aws.String("a"),
+							Port: aws.Int32(8675),
+						},
+						{
+							Name: aws.String("b"),
+							Port: aws.Int32(309),
+						},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(true),
+							},
 						},
 					},
 				},
@@ -233,34 +286,47 @@ func Test_Targets(t *testing.T) {
 				{
 					TargetIP: "10.10.1.1",
 					Port:     8675,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.1.1",
 					Port:     309,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.2.2",
 					Port:     8675,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.2.2",
 					Port:     309,
+					Ready:    true,
 				},
 			},
 		},
 		{
 			name: "Only add endpoints for port 8675 to build spec",
 			port: 8675,
-			endPoints: []corev1.Endpoints{
+			endpointSlice: []discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns1",
 						Name:      "export6",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "export6"},
 					},
-					Subsets: []corev1.EndpointSubset{
+					Ports: []discoveryv1.EndpointPort{
 						{
-							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}},
+							Name: aws.String("a"),
+							Port: aws.Int32(8675),
+						},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(true),
+							},
 						},
 					},
 				},
@@ -278,10 +344,12 @@ func Test_Targets(t *testing.T) {
 				{
 					TargetIP: "10.10.1.1",
 					Port:     8675,
+					Ready:    true,
 				},
 				{
 					TargetIP: "10.10.2.2",
 					Port:     8675,
+					Ready:    true,
 				},
 			},
 			serviceExport: anv1alpha1.ServiceExport{
@@ -295,16 +363,29 @@ func Test_Targets(t *testing.T) {
 		{
 			name: "BackendRef port does not match service port",
 			port: 8750,
-			endPoints: []corev1.Endpoints{
+			endpointSlice: []discoveryv1.EndpointSlice{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns1",
 						Name:      "export7",
+						Labels:    map[string]string{discoveryv1.LabelServiceName: "export7"},
 					},
-					Subsets: []corev1.EndpointSubset{
+					Ports: []discoveryv1.EndpointPort{
 						{
-							Addresses: []corev1.EndpointAddress{{IP: "10.10.1.1"}, {IP: "10.10.2.2"}},
-							Ports:     []corev1.EndpointPort{{Name: "a", Port: 8675}, {Name: "b", Port: 309}},
+							Name: aws.String("a"),
+							Port: aws.Int32(8675),
+						},
+						{
+							Name: aws.String("b"),
+							Port: aws.Int32(309),
+						},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(true),
+							},
 						},
 					},
 				},
@@ -331,14 +412,15 @@ func Test_Targets(t *testing.T) {
 			k8sSchema := runtime.NewScheme()
 			k8sSchema.AddKnownTypes(anv1alpha1.SchemeGroupVersion, &anv1alpha1.ServiceExport{})
 			clientgoscheme.AddToScheme(k8sSchema)
+			discoveryv1.AddToScheme(k8sSchema)
 			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
 
 			if !reflect.DeepEqual(tt.serviceExport, anv1alpha1.ServiceExport{}) {
 				assert.NoError(t, k8sClient.Create(ctx, tt.serviceExport.DeepCopy()))
 			}
 
-			if len(tt.endPoints) > 0 {
-				assert.NoError(t, k8sClient.Create(ctx, tt.endPoints[0].DeepCopy()))
+			if len(tt.endpointSlice) > 0 {
+				assert.NoError(t, k8sClient.Create(ctx, tt.endpointSlice[0].DeepCopy()))
 			}
 
 			assert.NoError(t, k8sClient.Create(ctx, tt.svc.DeepCopy()))
@@ -376,7 +458,7 @@ func Test_Targets(t *testing.T) {
 			st := stackTargets[0]
 
 			assert.Equal(t, "tg-id", st.Spec.StackTargetGroupId)
-			assert.Equal(t, tt.expectedTargetList, st.Spec.TargetList)
+			assert.ElementsMatch(t, tt.expectedTargetList, st.Spec.TargetList)
 		})
 	}
 }

--- a/pkg/gateway/model_build_targets_test.go
+++ b/pkg/gateway/model_build_targets_test.go
@@ -46,7 +46,7 @@ func Test_Targets(t *testing.T) {
 		expectedTargetList []model.Target
 	}{
 		{
-			name: "Add all endpoints to build spec",
+			name: "Add all endpoints with readiness to build spec",
 			port: 0,
 			endpointSlice: []discoveryv1.EndpointSlice{
 				{
@@ -60,9 +60,15 @@ func Test_Targets(t *testing.T) {
 					},
 					Endpoints: []discoveryv1.Endpoint{
 						{
-							Addresses: []string{"10.10.1.1", "10.10.2.2"},
+							Addresses: []string{"10.10.1.1"},
 							Conditions: discoveryv1.EndpointConditions{
 								Ready: aws.Bool(true),
+							},
+						},
+						{
+							Addresses: []string{"10.10.2.2"},
+							Conditions: discoveryv1.EndpointConditions{
+								Ready: aws.Bool(false),
 							},
 						},
 					},
@@ -86,7 +92,7 @@ func Test_Targets(t *testing.T) {
 				{
 					TargetIP: "10.10.2.2",
 					Port:     8675,
-					Ready:    true,
+					Ready:    false,
 				},
 			},
 		},

--- a/pkg/model/lattice/targets.go
+++ b/pkg/model/lattice/targets.go
@@ -20,6 +20,7 @@ type TargetsSpec struct {
 type Target struct {
 	TargetIP string `json:"targetip"`
 	Port     int64  `json:"port"`
+	Ready    bool   `json:"ready"`
 }
 
 func NewTargets(stack core.Stack, spec TargetsSpec) (*Targets, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

feature

**Which issue does this PR fix**:

Not yet - this is an initiation for pod readiness support project.

**What does this PR do / Why do we need it**:

* Record pod readiness on targets model builder
* Listen to endpointslice event, has multiple benefits:
  * has advanced read of status
  * can scale to 1000+ pods, old endpoint objects have limits on 1000 addresses
* Keep the old behavior yet - non-ready targets are filtered at targets manager. this will be changed on the next PR.

Splitting PR to keep reviewability.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.