### PR TITLE
Fix for CRD install during e2e-test workflow

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -72,9 +72,9 @@ jobs:
              --set=image.repository=$IMAGE_REPOSITORY \
              --set=image.tag=$RELEASE_VERSION \
              --set=log.level=debug
-      - name: Install Gateway API v1 CRDs
+      - name: Install Gateway API v1.2 CRDs
         run: |
-          kubectl apply -f config/crds/bases/k8s-gateway-v1.0.0.yaml
+          kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.2.0" | kubectl apply -f -
       - name: Create Lattice GatewayClass
         run: |
           kubectl apply -f files/controller-installation/gatewayclass.yaml


### PR DESCRIPTION

**What type of PR is this?**
bug

**Which issue does this PR fix**:
#638 

**What does this PR do / Why do we need it**:
Fixes `e2e-test.yaml` now that gateway CRDs are no longer packaged in the build.


**Testing done on this change**:
n/a

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.