### PR TITLE
Corrected the verion of gateway api controller

### DIFF
--- a/docs/guides/getstarted.md
+++ b/docs/guides/getstarted.md
@@ -42,7 +42,7 @@ This example creates a single cluster in a single VPC, then configures two HTTPR
         aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
         helm upgrade gateway-api-controller \
         oci://public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart \
-        --version=v1.0.5 \
+        --version=v1.0.6 \
         --reuse-values \
         --namespace aws-application-networking-system \
         --set=defaultServiceNetwork=my-hotel 
@@ -221,7 +221,7 @@ This section builds on the previous one. We will be migrating the Kubernetes `in
         aws ecr-public get-login-password --region us-east-1 | helm registry login --username AWS --password-stdin public.ecr.aws
         helm upgrade gateway-api-controller \
         oci://public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller-chart \
-        --version=v1.0.5 \
+        --version=v1.0.6 \
         --reuse-values \
         --namespace aws-application-networking-system \
         --set=defaultServiceNetwork=my-hotel 


### PR DESCRIPTION

**What type of PR is this?**
documentation


**Which issue does this PR fix**:
You encounter an error in AWS Gateway API Controller after deploying the gateway. The logs indicate that there are missing permissions for tlsroutes in ClusterRole. 
Logs from AWS Gateway API Controller pod: 

Error: E0904 23:06:10.238076 1 reflector.go:147] pkg/mod/k8s.io/client-go**@v0.28.3/tools/cache/reflector.go:229:** Failed to watch *v1alpha2.TLSRoute: failed to list *v1alpha2.TLSRoute: tlsroutes.gateway.networking.k8s.io is forbidden: User "system:serviceaccount:aws-application-networking-system:gateway-api-controller" cannot list resource "tlsroutes" in API group "gateway.networking.k8s.io" at the cluster scope

**What does this PR do / Why do we need it**:
There is a difference in version of AWS Gateway API Controller in the blog. The controller installation mentions the version as V1.0.6 but as we proceed with the blog it talks about the updating the AWS Gateway API Controller for updating defaultServiceNetwork. This command has a different version 

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
Yes

**Automation added to e2e**:
NA

**Will this PR introduce any new dependencies?**:
NA
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No
**Does this PR introduce any user-facing change?**:
No

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.