### PR TITLE
Enable separate validation on PR vs Push

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -3,8 +3,9 @@ permissions:
   id-token: write
   contents: read
 on:
-  merge_group:
-    branches: [ "main" ]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 jobs:
   e2e-test:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 jobs:
   e2e-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,8 +1,7 @@
 name: presubmit
 on:
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
+  workflow_call:
 jobs:
   golangci-lint:
     name: golangci-lint

--- a/.github/workflows/validate-merge-queue.yaml
+++ b/.github/workflows/validate-merge-queue.yaml
@@ -1,0 +1,17 @@
+name: Validate code in the merge queue with e2e-test
+permissions:
+  id-token: write
+  contents: read
+on:
+  merge_group:
+    branches: [ "main" ]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: e2e-test
+        uses: actions/checkout@v3
+        with:
+          workflow: e2e-test.yaml
+          repo: aws/aws-application-networking-k8s
+          ref: main

--- a/.github/workflows/validate-merge-queue.yaml
+++ b/.github/workflows/validate-merge-queue.yaml
@@ -7,11 +7,4 @@ on:
     branches: [ "main" ]
 jobs:
   validate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: e2e-test
-        uses: actions/checkout@v3
-        with:
-          workflow: e2e-test.yaml
-          repo: aws/aws-application-networking-k8s
-          ref: main
+    uses: ./.github/workflows/e2e-test.yaml

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -1,0 +1,13 @@
+name: Validate pull request with presubmit before putting into queue
+on:
+  pull_request:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: presubmit
+        uses: actions/checkout@v3
+        with:
+          workflow: presubmit.yaml
+          repo: aws/aws-application-networking-k8s
+          ref: main

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -3,11 +3,4 @@ on:
   pull_request:
 jobs:
   validate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: presubmit
-        uses: actions/checkout@v3
-        with:
-          workflow: presubmit.yaml
-          repo: aws/aws-application-networking-k8s
-          ref: main
+    uses: ./.github/workflows/presubmit.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#705 

**What does this PR do / Why do we need it**:
- This change allows for different validation on PR versus merge queue to workaround required status check restrictions. This will allow E2E test results to be reported correctly.

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.