### PR TITLE
Fix tls route event map

### DIFF
--- a/pkg/controllers/eventhandlers/mapper.go
+++ b/pkg/controllers/eventhandlers/mapper.go
@@ -3,6 +3,7 @@ package eventhandlers
 import (
 	"context"
 	"fmt"
+
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	k8sutils "github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s/policyhelper"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 type resourceMapper struct {
@@ -173,6 +175,12 @@ func (r *resourceMapper) backendRefToRoutes(ctx context.Context, obj client.Obje
 		r.client.List(ctx, routeList)
 		for _, k8sRoute := range routeList.Items {
 			routes = append(routes, core.NewGRPCRoute(k8sRoute))
+		}
+	case core.TlsRouteType:
+		routeList := &gwv1alpha2.TLSRouteList{}
+		r.client.List(ctx, routeList)
+		for _, k8sRoute := range routeList.Items {
+			routes = append(routes, core.NewTLSRoute(k8sRoute))
 		}
 	default:
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#669 

**What does this PR do / Why do we need it**:
Fixed incomplete detection of events related to TLSRoute, as described in the issue.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

With this change, as shown in the attached image, when the podIP changes, the TargetGroup association will also be updated accordingly.
![image](https://github.com/user-attachments/assets/8b7293f1-06d2-457d-b038-5a4c9c8291d1)

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
None
**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
None
**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No, this change does not break upgrades or downgrades.
Unit tests and end-to-end (e2e) tests confirm that the system behaves as expected.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
<!--
Please provide a snippet of a successful `make e2e-test` run to confirm.
-->
```
SECONDARY_ACCOUNT_TEST_ROLE_ARN=arn:aws:iam:xxxxxxxxxxxx:role/TestRole REGION=ap-northeast-1  make e2e-test
...
------------------------------
[SynchronizedAfterSuite] 
/Users/kai/aws-application-networking-k8s/test/suites/integration/suite_test.go:72
{"level":"info","ts":"2025-02-16T19:42:31.835+0900","caller":"test/framework.go:266","msg":"Deleting objects: *v1.Gateway/test-gateway, *v1.Pod/grpc-runner"}
{"level":"info","ts":"2025-02-16T19:42:31.884+0900","caller":"test/framework.go:285","msg":"Waiting for NotFound, objects: *v1.Gateway/test-gateway, *v1.Pod/grpc-runner"}
[SynchronizedAfterSuite] PASSED [32.103 seconds]
------------------------------

Ran 69 of 69 Specs in 2844.480 seconds
SUCCESS! -- 69 Passed | 0 Failed | 0 Pending | 0 Skipped

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.