### PR TITLE
Correct additional target group creation when using the exportedPorts with HTTPRoute

### DIFF
--- a/pkg/gateway/model_build_targetgroup.go
+++ b/pkg/gateway/model_build_targetgroup.go
@@ -225,12 +225,6 @@ func (t *svcExportTargetGroupModelBuildTask) buildTargetGroupForExportedPort(ctx
 	spec.K8SServiceNamespace = t.serviceExport.Namespace
 	spec.K8SProtocolVersion = protocolVersion
 
-	// Add a tag for the route type to help with identification
-	// This is not used by the controller but can be helpful for debugging
-	if exportedPort.RouteType != "" {
-		spec.K8SProtocolVersion = exportedPort.RouteType
-	}
-
 	stackTG, err := model.NewTargetGroup(t.stack, spec)
 	if err != nil {
 		return nil, err

--- a/pkg/gateway/model_build_targetgroup_test.go
+++ b/pkg/gateway/model_build_targetgroup_test.go
@@ -693,7 +693,7 @@ func Test_TGModelByServiceExportWithExportedPorts(t *testing.T) {
 			wantErrIsNil:         true,
 			wantTargetGroupCount: 3,
 			wantPorts:            []int32{80, 8081, 443},
-			wantRouteTypes:       []string{"HTTP", "GRPC", "TLS"},
+			wantRouteTypes:       []string{vpclattice.TargetGroupProtocolVersionHttp1, vpclattice.TargetGroupProtocolVersionGrpc, ""},
 		},
 		{
 			name: "ServiceExport with single exportedPort",
@@ -731,7 +731,7 @@ func Test_TGModelByServiceExportWithExportedPorts(t *testing.T) {
 			wantErrIsNil:         true,
 			wantTargetGroupCount: 1,
 			wantPorts:            []int32{80},
-			wantRouteTypes:       []string{"HTTP"},
+			wantRouteTypes:       []string{vpclattice.TargetGroupProtocolVersionHttp1},
 		},
 		{
 			name: "ServiceExport with no exportedPorts (legacy behavior)",
@@ -812,20 +812,18 @@ func Test_TGModelByServiceExportWithExportedPorts(t *testing.T) {
 				seenPorts[tg.Spec.Port] = true
 				seenRouteTypes[tg.Spec.K8SProtocolVersion] = true
 
-				// Check protocol and protocolVersion based on route type
+				// Check protocol and protocolVersion based on K8SProtocolVersion
 				switch tg.Spec.K8SProtocolVersion {
-				case "HTTP":
+				case vpclattice.TargetGroupProtocolVersionHttp1:
 					assert.Equal(t, vpclattice.TargetGroupProtocolHttp, tg.Spec.Protocol)
 					assert.Equal(t, vpclattice.TargetGroupProtocolVersionHttp1, tg.Spec.ProtocolVersion)
-				case "GRPC":
+				case vpclattice.TargetGroupProtocolVersionGrpc:
 					assert.Equal(t, vpclattice.TargetGroupProtocolHttp, tg.Spec.Protocol)
 					assert.Equal(t, vpclattice.TargetGroupProtocolVersionGrpc, tg.Spec.ProtocolVersion)
-				case "TLS":
+				case "":
+					// TLS case - no protocol version for TCP
 					assert.Equal(t, vpclattice.TargetGroupProtocolTcp, tg.Spec.Protocol)
 					assert.Equal(t, "", tg.Spec.ProtocolVersion)
-				case vpclattice.TargetGroupProtocolVersionHttp1:
-					// Legacy behavior
-					assert.Equal(t, vpclattice.TargetGroupProtocolHttp, tg.Spec.Protocol)
 				}
 			}
 

--- a/test/suites/integration/httproute_serviceexport_test.go
+++ b/test/suites/integration/httproute_serviceexport_test.go
@@ -1,0 +1,118 @@
+package integration
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+)
+
+var _ = Describe("HTTPRoute Service Export/Import Test", Ordered, func() {
+	var (
+		httpDeployment *appsv1.Deployment
+		httpSvc        *v1.Service
+		httpRoute      *gwv1.HTTPRoute
+		serviceExport  *anv1alpha1.ServiceExport
+		serviceImport  *anv1alpha1.ServiceImport
+	)
+
+	It("Create k8s resource", func() {
+		// Create an HTTP service and deployment
+		httpDeployment, httpSvc = testFramework.NewHttpApp(test.HTTPAppOptions{Name: "my-http-exportedports", Namespace: k8snamespace})
+		testFramework.ExpectCreated(ctx, httpDeployment, httpSvc)
+
+		// Create ServiceImport
+		serviceImport = testFramework.CreateServiceImport(httpSvc)
+		testFramework.ExpectCreated(ctx, serviceImport)
+
+		// Create ServiceExport with exportedPorts field
+		serviceExport = &anv1alpha1.ServiceExport{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "application-networking.k8s.aws/v1alpha1",
+				Kind:       "ServiceExport",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      httpSvc.Name,
+				Namespace: httpSvc.Namespace,
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/federation": "amazon-vpc-lattice",
+				},
+			},
+			Spec: anv1alpha1.ServiceExportSpec{
+				ExportedPorts: []anv1alpha1.ExportedPort{
+					{
+						Port:      httpSvc.Spec.Ports[0].Port,
+						RouteType: "HTTP",
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, serviceExport)
+
+		httpRoute = testFramework.NewHttpRoute(testGateway, httpSvc, "ServiceImport")
+		testFramework.ExpectCreated(ctx, httpRoute)
+	})
+
+	It("Verify lattice resource & traffic", func() {
+		route := core.NewHTTPRoute(*httpRoute)
+		vpcLatticeService := testFramework.GetVpcLatticeService(ctx, route)
+		fmt.Printf("vpcLatticeService: %v \n", vpcLatticeService)
+
+		// Get the target group and verify it's configured for HTTP
+		tgSummary := testFramework.GetTargetGroupWithProtocol(ctx, httpSvc, "http", "http1")
+		tg, err := testFramework.LatticeClient.GetTargetGroup(&vpclattice.GetTargetGroupInput{
+			TargetGroupIdentifier: aws.String(*tgSummary.Id),
+		})
+		Expect(tg).To(Not(BeNil()))
+		Expect(err).To(BeNil())
+		Expect(*tgSummary.VpcIdentifier).To(Equal(os.Getenv("CLUSTER_VPC_ID")))
+
+		// Verify the target group is configured for HTTP
+		Expect(*tgSummary.Protocol).To(Equal("HTTP"))
+		Expect(*tg.Config.ProtocolVersion).To(Equal("HTTP1"))
+
+		// Verify targets are registered
+		Eventually(func(g Gomega) {
+			targets := testFramework.GetTargets(ctx, tgSummary, httpDeployment)
+			for _, target := range targets {
+				g.Expect(*target.Port).To(BeEquivalentTo(httpSvc.Spec.Ports[0].TargetPort.IntVal))
+			}
+		}).WithTimeout(3 * time.Minute).WithOffset(1).Should(Succeed())
+
+		log.Println("Verifying traffic")
+		dnsName := testFramework.GetVpcLatticeServiceDns(httpRoute.Name, httpRoute.Namespace)
+		pods := testFramework.GetPodsByDeploymentName(httpDeployment.Name, httpDeployment.Namespace)
+		Expect(len(pods)).To(BeEquivalentTo(1))
+		pod := pods[0]
+
+		Eventually(func(g Gomega) {
+			cmd := fmt.Sprintf("curl %s", dnsName)
+			stdout, _, err := testFramework.PodExec(pod, cmd)
+			g.Expect(err).To(BeNil())
+			g.Expect(stdout).To(ContainSubstring("handler pod"))
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		testFramework.ExpectDeletedThenNotFound(ctx,
+			httpRoute,
+			httpDeployment,
+			httpSvc,
+			serviceImport,
+			serviceExport,
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->

**What type of PR is this?**
Bug

**Which issue does this PR fix**:
Fixes issue where multiple target groups are continually created for HTTPRoute with ServiceExport using `exportedPorts`

**What does this PR do / Why do we need it**:
This PR fixes a bug in the ServiceExport target group creation logic where the `K8SProtocolVersion` field was being inconsistently overwritten with the route type string (e.g., "HTTP") instead of maintaining the actual protocol version (e.g., "HTTP1"). This inconsistency caused target group lookups by tags to fail during reconciliation, leading to duplicate target groups being created instead of reusing existing ones.

The fix ensures that `K8SProtocolVersion` remains consistent with the actual VPC Lattice protocol version, which is used for target group identification and lookup via AWS resource tags.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
Repro steps:
1. Create a ServiceExport with exportedPorts specifying RouteType: "HTTP"
2. Create an HTTPRoute that references a ServiceImport backed by the ServiceExport
3. Observe multiple target groups being created continuously in AWS VPC Lattice console
4. Check controller logs for repeated target group creation events

The issue occurs because the target group spec hash changes between reconciliations due to inconsistent `K8SProtocolVersion` values, causing the controller to think it needs to create new target groups.

**Testing done on this change**:
- Added integration test `httproute_serviceexport_test.go` that mirrors the existing gRPC equivalent
- Verified that only one target group is created for HTTP routes with ServiceExport using exportedPorts
- Confirmed that target group lookup by tags works correctly with consistent protocol version
- Tested that the fix doesn't affect existing functionality for legacy ServiceExport behavior

**Automation added to e2e**:
Yes - Added `test/suites/integration/httproute_serviceexport_test.go` which tests HTTPRoute with ServiceExport using exportedPorts, mirroring the existing gRPC test pattern.

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No breaking changes. This fix only affects the internal target group spec generation and doesn't change any external APIs or behavior. Existing target groups will continue to work, and the fix prevents creation of duplicate target groups going forward.

**Does this PR introduce any user-facing change?**:
No user-facing changes. This is an internal bug fix that resolves duplicate target group creation.

```release-note
Fixed issue where HTTPRoute with ServiceExport using exportedPorts would create multiple target groups continuously
```

Do all end-to-end tests successfully pass when running make e2e-test?:
Yes, all tests pass including the new HTTPRoute ServiceExport integration test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.