### PR TITLE
Update dependabot to install dependencies

### DIFF
--- a/.github/workflows/dependabot-make-presubmit.yml
+++ b/.github/workflows/dependabot-make-presubmit.yml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.x'
+
+      - name: Install dependencies
+        run: |
+          go install github.com/golang/mock/mockgen@v1.6.0
+          go install sigs.k8s.io/kustomize/kustomize/v5@v5.6.0
+          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220421205612-c162794a9b12
+          go install github.com/mattn/goveralls@b031368
           
       - name: Run make presubmit
         run: |


### PR DESCRIPTION
Small PR to address [these failures](https://github.com/aws/aws-application-networking-k8s/actions/runs/17906247757/job/50907838993?pr=821) when dependabot attempts to run:

```
...
mocks/controller-runtime/client/generate.go:3: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/aws/cloud.go:24: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/aws/services/tagging.go:15: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/deploy/externaldns/dnsendpoint_manager.go:20: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/deploy/lattice/access_log_subscription_manager.go:16: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/gateway/model_build_lattice_service.go:21: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/k8s/finalizer.go:12: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/model/core/stack.go:15: running "mockgen": exec: "mockgen": executable file not found in $PATH
pkg/webhook/core/mutator.go:10: running "mockgen": exec: "mockgen": executable file not found in $PATH
make: *** [Makefile:61: vet] Error 1
Error: Process completed with exit code 2.
...
```