### PR TITLE
Remove port configuration from health checks

### DIFF
--- a/docs/guides/getstarted.md
+++ b/docs/guides/getstarted.md
@@ -329,6 +329,7 @@ spec:
     healthyThresholdCount: 2
     unhealthyThresholdCount: 3
     path: "/health"
+    port: 8090
     protocol: HTTP
     protocolVersion: HTTP1
     statusMatch: "200-299"


### PR DESCRIPTION
Removed the port configuration from health check settings to make the example work again. We can either remove it or keep it around, but it should be port 8090 in that case

**What type of PR is this?**
documentation

**Which issue does this PR fix**:
The health check doesn't work

**What does this PR do / Why do we need it**:
Update the health check by removing the port to make it target the workload port (which works)

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
Follow the multi-cluster guide

**Testing done on this change**:
<img width="970" height="247" alt="Screenshot 2026-01-22 at 11 48 07" src="https://github.com/user-attachments/assets/4ced04ab-5564-4a9a-b63d-32be6dffdc27" />

<img width="973" height="293" alt="Screenshot 2026-01-22 at 11 48 22" src="https://github.com/user-attachments/assets/f0196547-0c19-40e2-be7c-fd52f475be84" />

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
no

```release-note

```

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.