### PR TITLE
Update Helm chart to include pod mutating webhook for readiness gates

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Run test
         run: |
           make e2e-test
+          make webhook-e2e-test
       - name: Cleanup
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -101,16 +101,8 @@ docker-push: ## Push docker image with the manager.
 # also generates a placeholder cert for the webhook - this cert is not intended to be valid
 .PHONY: build-deploy
 build-deploy: ## Create a deployment file that can be applied with `kubectl apply -f deploy.yaml`
-	$(eval TEMP_KEY := $(shell mktemp))
-	$(eval TEMP_CERT := $(shell mktemp))
 	cd config/manager && kustomize edit set image controller=${ECRIMAGES}
 	kustomize build config/default > deploy.yaml
-	openssl req -x509 -nodes -days 1 -newkey rsa:2048 -keyout $(TEMP_KEY) -out $(TEMP_CERT) -subj "/CN=not-a-real-cn/O=not-a-real-o" > /dev/null 2>&1
-	export KEY_B64=`cat $(TEMP_KEY) | base64` && \
-	export CERT_B64=`cat $(TEMP_CERT) | base64` && \
-	yq -i e '(.[] as $$item | select(.metadata.name == "webhook-cert" and .kind == "Secret") | .data."tls.crt") = env(CERT_B64)' deploy.yaml && \
-	yq -i e '(.[] as $$item | select(.metadata.name == "webhook-cert" and .kind == "Secret") | .data."tls.key") = env(KEY_B64)' deploy.yaml 2>&1
-	rm $(TEMP_KEY) $(TEMP_CERT)
 
 .PHONY: manifest
 manifest: ## Generate CRD manifest
@@ -155,11 +147,8 @@ docs:
 	mkdocs build
 
 # NB webhook tests can only run if the controller is deployed to the cluster
-webhook-e2e-test-namespace := "webhook-e2e-test"
-
 .PHONY: webhook-e2e-test
 webhook-e2e-test:
-	@kubectl create namespace $(webhook-e2e-test-namespace) > /dev/null 2>&1 || true # ignore already exists error
 	LOG_LEVEL=debug
 	cd test && go test \
 		-p 1 \

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,6 +51,9 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        env:
+          - name: WEBHOOK_ENABLED
+            value: ""
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:

--- a/docs/guides/environment.md
+++ b/docs/guides/environment.md
@@ -75,3 +75,17 @@ Default: ""
 When set as "true", the controller will run in "single service network" mode that will override all gateways
 to point to default service network, instead of searching for service network with the same name.
 Can be used for small setups and conformance tests.
+
+---
+
+#### `WEBHOOK_ENABLED`
+
+Type: string
+
+Default: ""
+
+When set as "true", the controller will start the webhook listener responsible for pod readiness gate injection 
+(see ```pod-readiness-gates.md```). This is disabled by default for ```deploy.yaml``` because the controller will not start 
+successfully without the TLS certificate for the webhook in place. While this can be fixed by running 
+```scripts/gen-webhook-cert.sh```, it requires manual action. The webhook is enabled by default for the Helm install
+as the Helm install will also generate the necessary certificate.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -38,11 +38,12 @@ caCert: {{ .Values.webhookTLS.caCert }}
 cert: {{ .Values.webhookTLS.cert }}
 key: {{ .Values.webhookTLS.key }}
 {{- else -}}
+{{- $ca := genCA "aws-gateway-controller-ca" 36500 -}}
 {{- $serviceDefaultName:= printf "webhook-service.%s.svc" .Release.Namespace -}}
 {{- $secretName := "webhook-cert" -}}
 {{- $altNames := list ($serviceDefaultName) (printf "%s.cluster.local" $serviceDefaultName) -}}
