### PR TITLE
Correct Go toolchain version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.23.0 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-application-networking-k8s
 
-go 1.23
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go v1.55.5

--- a/go.sum
+++ b/go.sum
@@ -212,7 +212,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
-google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.6/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This corrects the issue below, from [here](https://github.com/aws/aws-application-networking-k8s/security/code-scanning/tools/CodeQL/status/configurations/automatic/5820253ebecd708ce71ac44ab761d599f372d935050ad7f697897a4ef8e3a8e7):

> As of Go 1.21, toolchain versions must use the 1.N.P syntax.
>
> 1.23 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Ran `make e2e-test` successfully.

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Set Go version to 1.23.6 to comply with CodeQL scans
```

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
<!--
Please provide a snippet of a successful `make e2e-test` run to confirm.
-->
Yes:

```
[SynchronizedAfterSuite] 
/Volumes/workplace/aws-application-networking-k8s/test/suites/integration/suite_test.go:72
{"level":"info","ts":"2025-02-10T12:38:33.562-0800","caller":"test/framework.go:266","msg":"Deleting objects: *v1.Gateway/test-gateway, *v1.Pod/grpc-runner"}
{"level":"info","ts":"2025-02-10T12:38:33.662-0800","caller":"test/framework.go:285","msg":"Waiting for NotFound, objects: *v1.Gateway/test-gateway, *v1.Pod/grpc-runner"}
[SynchronizedAfterSuite] PASSED [30.747 seconds]
------------------------------

Ran 69 of 69 Specs in 3068.433 seconds
SUCCESS! -- 69 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestIntegration (3068.43s)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.