### PR TITLE
Exponential backoff for reconciler requests

### DIFF
--- a/pkg/deploy/lattice/error.go
+++ b/pkg/deploy/lattice/error.go
@@ -1,9 +1,0 @@
-package lattice
-
-import "errors"
-
-const (
-	LATTICE_RETRY = "LATTICE_RETRY"
-)
-
-var RetryErr = errors.New(LATTICE_RETRY)

--- a/pkg/deploy/lattice/service_manager.go
+++ b/pkg/deploy/lattice/service_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -244,12 +245,12 @@ func (m *defaultServiceManager) updateAssociations(ctx context.Context, svc *Ser
 	return nil
 }
 
-// returns RetryErr on all non-active Sn-Svc association responses
+// returns RetryError on all non-active Sn-Svc association responses
 func handleCreateAssociationResp(resp *CreateSnSvcAssocResp) error {
 	status := aws.StringValue(resp.Status)
 	if status != vpclattice.ServiceNetworkServiceAssociationStatusActive {
 		return fmt.Errorf("%w: sn-service-association-id: %s, non-active status: %s",
-			RetryErr, aws.StringValue(resp.Id), status)
+			lattice_runtime.NewRetryError(), aws.StringValue(resp.Id), status)
 	}
 	return nil
 }
@@ -281,7 +282,7 @@ func associationsDiff(svc *Service, curAssocs []*SnSvcAssocSummary) ([]string, [
 		// TODO: we should have something more lightweight, retrying full reconciliation looks to heavy
 		if aws.StringValue(oldSn.Status) == vpclattice.ServiceNetworkServiceAssociationStatusDeleteInProgress {
 			return nil, nil, fmt.Errorf("%w: want to associate sn: %s to svc: %s, but status is: %s",
-				RetryErr, newSn, svc.LatticeServiceName(), *oldSn.Status)
+				lattice_runtime.NewRetryError(), newSn, svc.LatticeServiceName(), *oldSn.Status)
 		}
 		// TODO: if assoc in failed state, may be we should try to re-create?
 	}

--- a/pkg/deploy/lattice/service_manager_test.go
+++ b/pkg/deploy/lattice/service_manager_test.go
@@ -9,6 +9,7 @@ import (
 	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
@@ -398,7 +399,8 @@ func TestHandleSnSvcAssocResp(t *testing.T) {
 			Status: aws.String(vpclattice.ServiceNetworkServiceAssociationStatusCreateInProgress),
 		}
 		err := handleCreateAssociationResp(resp)
-		assert.True(t, errors.Is(err, RetryErr))
+		var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+		assert.True(t, errors.As(err, &requeueNeededAfter))
 	})
 
 }
@@ -459,7 +461,8 @@ func TestSnSvcAssocsDiff(t *testing.T) {
 			Status:             aws.String(vpclattice.ServiceNetworkServiceAssociationStatusDeleteInProgress),
 		}}
 		_, _, err := associationsDiff(svc, assocs)
-		assert.True(t, errors.Is(err, RetryErr))
+		var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+		assert.True(t, errors.As(err, &requeueNeededAfter))
 	})
 
 }

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -2,12 +2,12 @@ package lattice
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"golang.org/x/exp/slices"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -80,7 +80,7 @@ func (m *defaultServiceNetworkManager) UpsertVpcAssociation(ctx context.Context,
 		case vpclattice.ServiceNetworkVpcAssociationStatusActive:
 			return *resp.Arn, nil
 		default:
-			return *resp.Arn, fmt.Errorf("%w, vpc association status in %s", RetryErr, status)
+			return *resp.Arn, fmt.Errorf("%w, vpc association status in %s", lattice_runtime.NewRetryError(), status)
 		}
 	}
 }
@@ -125,7 +125,7 @@ func (m *defaultServiceNetworkManager) DeleteVpcAssociation(ctx context.Context,
 		if err != nil {
 			m.log.Infof(ctx, "Failed to delete association %s for %s, with response %s and err %s", *snva.Arn, snName, resp, err.Error())
 		}
-		return errors.New(LATTICE_RETRY)
+		return lattice_runtime.NewRetryError()
 	}
 	return nil
 }
@@ -163,7 +163,7 @@ func (m *defaultServiceNetworkManager) getActiveVpcAssociation(ctx context.Conte
 		return nil, nil
 	default:
 		// a mutation is in progress, try later
-		return nil, errors.New(LATTICE_RETRY)
+		return nil, lattice_runtime.NewRetryError()
 	}
 }
 
