### PR TITLE
Upgrade to actions/cache@v4

### DIFF
--- a/.github/workflows/validate-pull-request-presubmit.yaml
+++ b/.github/workflows/validate-pull-request-presubmit.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,16 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - staticcheck
+        text: "ST1012:"
+      - linters:
+          - staticcheck
+        text: "QF1003:"
+      - linters:
+          - staticcheck
+        text: "QF1001:"
 formatters:
   exclusions:
     generated: lax

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,22 @@
-# https://golangci-lint.run/usage/configuration
+version: "2"
 linters:
   disable:
     - errcheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/controllers/accesslogpolicy_controller.go
+++ b/pkg/controllers/accesslogpolicy_controller.go
@@ -247,7 +247,7 @@ func (r *accessLogPolicyReconciler) targetRefExists(ctx context.Context, alp *an
 		grpcRoute := &gwv1.GRPCRoute{}
 		err = r.client.Get(ctx, targetRefNamespacedName, grpcRoute)
 	default:
-		return false, fmt.Errorf("Access Log Policy targetRef is for unsupported Kind: %s", alp.Spec.TargetRef.Kind)
+		return false, fmt.Errorf("access Log Policy targetRef is for unsupported Kind: %s", alp.Spec.TargetRef.Kind)
 	}
 
 	if err != nil && !errors.IsNotFound(err) {
@@ -294,10 +294,10 @@ func (r *accessLogPolicyReconciler) updateAccessLogPolicyAnnotations(
 	for _, als := range accessLogSubscriptions {
 		if als.Spec.EventType != core.DeleteEvent {
 			oldAlp := alp.DeepCopy()
-			if alp.ObjectMeta.Annotations == nil {
-				alp.ObjectMeta.Annotations = make(map[string]string)
+			if alp.Annotations == nil {
+				alp.Annotations = make(map[string]string)
 			}
-			alp.ObjectMeta.Annotations[anv1alpha1.AccessLogSubscriptionAnnotationKey] = als.Status.Arn
+			alp.Annotations[anv1alpha1.AccessLogSubscriptionAnnotationKey] = als.Status.Arn
 			if err := r.client.Patch(ctx, alp, client.MergeFrom(oldAlp)); err != nil {
 				r.eventRecorder.Event(alp, corev1.EventTypeWarning, k8s.FailedReconcileEvent,
 					"Failed to update annotation due to "+err.Error())

--- a/pkg/controllers/serviceexport_controller.go
+++ b/pkg/controllers/serviceexport_controller.go
@@ -121,7 +121,7 @@ func (r *serviceExportReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return client.IgnoreNotFound(err)
 	}
 
-	if srvExport.ObjectMeta.Annotations["application-networking.k8s.aws/federation"] != "amazon-vpc-lattice" {
+	if srvExport.Annotations["application-networking.k8s.aws/federation"] != "amazon-vpc-lattice" {
 		return nil
 	}
 	r.log.Debugf(ctx, "Found matching service export %s-%s", srvExport.Name, srvExport.Namespace)

--- a/pkg/deploy/lattice/listener_manager.go
+++ b/pkg/deploy/lattice/listener_manager.go
@@ -109,7 +109,7 @@ func (d *defaultListenerManager) create(ctx context.Context, latticeSvcId string
 	resp, err := d.cloud.Lattice().CreateListenerWithContext(ctx, &listenerInput)
 	if err != nil {
 		return model.ListenerStatus{},
-			fmt.Errorf("Failed CreateListener %s due to %s", aws.StringValue(listenerInput.Name), err)
+			fmt.Errorf("failed CreateListener %s due to %s", aws.StringValue(listenerInput.Name), err)
 	}
 	d.log.Infof(ctx, "Success CreateListener %s, %s", aws.StringValue(resp.Name), aws.StringValue(resp.Id))
 
@@ -280,7 +280,7 @@ func (d *defaultListenerManager) Delete(ctx context.Context, modelListener *mode
 			d.log.Debugf(ctx, "Listener already deleted")
 			return nil
 		}
-		return fmt.Errorf("Failed DeleteListener %s, %s due to %s", modelListener.Status.Id, modelListener.Status.ServiceId, err)
+		return fmt.Errorf("failed DeleteListener %s, %s due to %s", modelListener.Status.Id, modelListener.Status.ServiceId, err)
 	}
 
 	d.log.Infof(ctx, "Success DeleteListener %s, %s", modelListener.Status.Id, modelListener.Status.ServiceId)

--- a/pkg/deploy/lattice/rule_synthesizer.go
+++ b/pkg/deploy/lattice/rule_synthesizer.go
@@ -87,7 +87,7 @@ func (r *ruleSynthesizer) createOrUpdateRules(ctx context.Context, rule *model.R
 	}
 	status, err := r.ruleManager.Upsert(ctx, rule, stackListener, stackSvc)
 	if err != nil {
-		return fmt.Errorf("Failed RuleManager.Upsert due to %s", err)
+		return fmt.Errorf("failed RuleManager.Upsert due to %s", err)
 	}
 	rule.Status = &status
 

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -103,7 +103,7 @@ func (s *defaultTargetGroupManager) create(ctx context.Context, modelTg *model.T
 	resp, err := lattice.CreateTargetGroupWithContext(ctx, &createInput)
 	if err != nil {
 		return model.TargetGroupStatus{},
-			fmt.Errorf("Failed CreateTargetGroup %s due to %s", latticeTgName, err)
+			fmt.Errorf("failed CreateTargetGroup %s due to %s", latticeTgName, err)
 	}
 	s.log.Infof(ctx, "Success CreateTargetGroup %s", latticeTgName)
 

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -240,16 +240,16 @@ func Test_DoNotDeleteCases(t *testing.T) {
 		},
 	}
 	svcExportModelTg := baseModelTg
-	svcExportModelTg.Spec.TargetGroupTagFields.K8SSourceType = model.SourceTypeSvcExport
+	svcExportModelTg.Spec.K8SSourceType = model.SourceTypeSvcExport
 
 	mockSvcExportTgBuilder.EXPECT().BuildTargetGroup(ctx, gomock.Any()).Return(&svcExportModelTg, nil)
 
 	stack := core.NewDefaultStack(core.StackID{Name: "foo", Namespace: "bar"})
 	svcModelTg := baseModelTg
 	svcModelTg.ResourceMeta = core.NewResourceMeta(stack, "AWS:VPCServiceNetwork::TargetGroup", "tg-id")
-	svcModelTg.Spec.TargetGroupTagFields.K8SSourceType = model.SourceTypeHTTPRoute
-	svcModelTg.Spec.TargetGroupTagFields.K8SRouteName = "route"
-	svcModelTg.Spec.TargetGroupTagFields.K8SRouteNamespace = "route-ns"
+	svcModelTg.Spec.K8SSourceType = model.SourceTypeHTTPRoute
+	svcModelTg.Spec.K8SRouteName = "route"
+	svcModelTg.Spec.K8SRouteNamespace = "route-ns"
 	stack.AddResource(&svcModelTg)
 
 	mockTGManager.EXPECT().IsTargetGroupMatch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)

--- a/pkg/deploy/lattice/targets_manager.go
+++ b/pkg/deploy/lattice/targets_manager.go
@@ -119,10 +119,10 @@ func (s *defaultTargetsManager) registerTargets(
 		}
 		resp, err := s.cloud.Lattice().RegisterTargetsWithContext(ctx, &registerTargetsInput)
 		if err != nil {
-			registerTargetsError = errors.Join(registerTargetsError, fmt.Errorf("Failed to register targets from VPC Lattice Target Group %s due to %s", modelTg.Status.Id, err))
+			registerTargetsError = errors.Join(registerTargetsError, fmt.Errorf("failed to register targets from VPC Lattice Target Group %s due to %s", modelTg.Status.Id, err))
 		}
 		if len(resp.Unsuccessful) > 0 {
-			registerTargetsError = errors.Join(registerTargetsError, fmt.Errorf("Failed to register targets from VPC Lattice Target Group %s for chunk %d/%d, unsuccessful targets %v",
+			registerTargetsError = errors.Join(registerTargetsError, fmt.Errorf("failed to register targets from VPC Lattice Target Group %s for chunk %d/%d, unsuccessful targets %v",
 				modelTg.Status.Id, i+1, len(chunks), resp.Unsuccessful))
 		}
 		s.log.Debugf(ctx, "Successfully registered %d targets from VPC Lattice Target Group %s for chunk %d/%d",
@@ -152,10 +152,10 @@ func (s *defaultTargetsManager) deregisterTargets(
 		}
 		resp, err := s.cloud.Lattice().DeregisterTargetsWithContext(ctx, &deregisterTargetsInput)
 		if err != nil {
-			deregisterTargetsError = errors.Join(deregisterTargetsError, fmt.Errorf("Failed to deregister targets from VPC Lattice Target Group %s due to %s", modelTg.Status.Id, err))
+			deregisterTargetsError = errors.Join(deregisterTargetsError, fmt.Errorf("failed to deregister targets from VPC Lattice Target Group %s due to %s", modelTg.Status.Id, err))
 		}
 		if len(resp.Unsuccessful) > 0 {
-			deregisterTargetsError = errors.Join(deregisterTargetsError, fmt.Errorf("Failed to deregister targets from VPC Lattice Target Group %s for chunk %d/%d, unsuccessful targets %v",
+			deregisterTargetsError = errors.Join(deregisterTargetsError, fmt.Errorf("failed to deregister targets from VPC Lattice Target Group %s for chunk %d/%d, unsuccessful targets %v",
 				modelTg.Status.Id, i+1, len(chunks), resp.Unsuccessful))
 		}
 		s.log.Debugf(ctx, "Successfully deregistered %d targets from VPC Lattice Target Group %s for chunk %d/%d", len(resp.Successful), modelTg.Status.Id, i+1, len(chunks))

--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -423,7 +423,7 @@ func buildTargetGroupIpAddressType(svc *corev1.Service) (string, error) {
 	ipFamilies := svc.Spec.IPFamilies
 
 	if len(ipFamilies) != 1 {
-		return "", errors.New("Lattice Target Group only supports single stack IP addresses")
+		return "", errors.New("lattice Target Group only supports single stack IP addresses")
 	}
 
 	// IpFamilies will always have at least 1 element

--- a/pkg/gateway/model_build_targets.go
+++ b/pkg/gateway/model_build_targets.go
@@ -212,14 +212,14 @@ func (t *latticeTargetsModelBuildTask) getDefinedPorts() map[int32]struct{} {
 
 	isServiceExport := t.serviceExport != nil
 	if isServiceExport {
-		portsAnnotations := strings.Split(t.serviceExport.ObjectMeta.Annotations[portAnnotationsKey], ",")
+		portsAnnotations := strings.Split(t.serviceExport.Annotations[portAnnotationsKey], ",")
 
 		for _, portAnnotation := range portsAnnotations {
 			if portAnnotation != "" {
 				definedPort, err := strconv.ParseInt(portAnnotation, 10, 32)
 				if err != nil {
 					t.log.Infof(context.TODO(), "failed to read Annotations/Port: %s due to %s",
-						t.serviceExport.ObjectMeta.Annotations[portAnnotationsKey], err)
+						t.serviceExport.Annotations[portAnnotationsKey], err)
 				} else {
 					definedPorts[int32(definedPort)] = struct{}{}
 				}

--- a/pkg/model/core/stack_test.go
+++ b/pkg/model/core/stack_test.go
@@ -96,7 +96,7 @@ func Test_defaultStack_ListResources(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				for _, want := range tt.wantFakeResources {
-					want.ResourceMeta.stack = s
+					want.stack = s
 				}
 				sort.Slice(gotFakeResources, func(i, j int) bool {
 					return gotFakeResources[i].ID() < gotFakeResources[j].ID()

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,7 +68,13 @@ tools() {
             echo "Installing golangci-lint"
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOLANGCI_LINT_VERSION
         else
-            echo "golangci-lint is already installed."
+
+            read -p "golangci-lint is already installed, do you want to update? (Y/N): " update_package
+
+            if [[ $update_package == 'Y' || $update_package == 'y' ]]; then
+                echo "Updating golangci-lint"
+                curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOLANGCI_LINT_VERSION
+            fi
         fi
 
         go install github.com/golang/mock/mockgen@v1.6.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 declare -a DEPENDENCY_LIST=("go" "awscli" "kubernetes-cli" "eksctl" "helm" "jq" "yq" "make")
 CURRENT_CONTROLLER_VERSION="1.1.0"
 CURRENT_CRD_VERSION="1.2.0"
-GOLANGCI_LINT_VERSION="1.63.4"
+GOLANGCI_LINT_VERSION="2.1.5"
 EKS_POD_IDENTITY_AGENT_VERSION="1.0.0-eksbuild.1"
 
 main() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

Bug

**Which issue does this PR fix**:

N/A

**What does this PR do / Why do we need it**:

[Versions of `actions/cache` prior to 4.0.0 have been deprecated](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down). This now tracks the latest v4 release to restore functionality. In addition to this upgrade,`golanglint-ci` was also upgraded to address Apple Silicon incompatibility.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

N/A

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.