### PR TITLE
Update dependabot to install golangci

### DIFF
--- a/.github/workflows/dependabot-make-presubmit.yml
+++ b/.github/workflows/dependabot-make-presubmit.yml
@@ -32,6 +32,7 @@ jobs:
           go install sigs.k8s.io/kustomize/kustomize/v5@v5.6.0
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220421205612-c162794a9b12
           go install github.com/mattn/goveralls@b031368
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
           
       - name: Run make presubmit
         run: |


### PR DESCRIPTION
This addresses the following failure [here](https://github.com/aws/aws-application-networking-k8s/actions/runs/18043646499/job/51348928465?pr=821) that prevents dependabot from making valid PRs:
```
Error: golangci-lint is not installed. Please run the 'make setup'
```