### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-doc.yaml
+++ b/.github/workflows/publish-doc.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 'release-v*.*.*'
+permissions:
+  contents: write
 jobs:
   publish-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-application-networking-k8s/security/code-scanning/1](https://github.com/aws/aws-application-networking-k8s/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Based on the workflow's operations, it likely needs `contents: write` to deploy documentation using `mike`. However, we will start with the minimal permissions (`contents: read`) and adjust to `contents: write` if necessary for the workflow to function correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This ensures that the `GITHUB_TOKEN` used in the workflow has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