@@ -253,7 +253,7 @@ func (m *defaultServiceNetworkManager) updateServiceNetworkVpcAssociation(ctx co
 			SnvaSecurityGroupIds: updateSnvaResp.SecurityGroupIds,
 		}, nil
 	} else {
-		return model.ServiceNetworkStatus{}, fmt.Errorf("%w, update snva status: %s", RetryErr, *updateSnvaResp.Status)
+		return model.ServiceNetworkStatus{}, fmt.Errorf("%w, update snva status: %s", lattice_runtime.NewRetryError(), *updateSnvaResp.Status)
 	}
 }
 

--- a/pkg/deploy/lattice/service_network_manager_test.go
+++ b/pkg/deploy/lattice/service_network_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
@@ -147,7 +148,8 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 	resp, err := snMgr.CreateOrUpdate(ctx, &snCreateInput)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
+	var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+	assert.True(t, errors.As(err, &requeueNeededAfter))
 	assert.Equal(t, resp.ServiceNetworkARN, "")
 	assert.Equal(t, resp.ServiceNetworkID, "")
 }
@@ -199,7 +201,8 @@ func Test_CreateOrUpdateServiceNetwork_SnAlreadyExist_ServiceNetworkVpcAssociati
 	resp, err := snMgr.CreateOrUpdate(ctx, &snCreateInput)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
+	var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+	assert.True(t, errors.As(err, &requeueNeededAfter))
 	assert.Equal(t, resp.ServiceNetworkARN, "")
 	assert.Equal(t, resp.ServiceNetworkID, "")
 }
@@ -629,7 +632,8 @@ func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaCreateInProgr
 	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
 	_, err := snMgr.UpsertVpcAssociation(ctx, name, securityGroupIds)
 
-	assert.Equal(t, err, errors.New(LATTICE_RETRY))
+	var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+	assert.True(t, errors.As(err, &requeueNeededAfter))
 }
 
 func Test_defaultServiceNetworkManager_CreateOrUpdate_SnExists_SnvaExists_CannotUpdateSecurityGroupsFromNonemptyToEmpty(t *testing.T) {

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -220,7 +220,7 @@ func (s *defaultTargetGroupManager) Delete(ctx context.Context, modelTg *model.T
 
 	if drainCount > 0 {
 		// no point in trying to deregister may as well wait
-		return fmt.Errorf("cannot deregister targets for %s as %d targets are DRAINING", modelTg.Status.Id, drainCount)
+		return fmt.Errorf("%w: cannot deregister targets for %s as %d targets are DRAINING", lattice_runtime.NewRetryError(), modelTg.Status.Id, drainCount)
 	}
 
 	if len(targetsToDeregister) > 0 {

--- a/pkg/deploy/lattice/target_group_manager.go
+++ b/pkg/deploy/lattice/target_group_manager.go
@@ -17,6 +17,7 @@ import (
 
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 )
 
@@ -115,7 +116,7 @@ func (s *defaultTargetGroupManager) create(ctx context.Context, modelTg *model.T
 		latticeTgStatus != vpclattice.TargetGroupStatusCreateInProgress {
 
 		s.log.Infof(ctx, "Target group is not in the desired state. State is %s, will retry", latticeTgStatus)
-		return model.TargetGroupStatus{}, errors.New(LATTICE_RETRY)
+		return model.TargetGroupStatus{}, lattice_runtime.NewRetryError()
 	}
 
 	// create-in-progress is considered success
@@ -341,7 +342,7 @@ func (s *defaultTargetGroupManager) findTargetGroup(
 		if match {
 			switch status {
 			case vpclattice.TargetGroupStatusCreateInProgress, vpclattice.TargetGroupStatusDeleteInProgress:
-				return nil, errors.New(LATTICE_RETRY)
+				return nil, lattice_runtime.NewRetryError()
 			case vpclattice.TargetGroupStatusDeleteFailed, vpclattice.TargetGroupStatusActive:
 				return latticeTg, nil
 			}

--- a/pkg/deploy/lattice/target_group_manager_test.go
+++ b/pkg/deploy/lattice/target_group_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 )
 
@@ -363,7 +364,8 @@ func Test_CreateTargetGroup_ExistingTG_Status_Retry(t *testing.T) {
 			tgManager := NewTargetGroupManager(gwlog.FallbackLogger, cloud, nil)
 			_, err := tgManager.Upsert(ctx, &tgCreateInput)
 
-			assert.Equal(t, errors.New(LATTICE_RETRY), err)
+			var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+			assert.True(t, errors.As(err, &requeueNeededAfter))
 		})
 	}
 }
@@ -412,7 +414,8 @@ func Test_CreateTargetGroup_NewTG_RetryStatus(t *testing.T) {
 			tgManager := NewTargetGroupManager(gwlog.FallbackLogger, cloud, nil)
 			_, err := tgManager.Upsert(ctx, &tgCreateInput)
 
-			assert.Equal(t, errors.New(LATTICE_RETRY), err)
+			var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+			assert.True(t, errors.As(err, &requeueNeededAfter))
 		})
 	}
 }

