### PR TITLE
fix: rebuild Gateway listener status from spec to remove stale entries

### DIFF
--- a/pkg/controllers/gateway_controller_test.go
+++ b/pkg/controllers/gateway_controller_test.go
@@ -1,0 +1,159 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestUpdateGWListenerStatus_RemovesStaleListeners(t *testing.T) {
+	scheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(scheme)
+	gwv1.Install(scheme)
+	gwv1alpha2.Install(scheme)
+	addOptionalCRDs(scheme)
+
+	tests := []struct {
+		name                  string
+		gatewaySpec           gwv1.GatewaySpec
+		initialStatus         gwv1.GatewayStatus
+		expectedListenerCount int
+		expectedListenerNames []gwv1.SectionName
+	}{
+		{
+			name: "removes deleted listener from status",
+			gatewaySpec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: gwv1.HTTPProtocolType,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Kinds: []gwv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						},
+					},
+				},
+			},
+			initialStatus: gwv1.GatewayStatus{
+				Listeners: []gwv1.ListenerStatus{
+					{Name: "http", AttachedRoutes: 0},
+					{Name: "https", AttachedRoutes: 0},
+				},
+			},
+			expectedListenerCount: 1,
+			expectedListenerNames: []gwv1.SectionName{"http"},
+		},
+		{
+			name: "removes multiple deleted listeners",
+			gatewaySpec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: gwv1.HTTPProtocolType,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Kinds: []gwv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						},
+					},
+				},
+			},
+			initialStatus: gwv1.GatewayStatus{
+				Listeners: []gwv1.ListenerStatus{
+					{Name: "http", AttachedRoutes: 0},
+					{Name: "https", AttachedRoutes: 0},
+					{Name: "grpc", AttachedRoutes: 0},
+				},
+			},
+			expectedListenerCount: 1,
+			expectedListenerNames: []gwv1.SectionName{"http"},
+		},
+		{
+			name: "preserves all listeners when none deleted",
+			gatewaySpec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: gwv1.HTTPProtocolType,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Kinds: []gwv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						},
+					},
+					{
+						Name:     "https",
+						Port:     443,
+						Protocol: gwv1.HTTPSProtocolType,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Kinds: []gwv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+						},
+					},
+				},
+			},
+			initialStatus: gwv1.GatewayStatus{
+				Listeners: []gwv1.ListenerStatus{
+					{Name: "http", AttachedRoutes: 2},
+					{Name: "https", AttachedRoutes: 1},
+				},
+			},
+			expectedListenerCount: 2,
+			expectedListenerNames: []gwv1.SectionName{"http", "https"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			gw := &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gateway",
+					Namespace: "default",
+				},
+				Spec:   tt.gatewaySpec,
+				Status: tt.initialStatus,
+			}
+
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(gw).
+				WithStatusSubresource(gw).
+				Build()
+
+			err := UpdateGWListenerStatus(ctx, k8sClient, gw)
+			assert.NoError(t, err)
+
+			updatedGw := &gwv1.Gateway{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-gateway",
+				Namespace: "default",
+			}, updatedGw)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expectedListenerCount, len(updatedGw.Status.Listeners))
+
+			actualNames := make([]gwv1.SectionName, len(updatedGw.Status.Listeners))
+			for i, listener := range updatedGw.Status.Listeners {
+				actualNames[i] = listener.Name
+			}
+
+			for _, expectedName := range tt.expectedListenerNames {
+				assert.Contains(t, actualNames, expectedName)
+			}
+
+			for _, actualName := range actualNames {
+				assert.Contains(t, tt.expectedListenerNames, actualName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a listener is removed from Gateway.Spec.Listeners, it incorrectly persisted in Gateway.Status.Listeners. The previous merge-based approach in `UpdateGWListenerStatus` only updated or appended entries, never removing stale ones.

## Solution

Replaced the merge-or-append pattern with a rebuild-from-spec pattern. The function now builds a fresh listener status list from the current spec on each reconciliation, ensuring status always accurately reflects the current spec.

## Changes

- **`pkg/controllers/gateway_controller.go`**: `UpdateGWListenerStatus()` now rebuilds listener status from scratch instead of merging with existing status.
- **`pkg/controllers/gateway_controller_test.go`** (new): Adds unit test with 3 cases:
  - Removes single deleted listener from status
  - Removes multiple deleted listeners from status
  - Preserves all listeners when none deleted

## Testing

```
go test ./pkg/controllers -run TestUpdateGWListenerStatus -v
--- PASS: TestUpdateGWListenerStatus_RemovesStaleListeners (0.08s)
    --- PASS: removes_deleted_listener_from_status (0.07s)
    --- PASS: removes_multiple_deleted_listeners (0.00s)
    --- PASS: preserves_all_listeners_when_none_deleted (0.00s)
PASS
```

All existing tests continue to pass with no regressions.