### PR TITLE
Add configurable max workers for route controller instances

### DIFF
--- a/docs/guides/environment.md
+++ b/docs/guides/environment.md
@@ -102,3 +102,13 @@ When set as "true", the controller will not use the [AWS Resource Groups Tagging
 The Resource Groups Tagging API is only available on the public internet and customers using private clusters will need to enable this feature. When enabled, the controller will use VPC Lattice APIs to lookup tags which are not as performant and requires more API calls.
 
 The Helm chart sets this value to "false" by default.
+
+---
+
+#### `ROUTE_MAX_CONCURRENT_RECONCILES`
+
+**Type:** *int*
+
+**Default:** 1
+
+Maximum number of concurrently running reconcile loops per route type (HTTP, GRPC, TLS)

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -97,6 +97,9 @@ spec:
             value: {{ .Values.webhookEnabled | quote }}
           - name: DISABLE_TAGGING_SERVICE_API
             value: {{ .Values.disableTaggingServiceApi | quote }}
+          - name: ROUTE_MAX_CONCURRENT_RECONCILES
+            value: {{ .Values.routeMaxConcurrentReconciles | quote }}
+
       terminationGracePeriodSeconds: 10
       volumes:
         - name: webhook-cert

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -85,6 +85,7 @@ defaultServiceNetwork:
 latticeEndpoint:
 webhookEnabled: true
 disableTaggingServiceApi: false
+routeMaxConcurrentReconciles:
 
 # TLS cert/key for the webhook. If specified, values must be base64 encoded
 webhookTLS:

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"strings"
 
@@ -28,6 +29,7 @@ const (
 	AWS_ACCOUNT_ID                  = "AWS_ACCOUNT_ID"
 	DEV_MODE                        = "DEV_MODE"
 	WEBHOOK_ENABLED                 = "WEBHOOK_ENABLED"
+	ROUTE_MAX_CONCURRENT_RECONCILES = "ROUTE_MAX_CONCURRENT_RECONCILES"
 )
 
 var VpcID = ""
@@ -40,6 +42,7 @@ var WebhookEnabled = ""
 
 var DisableTaggingServiceAPI = false
 var ServiceNetworkOverrideMode = false
+var RouteMaxConcurrentReconciles = 1
 
 func ConfigInit() error {
 	sess, _ := session.NewSession()
@@ -93,6 +96,15 @@ func configInit(sess *session.Session, metadata EC2Metadata) error {
 	ClusterName, err = getClusterName(sess)
 	if err != nil {
 		return fmt.Errorf("cannot get cluster name: %s", err)
+	}
+
+	routeMaxConcurrentReconciles := os.Getenv(ROUTE_MAX_CONCURRENT_RECONCILES)
+	if routeMaxConcurrentReconciles != "" {
+		routeMaxConcurrentReconcilesInt, err := strconv.Atoi(routeMaxConcurrentReconciles)
+		if err != nil {
+			return fmt.Errorf("invalid value for ROUTE_MAX_CONCURRENT_RECONCILES: %s", err)
+		}
+		RouteMaxConcurrentReconciles = routeMaxConcurrentReconcilesInt
 	}
 
 	return nil

--- a/pkg/config/controller_config_test.go
+++ b/pkg/config/controller_config_test.go
@@ -46,6 +46,7 @@ func Test_config_init_no_env_var(t *testing.T) {
 	os.Unsetenv(CLUSTER_VPC_ID)
 	os.Unsetenv(DEFAULT_SERVICE_NETWORK)
 	os.Unsetenv(AWS_ACCOUNT_ID)
+	os.Unsetenv(ROUTE_MAX_CONCURRENT_RECONCILES)
 	err := configInit(nil, ec2MetadataUnavailable())
 	assert.NotNil(t, err)
 
@@ -58,16 +59,30 @@ func Test_config_init_with_all_env_var(t *testing.T) {
 	testClusterLocalGateway := "default"
 	testAwsAccountId := "12345678"
 	testClusterName := "cluster-name"
+	testMaxRouteReconciles := "5"
+	testMaxRouteReconcilesInt := 5
 
 	os.Setenv(REGION, testRegion)
 	os.Setenv(CLUSTER_VPC_ID, testClusterVpcId)
 	os.Setenv(DEFAULT_SERVICE_NETWORK, testClusterLocalGateway)
 	os.Setenv(AWS_ACCOUNT_ID, testAwsAccountId)
 	os.Setenv(CLUSTER_NAME, testClusterName)
-	configInit(nil, ec2MetadataUnavailable())
-	assert.Equal(t, Region, testRegion)
-	assert.Equal(t, VpcID, testClusterVpcId)
-	assert.Equal(t, AccountID, testAwsAccountId)
-	assert.Equal(t, DefaultServiceNetwork, testClusterLocalGateway)
+	os.Setenv(ROUTE_MAX_CONCURRENT_RECONCILES, testMaxRouteReconciles)
+	err := configInit(nil, ec2MetadataUnavailable())
+	assert.Nil(t, err)
+	assert.Equal(t, testRegion, Region)
+	assert.Equal(t, testClusterVpcId, VpcID)
+	assert.Equal(t, testAwsAccountId, AccountID)
+	assert.Equal(t, testClusterLocalGateway, DefaultServiceNetwork)
 	assert.Equal(t, testClusterName, ClusterName)
+	assert.Equal(t, testMaxRouteReconcilesInt, RouteMaxConcurrentReconciles)
+}
+
+func Test_bad_reconcile_value(t *testing.T) {
+	// Test variable
+	maxReconciles := "FOO"
+
+	os.Setenv(ROUTE_MAX_CONCURRENT_RECONCILES, maxReconciles)
+	err := configInit(nil, ec2MetadataUnavailable())
+	assert.NotNil(t, err)
 }

--- a/pkg/controllers/route_controller.go
+++ b/pkg/controllers/route_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -119,7 +120,10 @@ func RegisterAllRouteControllers(
 			Watches(&gwv1beta1.Gateway{}, gwEventHandler).
 			Watches(&corev1.Service{}, svcEventHandler.MapToRoute(routeInfo.routeType)).
 			Watches(&anv1alpha1.ServiceImport{}, svcImportEventHandler.MapToRoute(routeInfo.routeType)).
-			Watches(&discoveryv1.EndpointSlice{}, svcEventHandler.MapToRoute(routeInfo.routeType))
+			Watches(&discoveryv1.EndpointSlice{}, svcEventHandler.MapToRoute(routeInfo.routeType)).
+			WithOptions(controller.Options{
+				MaxConcurrentReconciles: config.RouteMaxConcurrentReconciles,
+			})
 
 		if ok, err := k8s.IsGVKSupported(mgr, anv1alpha1.GroupVersion.String(), anv1alpha1.TargetGroupPolicyKind); ok {
 			builder.Watches(&anv1alpha1.TargetGroupPolicy{}, svcEventHandler.MapToRoute(routeInfo.routeType))

--- a/pkg/utils/gwlog/actions.go
+++ b/pkg/utils/gwlog/actions.go
@@ -1,4 +1,4 @@
 package gwlog
 
-const ReconcileStart = "RECONCILE_START_MARKER"
-const ReconcileEnd = "RECONCILE_END_MARKER"
+const ReconcileStart = "reconcile_start"
+const ReconcileEnd = "reconcile_end"


### PR DESCRIPTION
**What type of PR is this?**
Feature/Improvement

**Which issue does this PR fix**:
#671 

**What does this PR do / Why do we need it**:
Adds a configurable value for the number of max workers for route controller instances. Note this worker count applies to each route type: HTTP, GRPC, and TLS. This change also updates locking mechanism for target group garbage collection to be more performant and allow parallel execution for route reconciliation.

**Testing done on this change**:
Created 50 HTTP routes. On start or change, all 50 are reconciled. Previously with max workers = 1 (default), the reconciliation rate was 1/s and total time was roughly 50s. For 5 workers, the rate was closer to 5/s, and total time was around 12s. When set to very large numbers (e.g. 25 or 100), the controller encounters throttling from the Lattice APIs. At the default API rate limits, the controller maxes out between 5-10/s and handles the throttles fine enough. If customers need higher reconciliation rates, they can request API limit increases.

I also checked the Helm install, including a `--dry-run` to verify the environment variable as well as a deployment. When run correctly, the max worker count will show in the logs.

```
# example log line when worker count set to 10
2024-10-29T16:37:47.088-0700	INFO	runtime	controller/controller.go:234	Starting workers	{"controller": "grpcroute", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "GRPCRoute", "worker count": 10}
```

This is how I was eyeballing the reconciliation rate and found the issue with the target group GC lock.
```
# pull the metrics for the HTTPRoute queue depth
while true; do curl -s http://127.0.0.1:8080/metrics | grep 'workqueue_depth{name="httproute"}' | awk -v d="$(date -j +%H:%M:%S)"  '{ print d, $2 }'; sleep 1; done
```

Also validated the controller errors out when an invalid value is supplied.

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No. Default for workers is still 1 if the value unspecified.

**Does this PR introduce any user-facing change?**:
Yes, new optional/opt-in feature.

```release-note
Allow configuring concurrency for route reconciliation via ROUTE_MAX_CONCURRENT_RECONCILES environment variable.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.