-{{- $cert := genSelfSignedCert $serviceDefaultName nil $altNames 365000 -}}
-caCert: {{ $cert.Cert | b64enc }}
+{{- $cert := genSignedCert $serviceDefaultName nil $altNames 36500 $ca -}}
+caCert: {{ $ca.Cert | b64enc }}
 cert: {{ $cert.Cert | b64enc }}
 key: {{ $cert.Key | b64enc }}
 {{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{ $tls := fromYaml ( include "aws-gateway-controller.webhookTLS" . ) }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,6 +74,10 @@ spec:
             drop:
               - ALL
           readOnlyRootFilesystem: true
+        volumeMounts:
+          - mountPath: /etc/webhook-cert
+            name: webhook-cert
+            readOnly: true
         env:
           - name: REGION
             value: {{ .Values.awsRegion | quote }}
@@ -88,6 +94,11 @@ spec:
           - name: LOG_LEVEL
             value: {{ .Values.log.level | quote }}
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: webhook-cert
+          secret:
+            defaultMode: 420
+            secretName: webhook-cert
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if .Values.deployment.tolerations -}}
       tolerations: {{ toYaml .Values.deployment.tolerations | nindent 8 }}
@@ -98,3 +109,13 @@ spec:
       {{ if .Values.deployment.priorityClassName -}}
       priorityClassName: {{ .Values.deployment.priorityClassName }}
       {{ end -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-cert
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $tls.cert }}
+  tls.key: {{ $tls.key }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,5 +1,3 @@
-{{ $tls := fromYaml ( include "aws-gateway-controller.webhookTLS" . ) }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -109,13 +107,3 @@ spec:
       {{ if .Values.deployment.priorityClassName -}}
       priorityClassName: {{ .Values.deployment.priorityClassName }}
       {{ end -}}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: webhook-cert
-  namespace: {{ .Release.Namespace }}
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ $tls.cert }}
-  tls.key: {{ $tls.key }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
         ports:
           - name: http
             containerPort: {{ .Values.deployment.containerPort }}
+          - name: webhook-server
+            containerPort: 9443
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         livenessProbe:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -93,6 +93,8 @@ spec:
             value: {{ .Values.defaultServiceNetwork | quote }}
           - name: LOG_LEVEL
             value: {{ .Values.log.level | quote }}
+          - name: WEBHOOK_ENABLED
+            value: {{ .Values.webhookEnabled | quote }}
       terminationGracePeriodSeconds: 10
       volumes:
         - name: webhook-cert

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -1,3 +1,4 @@
+{{ $tls := fromYaml ( include "aws-gateway-controller.webhookTLS" . ) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -7,9 +8,10 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
+      caBundle: {{ $tls.caCert }}
       service:
         name: webhook-service
-        namespace: aws-application-networking-system
+        namespace: {{ .Release.Namespace }}
         path: /mutate-pod
     failurePolicy: Fail
     name: mpod.gwc.k8s.aws
@@ -40,7 +42,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: webhook-service
-  namespace: aws-application-networking-system
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - port: 443

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 9443
+      targetPort: webhook-server
   selector:
     control-plane: gateway-api-controller
 ---

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -49,3 +49,14 @@ spec:
       targetPort: 9443
   selector:
     control-plane: gateway-api-controller
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-cert
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $tls.caCert }}
+  tls.crt: {{ $tls.cert }}
+  tls.key: {{ $tls.key }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,3 +77,9 @@ clusterVpcId:
 clusterName:
 defaultServiceNetwork:
 latticeEndpoint:
+
+# TLS cert/key for the webhook. If specified, values must be base64 encoded
+webhookTLS:
+  caCert:
+  cert:
+  key:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,6 +77,7 @@ clusterVpcId:
 clusterName:
 defaultServiceNetwork:
 latticeEndpoint:
+webhookEnabled: true
 
 # TLS cert/key for the webhook. If specified, values must be base64 encoded
 webhookTLS:

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -26,6 +26,7 @@ const (
 	ENABLE_SERVICE_NETWORK_OVERRIDE = "ENABLE_SERVICE_NETWORK_OVERRIDE"
 	AWS_ACCOUNT_ID                  = "AWS_ACCOUNT_ID"
 	DEV_MODE                        = "DEV_MODE"
+	WEBHOOK_ENABLED                 = "WEBHOOK_ENABLED"
 )
 
 var VpcID = ""
@@ -34,6 +35,7 @@ var Region = ""
 var DefaultServiceNetwork = ""
 var ClusterName = ""
 var DevMode = ""
+var WebhookEnabled = ""
 
 var ServiceNetworkOverrideMode = false
 
@@ -47,6 +49,7 @@ func configInit(sess *session.Session, metadata EC2Metadata) error {
 	var err error
 
 	DevMode = os.Getenv(DEV_MODE)
+	WebhookEnabled = os.Getenv(WEBHOOK_ENABLED)
 
 	VpcID = os.Getenv(CLUSTER_VPC_ID)
 	if VpcID == "" {

--- a/scripts/gen-webhook-secret.sh
+++ b/scripts/gen-webhook-secret.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Use this script to update the webhook secret post-deployment. Alternatively,
+# you can use patch-deploy-yaml.sh prior to deployment.
+#
+# Generates a certificate for use by the controller webhook
+# You can also manually re-create the webhook secret using your own PKI
+
+TEMP_KEY=`mktemp`
+TEMP_CERT=`mktemp`
+
+WEBHOOK_SVC_NAME=webhook-service
+WEBHOOK_NAME=aws-appnet-gwc-mutating-webhook
+WEBHOOK_NAMESPACE=aws-application-networking-system
+WEBHOOK_SECRET_NAME=webhook-cert
+
+echo "Generating certificate for webhook"
+HOST=${WEBHOOK_SVC_NAME}.${WEBHOOK_NAMESPACE}.svc
+openssl req -x509 -nodes -days 36500 -newkey rsa:2048 -keyout ${TEMP_KEY} -out ${TEMP_CERT} -subj "/CN=${HOST}/O=${HOST}" \
+   -addext "subjectAltName = DNS:${HOST}, DNS:${HOST}.cluster.local"
+
+export KEY_B64=`cat $TEMP_KEY | base64`
+export CERT_B64=`cat $TEMP_CERT | base64`
+
+echo "Recreating webhook secret"
+kubectl delete secret $WEBHOOK_SECRET_NAME --namespace $WEBHOOK_NAMESPACE
+kubectl create secret tls $WEBHOOK_SECRET_NAME --namespace $WEBHOOK_NAMESPACE --cert=${TEMP_CERT} --key=${TEMP_KEY}
+
+echo "Patching webhook with new cert"
+kubectl patch mutatingwebhookconfigurations.admissionregistration.k8s.io $WEBHOOK_NAME \
+    --namespace $WEBHOOK_NAMESPACE --type='json' \
+    -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value': '${CERT_B64}'}]"
+
+rm $TEMP_KEY $TEMP_CERT
+echo "Done"

--- a/scripts/gen-webhook-secret.sh
+++ b/scripts/gen-webhook-secret.sh
@@ -19,8 +19,7 @@ HOST=${WEBHOOK_SVC_NAME}.${WEBHOOK_NAMESPACE}.svc
 openssl req -x509 -nodes -days 36500 -newkey rsa:2048 -keyout ${TEMP_KEY} -out ${TEMP_CERT} -subj "/CN=${HOST}/O=${HOST}" \
    -addext "subjectAltName = DNS:${HOST}, DNS:${HOST}.cluster.local"
 
-export KEY_B64=`cat $TEMP_KEY | base64`
-export CERT_B64=`cat $TEMP_CERT | base64`
+CERT_B64=`cat $TEMP_CERT | base64`
 
 echo "Recreating webhook secret"
 kubectl delete secret $WEBHOOK_SECRET_NAME --namespace $WEBHOOK_NAMESPACE

--- a/scripts/patch-deploy-yaml.sh
+++ b/scripts/patch-deploy-yaml.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Updates deploy.yaml with a certificate for use by the controller webhook
+# AND enables the webhook via environment variable.
+# You can also provide a certificate with using own PKI, or use the
+# gen-webhook-secret.sh script after deploying.
+#
+# Usage:
+#  ./patch-deploy-yaml.sh [-k KEY_FILE -c CERT_FILE -a CA_FILE] <path/to/deploy.yaml>
+
+KEY=""
+CERT=""
+CA=""
+TEMP_KEY=`mktemp`
+TEMP_CERT=`mktemp`
+
+while getopts "k:c:a:" opt; do
+  case $opt in
+    k)
+      KEY=${OPTARG}
+      ;;
+    c)
+      CERT=${OPTARG}
+      ;;
+    a)
+      CA=${OPTARG}
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+DEPLOY_YAML=$1
+
+if [ -z "${DEPLOY_YAML}" ]; then
+  echo "Target deploy.yaml file not specified" >&2
+  exit 1
+fi
+
+generate_cert() {
+  KEY=$TEMP_KEY
+  CERT=$TEMP_CERT
+  # point the CA to the cert itself, this will ensure it is trusted by API server
+  CA=$CERT
+
+  WEBHOOK_SVC_NAME=webhook-service
+  WEBHOOK_NAME=aws-appnet-gwc-mutating-webhook
+  WEBHOOK_NAMESPACE=aws-application-networking-system
+  WEBHOOK_SECRET_NAME=webhook-cert
+
+  echo "Generating certificate for webhook"
+  HOST=${WEBHOOK_SVC_NAME}.${WEBHOOK_NAMESPACE}.svc
+  openssl req -x509 -nodes -days 36500 -newkey rsa:2048 -keyout ${KEY} -out ${CERT} -subj "/CN=${HOST}/O=${HOST}" \
+     -addext "subjectAltName = DNS:${HOST}, DNS:${HOST}.cluster.local"
+}
+
+if [ -z "${KEY}" ]; then
+  echo "Key not specified. Will generate..."
+  REMOVE_KEY_FILES="1"
+  generate_cert
+fi
+
+export KEY_B64=`cat $KEY | base64`
+export CERT_B64=`cat $CERT | base64`
+export CA_B64=`cat $CA | base64`
+
+echo "Patching webhook secret"
+yq -i e '(.[] as $item | select(.metadata.name == "webhook-cert" and .kind == "Secret") | .data."tls.crt") = env(CERT_B64)' $DEPLOY_YAML 2>&1
+yq -i e '(.[] as $item | select(.metadata.name == "webhook-cert" and .kind == "Secret") | .data."tls.key") = env(KEY_B64)' $DEPLOY_YAML 2>&1
+yq -i e '(.[] as $item | select(.metadata.name == "webhook-cert" and .kind == "Secret") | .data."ca.crt") = env(CA_B64)' $DEPLOY_YAML 2>&1
+
+echo "Patching webhook"
+yq -i e '(.[] as $item | select(.metadata.name == "aws-appnet-gwc-mutating-webhook" and .kind == "MutatingWebhookConfiguration") | .webhooks[0].clientConfig.caBundle) = env(CA_B64)' $DEPLOY_YAML 2>&1
+
+echo "Enabling webhook"
+yq -i -e '(.[] as $item | select(.metadata.name == "gateway-api-controller" and .kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "manager") | .env[] | select(.name == "WEBHOOK_ENABLED") | .value) = "true"' $DEPLOY_YAML 2>&1
+
+rm $TEMP_KEY $TEMP_CERT
+echo "Done"


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/aws/aws-application-networking-k8s/issues/596

**What does this PR do / Why do we need it**:
1. Updates Helm install to include pod readiness gate webhook.
2. For manual installs, defers cert generation to install time and does NOT enable webhook by default
3. New scripts in ```scripts/``` to provision webhook TLS certificate and enable the webhook 
4. Include ```webhook-e2e-test``` in github workflow
5. Doc updates

Since the controller cannot start without a valid TLS secret in place AND we cannot provision a cert at build time without confusing github with "secret" material, we now disable the webhook by default for manual installs using ```deploy.yaml```. Instead, I have created new scripts (```gen-webhook-secret.sh``` and ```patch-deploy-yaml.sh```) to help provision the certificate and configure the webhook. The webhook is still enabled by default in the Helm chart.

Otherwise, the github workflow looks like it's currently broken, so there is a small risk I may be breaking it more.

**Testing done on this change**:
Installed locally built Helm chart. Tested with and without setting new environment variable setting.
```
helm package helm
tar xvf aws-gateway-controller-chart-v1.0.3.tgz

helm install test-release ./aws-gateway-controller-chart --set=serviceAccount.create=true --namespace aws-application-networking-system --set=log.level=debug --set=awsRegion=$AWS_REGION --set=clusterVpcId=$CLUSTER_VPC_ID --set=awsAccountId=$AWS_ACCOUNT_ID --set clusterName=$CLUSTER_NAME --set=defaultServiceNetwork=test-gateway
NAME: test-release
LAST DEPLOYED: Mon Mar 11 19:30:22 2024
NAMESPACE: aws-application-networking-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
aws-gateway-controller-chart has been installed.
This chart deploys "<redacted>.dkr.ecr.us-west-2.amazonaws.com/controller:".

Check its status by running:
  kubectl --namespace aws-application-networking-system get pods -l "app.kubernetes.io/instance=test-release"

The controller is running in "cluster" mode.
```

Ran webhook e2e-tests
```
make webhook-e2e-test                                                                       
=== RUN   TestIntegration
Running Suite: WebhookIntegration - /.../aws-application-networking-k8s/test/suites/webhook
===============================================================================================================
Random Seed: 1710185534

Will run 2 of 2 specs
------------------------------
[SynchronizedBeforeSuite] 
/.../aws-application-networking-k8s/test/suites/webhook/suite_test.go:23
[SynchronizedBeforeSuite] PASSED [0.000 seconds]
------------------------------
Readiness Gate Inject create deployment in untagged namespace, no readiness gate
/.../aws-application-networking-k8s/test/suites/webhook/readiness_gate_inject_test.go:42
{"level":"info","ts":"2024-03-11T12:32:15.506-0700","caller":"test/framework.go:282","msg":"Waiting for NotFound, objects: *v1.Namespace/webhook-e2e-test-no-tag, *v1.Namespace/webhook-e2e-test-tagged"}
{"level":"info","ts":"2024-03-11T12:32:15.526-0700","caller":"test/framework.go:186","msg":"Creating objects: *v1.Namespace/webhook-e2e-test-no-tag, *v1.Namespace/webhook-e2e-test-tagged"}
{"level":"info","ts":"2024-03-11T12:32:15.621-0700","caller":"test/pod_manager.go:68","msg":"deployment.Spec.Selector.MatchLabels: map[app:untagged-test-pod]"}
{"level":"info","ts":"2024-03-11T12:32:25.694-0700","caller":"test/pod_manager.go:68","msg":"deployment.Spec.Selector.MatchLabels: map[app:untagged-test-pod]"}
• [11.019 seconds]
------------------------------
Readiness Gate Inject create deployment in tagged namespace, has readiness gate
/.../aws-application-networking-k8s/test/suites/webhook/readiness_gate_inject_test.go:62
{"level":"info","ts":"2024-03-11T12:32:25.772-0700","caller":"test/pod_manager.go:68","msg":"deployment.Spec.Selector.MatchLabels: map[app:tagged-test-pod]"}
{"level":"info","ts":"2024-03-11T12:32:25.798-0700","caller":"test/framework.go:264","msg":"Deleting objects: *v1.Namespace/webhook-e2e-test-no-tag, *v1.Namespace/webhook-e2e-test-tagged"}
{"level":"info","ts":"2024-03-11T12:32:25.825-0700","caller":"test/framework.go:282","msg":"Waiting for NotFound, objects: *v1.Namespace/webhook-e2e-test-no-tag, *v1.Namespace/webhook-e2e-test-tagged"}
• [11.325 seconds]
------------------------------
[SynchronizedAfterSuite] 
/.../aws-application-networking-k8s/test/suites/webhook/suite_test.go:39
[SynchronizedAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 2 of 2 Specs in 22.345 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (22.35s)
PASS
ok  	github.com/aws/aws-application-networking-k8s/test/suites/webhook	23.032s

```

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
By design, the webhook does not install to the controller namespace
```
kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io aws-appnet-gwc-mutating-webhook         
NAME                              WEBHOOKS   AGE
aws-appnet-gwc-mutating-webhook   1          8m18s
```
If a namespace is tagged with ```application-networking.k8s.aws/pod-readiness-gate-inject=enabled``` and the webhook exists BUT the controller has been downgraded to a pre-webhook version, you will not be able to successfully create new pods. To work around this issue, you would need to remove the namespace tag or delete the webhook, then also re-launch any pods or manually set the readiness gate value.

**Does this PR introduce any user-facing change?**:
Yes, but it is covered in the main PR https://github.com/aws/aws-application-networking-k8s/pull/606

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.