### PR TITLE
Correct Dependabot to run "make presubmit" before creating PRs

### DIFF
--- a/.github/workflows/dependabot-make-presubmit.yml
+++ b/.github/workflows/dependabot-make-presubmit.yml
@@ -1,4 +1,4 @@
-name: Dependabot Go Mod Tidy
+name: Dependabot Make Presubmit
 
 on:
   pull_request:
@@ -26,9 +26,9 @@ jobs:
         with:
           go-version: '1.x'
           
-      - name: Run go mod tidy
+      - name: Run make presubmit
         run: |
-          go mod tidy
+          make presubmit
           
       - name: Check for changes
         id: git-check
@@ -46,5 +46,5 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add go.mod go.sum
-          git commit -m "Run go mod tidy for Dependabot PR"
+          git commit -m "Run make presubmit for Dependabot PR"
           git push


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

Bug

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
This corrects dependabot PRs that fail after merging because `go mod tidy` was not run after making the dependency upgrades.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No.

**Does this PR introduce any user-facing change?**:
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.