--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -121,7 +121,7 @@ func (t *TargetGroupSynthesizer) SynthesizeDelete(ctx context.Context) error {
 		err := t.targetGroupManager.Delete(ctx, resTargetGroup)
 		if err != nil {
 			prefix := model.TgNamePrefix(resTargetGroup.Spec)
-			retErr = errors.Join(retErr, fmt.Errorf("failed TargetGroupManager.Delete %s due to %s", prefix, err))
+			retErr = errors.Join(retErr, fmt.Errorf("failed TargetGroupManager.Delete %s due to %w", prefix, err))
 		}
 	}
 

--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -60,7 +60,7 @@ func (t *TargetGroupSynthesizer) Synthesize(ctx context.Context) error {
 }
 func (t *TargetGroupSynthesizer) SynthesizeCreate(ctx context.Context) error {
 	var resTargetGroups []*model.TargetGroup
-	var returnErr = false
+	var firstError error
 
 	err := t.stack.ListResources(&resTargetGroups)
 	if err != nil {
@@ -91,12 +91,14 @@ func (t *TargetGroupSynthesizer) SynthesizeCreate(ctx context.Context) error {
 			resTargetGroup.Status = &tgStatus
 		} else {
 			t.log.Debugf(ctx, "Failed TargetGroupManager.Upsert %s due to %s", prefix, err)
-			returnErr = true
+			if firstError == nil {
+				firstError = err
+			}
 		}
 	}
 
-	if returnErr {
-		return fmt.Errorf("error during target group synthesis, will retry")
+	if firstError != nil {
+		return fmt.Errorf("error during target group synthesis, will retry: %w", firstError)
 	}
 
 	return nil

--- a/pkg/deploy/lattice/targets_synthesizer.go
+++ b/pkg/deploy/lattice/targets_synthesizer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/aws/aws-application-networking-k8s/pkg/webhook"
@@ -107,7 +108,7 @@ func (t *targetsSynthesizer) PostSynthesize(ctx context.Context) error {
 	}
 
 	if requeueNeeded {
-		return fmt.Errorf("%w: target status still in pending", RetryErr)
+		return fmt.Errorf("%w: target status still in pending", lattice_runtime.NewRetryError())
 	}
 	return nil
 }

--- a/pkg/deploy/lattice/targets_synthesizer_test.go
+++ b/pkg/deploy/lattice/targets_synthesizer_test.go
@@ -2,8 +2,12 @@ package lattice
 
 import (
 	"context"
+	"errors"
+	"testing"
+
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func Test_SynthesizeTargets(t *testing.T) {
@@ -249,7 +252,8 @@ func Test_PostSynthesize_Conditions(t *testing.T) {
 			err := synthesizer.PostSynthesize(ctx)
 
 			if tt.requeue {
-				assert.ErrorAs(t, err, &RetryErr)
+				var requeueNeededAfter *lattice_runtime.RequeueNeededAfter
+				assert.True(t, errors.As(err, &requeueNeededAfter))
 			} else {
 				assert.Nil(t, err)
 			}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -1,25 +1,20 @@
 package runtime
 
 import (
-	"errors"
 	"fmt"
 	"time"
-
-	"github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
 )
 
-type RetryError error
+const (
+	LATTICE_RETRY = "LATTICE_RETRY"
+)
 
-func NewRetryError() RetryError {
-	return RetryError(errors.New(lattice.LATTICE_RETRY))
-}
-
-// NewRequeueNeeded constructs new RequeueError to
-// instruct controller-runtime to requeue the processing item without been logged as error.
-func NewRequeueNeeded(reason string) *RequeueNeeded {
-	return &RequeueNeeded{
-		reason: reason,
-	}
+// Retry errors caused by Lattice APIs which need high requeuAfter seconds
+func NewRetryError() *RequeueNeededAfter {
+	return NewRequeueNeededAfter(
+		LATTICE_RETRY,
+		time.Second*10,
+	)
 }
 
 // NewRequeueNeededAfter constructs new RequeueNeededAfter to
@@ -29,23 +24,6 @@ func NewRequeueNeededAfter(reason string, duration time.Duration) *RequeueNeeded
 		reason:   reason,
 		duration: duration,
 	}
-}
-
-var _ error = &RequeueNeeded{}
-
-// An error to instruct controller-runtime to requeue the processing item without been logged as error.
-// This should be used when a "error condition" occurrence is sort of expected and can be resolved by retry.
-// e.g. a dependency haven't been fulfilled yet.
-type RequeueNeeded struct {
-	reason string
-}
-
-func (e *RequeueNeeded) Reason() string {
-	return e.reason
-}
-
-func (e *RequeueNeeded) Error() string {
-	return fmt.Sprintf("requeue needed: %v", e.reason)
 }
 
 var _ error = &RequeueNeededAfter{}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -9,7 +9,7 @@ const (
 	LATTICE_RETRY = "LATTICE_RETRY"
 )
 
-// Retry errors caused by Lattice APIs which need high requeuAfter seconds
+// Retry errors caused by Lattice APIs which need high requeueAfter seconds
 func NewRetryError() *RequeueNeededAfter {
 	return NewRequeueNeededAfter(
 		LATTICE_RETRY,

--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -2,8 +2,6 @@ package runtime
 
 import (
 	"errors"
-	"fmt"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -14,21 +12,10 @@ func HandleReconcileError(err error) (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	retryErr := NewRetryError()
-	if errors.As(err, &retryErr) {
-		return ctrl.Result{RequeueAfter: time.Second * 20}, nil
-	}
-
 	var requeueNeededAfter *RequeueNeededAfter
 	if errors.As(err, &requeueNeededAfter) {
 		return ctrl.Result{RequeueAfter: requeueNeededAfter.Duration()}, nil
 	}
 
-	var requeueNeeded *RequeueNeeded
-	if errors.As(err, &requeueNeeded) {
-		fmt.Print("requeue", "reason", requeueNeeded.Reason())
-		return ctrl.Result{Requeue: true}, nil
-	}
-
-	return ctrl.Result{RequeueAfter: time.Minute * 10}, err
+	return ctrl.Result{}, err
 }

--- a/pkg/runtime/reconcile_test.go
+++ b/pkg/runtime/reconcile_test.go
@@ -1,0 +1,42 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Test_NilError(t *testing.T) {
+	result, err := HandleReconcileError(nil)
+
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.NoError(t, err)
+}
+
+func Test_LatticeRetryError(t *testing.T) {
+	retryErr := NewRetryError()
+	result, err := HandleReconcileError(retryErr)
+
+	assert.Equal(t, ctrl.Result{RequeueAfter: time.Second * 10}, result)
+	assert.NoError(t, err)
+}
+
+func Test_RequeueNeededAfter(t *testing.T) {
+	requeueErr := NewRequeueNeededAfter("test reason", time.Minute*5)
+	result, err := HandleReconcileError(requeueErr)
+
+	assert.Equal(t, ctrl.Result{RequeueAfter: time.Minute * 5}, result)
+	assert.NoError(t, err)
+}
+
+func Test_GenericError(t *testing.T) {
+	genericErr := errors.New("generic error")
+	result, err := HandleReconcileError(genericErr)
+
+	assert.Equal(t, ctrl.Result{}, result)
+	assert.Error(t, err)
+	assert.Equal(t, "generic error", err.Error())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
Cleanup and Fix
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fix `HandleReconcileError` function to enable exponential backoff.
Incase of transient errors from lattice apis keep static 10 seconds delay. 

> [Exponential backoff](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go#L116) is problematic here because for operations like target group deletion where target draining takes time, this results in unnecessarily long delays in reconciliation. 


**What does this PR do / Why do we need it**:
According to the [docs](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.22.1/pkg/reconcile)
```
 If the returned error is non-nil:
       the Result is ignored and the request will requeued using exponential backoff unless error is a terminal error
 If the error is nil:
      the returned Result has a non-zero result RequeueAfter, the request will be requeued after the specified duration.
 
```

- Cleanup deprecated `Requeue`
- Remove returning `Result` if the returned error is non-nil
- In [reconcile.go](https://github.com/aws/aws-application-networking-k8s/blob/main/pkg/runtime/reconcile.go#L18) we check if err is of type `RetryError` but since [RetryError](https://github.com/aws/aws-application-networking-k8s/blob/main/pkg/runtime/errors.go#L11) is just an alias for err type, all error types satisfy that if condition which leads to 20 second requeue delay for all errors. Refactored `NewRetryError` function to return `RequeueNeededAfter` error type instead.
- Remove [`RetryErr`](https://github.com/aws/aws-application-networking-k8s/blob/main/pkg/deploy/lattice/error.go#L9) which created err with `Lattice_Retry` error message with `NewRetryError` function call which returns a custom error type to fix type comparisons. 



**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
https://github.com/aws/aws-application-networking-k8s/issues/462

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
make `presubmit` and `make e2e-test` run successfully.

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->
N/A

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.