### PR TITLE
Allow targetgroup policy attached to serviceExport

### DIFF
--- a/pkg/k8s/policyhelper/kind.go
+++ b/pkg/k8s/policyhelper/kind.go
@@ -5,6 +5,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 )
 
 type GroupKind struct {
@@ -20,6 +22,8 @@ func ObjToGroupKind(obj client.Object) GroupKind {
 		return GroupKind{gwv1beta1.GroupName, "HTTPRoute"}
 	case *gwv1alpha2.GRPCRoute:
 		return GroupKind{gwv1alpha2.GroupName, "GRPCRoute"}
+	case *anv1alpha1.ServiceExport:
+		return GroupKind{anv1alpha1.GroupName, "ServiceExport"}
 	case *corev1.Service:
 		return GroupKind{corev1.GroupName, "Service"}
 	default:
@@ -44,6 +48,8 @@ func GroupKindToObj(gk GroupKind) (client.Object, bool) {
 		return &gwv1alpha2.GRPCRoute{}, true
 	case GroupKind{corev1.GroupName, "Service"}:
 		return &corev1.Service{}, true
+	case GroupKind{anv1alpha1.GroupName, "ServiceExport"}:
+		return &anv1alpha1.ServiceExport{}, true
 	default:
 		return nil, false
 	}

--- a/pkg/k8s/policyhelper/policy.go
+++ b/pkg/k8s/policyhelper/policy.go
@@ -73,7 +73,7 @@ func NewTargetGroupPolicyHandler(log gwlog.Logger, c k8sclient.Client) *PolicyHa
 	phcfg := PolicyHandlerConfig{
 		Log:            log,
 		Client:         c,
-		TargetRefKinds: NewGroupKindSet(&corev1.Service{}),
+		TargetRefKinds: NewGroupKindSet(&corev1.Service{}, &anv1alpha1.ServiceExport{}),
 	}
 	return NewPolicyHandler[TGP, TGPL](phcfg)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->
feature

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Allow targetgroup policy being attached to a serviceExport object.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
Today, there is no way to configure target group policy for target group reconciled from serviceExport CRD.


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
make presubmit pass

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.