### PR TITLE
Remove strategy from validate workflow

### DIFF
--- a/.github/workflows/validate-pull-request-presubmit.yaml
+++ b/.github/workflows/validate-pull-request-presubmit.yaml
@@ -4,9 +4,6 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        k8sVersion: ["1.31.1"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Enhancement
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
- This change corrects an issue where the validate workflow could not correctly differentiate running on versus merge queues

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
N/A

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.