### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-pull-request-presubmit.yaml
+++ b/.github/workflows/validate-pull-request-presubmit.yaml
@@ -1,7 +1,8 @@
 name: Validate pull request with presubmit before putting into queue
+permissions:
+  contents: read
 on:
   pull_request:
-jobs:
   validate:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-application-networking-k8s/security/code-scanning/13](https://github.com/aws/aws-application-networking-k8s/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow primarily reads repository contents and does not perform write operations, we will set `contents: read` as the minimal required permission. This ensures the workflow has only the permissions it needs to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
