### PR TITLE
Control public doc versioning by "mike"

### DIFF
--- a/.github/workflows/publish-doc.yaml
+++ b/.github/workflows/publish-doc.yaml
@@ -1,0 +1,33 @@
+name: publish-doc
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Configure git
+        run: |
+          git config --global user.email "ci-bot@amazon.com"
+          git config --global user.name "ci-bot"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material mike
+      - name: Build
+        run: |
+          mike deploy 1.0.5 latest --update-aliases --push
+          mike set-default latest --allow-empty --push
+          
+          
+

--- a/docs/contributing/developer.md
+++ b/docs/contributing/developer.md
@@ -155,7 +155,7 @@ To build and verify your changes locally:
 pip install -r requirements.txt
 make docs
 ```
-The website will be located in `site/` directory. You can also run a local dev-server by running `mike serve`.
+The website will be located in `site/` directory. You can also run a local dev-server by running `mike serve` or `mkdocs serve`.
 
 ## Contributing
 

--- a/docs/contributing/developer.md
+++ b/docs/contributing/developer.md
@@ -149,13 +149,13 @@ After all test cases running finished, in the `AfterSuite()` function, it will c
 
 ## Documentations
 
-The controller documentation is managed in `docs/` directory, and built with [mkdocs](https://www.mkdocs.org/).
+The controller documentation is managed in `docs/` directory, and built with [mkdocs](https://www.mkdocs.org/). It uses [mike](https://github.com/jimporter/mike) to manage versioning.
 To build and verify your changes locally:
 ```sh
 pip install -r requirements.txt
 make docs
 ```
-The website will be located in `site/` directory. You can also run a local dev-server by running `mkdocs serve`.
+The website will be located in `site/` directory. You can also run a local dev-server by running `mike serve`.
 
 ## Contributing
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -228,7 +228,7 @@
     <div class="md-grid md-typeset">
       <div class="tx-hero">
         <div class="tx-hero__image">
-          <img src="../images/controller.png" draggable="false">
+          <img src="./images/controller.png" draggable="false">
         </div>
         <div class="tx-hero__content">
           <h1> AWS Gateway API Controller Documentation </h1>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ repo_name: aws/aws-application-networking-k8s
 repo_url: https://github.com/aws/aws-application-networking-k8s
 edit_uri: edit/main/docs/
 strict: true
+site_url: https://www.gateway-api-controller.eks.aws.dev/
+
 
 nav:
   - Home: index.md
@@ -17,6 +19,7 @@ nav:
     - TLS: guides/https.md
     - Custom Domain Name: guides/custom-domain-name.md
     - GRPC: guides/grpc.md
+    - Pod Readiness Gates: guides/pod-readiness-gates.md
     - Configuration: guides/environment.md
   - API Specification: api-reference.md
   - API Reference:
@@ -111,6 +114,5 @@ extra_javascript:
 
 extra:
   generator: false
-#   version:
-#     provider: mike #mike deploy --push --update-aliases 0.1 latest
-#     site_url: 'https://docs.example.com/'
+  version:
+    provider: mike

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ mergedeep==1.3.4
 mkdocs==1.5.3
 mkdocs-material==9.4.12
 mkdocs-material-extensions==1.3.1
+mike==2.1.1
 packaging==23.2
 paginate==0.5.6
 pathspec==0.11.2

--- a/scripts/github-release.sh
+++ b/scripts/github-release.sh
@@ -62,6 +62,8 @@ sed_inplace "tag: $OLD_VERSION" "tag: $RELEASE_VERSION" "$WORKSPACE_DIR"/helm/va
 sed_inplace "deploy-$OLD_VERSION.yaml" "deploy-$RELEASE_VERSION.yaml" "$WORKSPACE_DIR"/docs/guides/deploy.md
 sed_inplace "--version=$OLD_VERSION" "--version=$RELEASE_VERSION" "$WORKSPACE_DIR"/docs/guides/deploy.md
 sed_inplace "--version=$OLD_VERSION" "--version=$RELEASE_VERSION" "$WORKSPACE_DIR"/docs/guides/getstarted.md
+sed_inplace "mike deploy $OLD_VERSION" "mike deploy $RELEASE_VERSION" "$WORKSPACE_DIR"/.github/workflows/publish-doc.yml
+
 
 # Build the deploy.yaml
 make build-deploy


### PR DESCRIPTION
### Changes
- Use  "mike" to managed mkdoc generated public doc versioning. https://github.com/jimporter/mike
- Enable versioning in the "Material for MkDocs" https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/
- Need to deprecate the aws amplify CI pipeline to build doc website in the 094684711435 account, use "github Action" `publish-doc.yaml`, to build and deploy public doc instead. Referenced other open source project on how they generate doc: e.g. https://github.com/tvdboom/ATOM/tree/master, https://github.com/pydantic/pydantic

### Background

Old and new ways of mkdoc build and deploy flow:

#### mkdoc build and deploy OLD way: 

every time when we push code with doc update, the one aws amplify CI pipeline in the 094684711435 will ingest that change and build the main branch code then pack the artifact, amplify.yml for that CI pipeline

```
version: 1
frontend:
  phases:
    preBuild:
      commands: []
    # IMPORTANT - Please verify your build commands
    build:
      commands: []
  artifacts:
    # IMPORTANT - Please verify your build output directory
    baseDirectory: /
    files:
      - '**/*'
  cache:
    paths: []
```


The built main branch artifact will deploy to the static server with domain name: https://www.gateway-api-controller.eks.aws.dev/

**However, since the 'mike' use `gh-pages` branch to manage the doc historical versioning. We cannot pack the `gh-pages` branch content in the aws amplify packed artifact zip (I actually tried many many ways to achieve that, but all don't work)** 


#### mkdoc build and deploy NEW way:

The "main" branch (for my own testing, I used a feature branch "doc-versioning") update will trigger the github action "publish-doc.yaml" for example:
https://github.com/zijun726911/aws-application-networking-k8s/actions/runs/9176696636/job/25232578464

One step of the publish-doc.yaml github action  will do `mike deploy 1.0.5 latest --update-aliases --push` which will push a new git commit in the `gh-pages` branch (if doc version update updated, check the "mike" doc for more detail: https://github.com/jimporter/mike), which will trigger another github action: 
https://github.com/zijun726911/aws-application-networking-k8s/actions/runs/9176751993

That second github action will pack the `gh-pages` branch content and deploy it to https://<user_name>.github.io/<repo_name>  as a static website if we set the github pages for that repo 


https://zijun726911.github.io/aws-application-networking-k8s/latest/

 https://docs.github.com/en/pages


### Testing
Use my own repo to test the "mike" versioning and "publish-doc.yaml"  github action, deployed to my own github page success:

https://github.com/zijun726911/aws-application-networking-k8s/actions/runs/9176696636/job/25232578464
https://github.com/zijun726911/aws-application-networking-k8s/actions/runs/9176751993
https://zijun726911.github.io/aws-application-networking-k8s/latest/


### Next steps after merging that this PR:

- In the repo   "aws/ aws-application-networking-k8s", go to the github Settings > Pages > Build and deploy to enable github page, for example:
<img width="1674" alt="image" src="https://github.com/aws/aws-application-networking-k8s/assets/32318664/c3490483-3e7f-4693-80f7-4292a472bc30">


https://zijun726911.github.io/aws-application-networking-k8s/latest/

- Following this instruction to enable github doc custom domain name (i.e., make the https://www.gateway-api-controller.eks.aws.dev/ point to the github generated doc): https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site  

- Need to deprecate the old aws amplify CI pipeline in the 094684711435 account 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.