### PR TITLE
Fix brew package check in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ main() {
 }
 
 installOrUpdatePackage() {
-    if brew list --versions | grep -q "${1}"; then
+    if brew list "$1" &>/dev/null; then
         read -p "${1} is already installed, do you want to update? (Y/N): " update_package
         if [[ $update_package == 'Y' || $update_package == 'y' ]]; then
             echo "Updating ${1}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

In `installOrUpdatePackage`, the package check uses grep to find existing packages, which can incorrectly match packages whose names contain the search term as a substring (e.g. checking for `go`, but grep finds `pango` library as a match)

**What does this PR do / Why do we need it**:

This fix uses `brew list <package>` which checks for an exact match

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

When running `bash ./scripts/setup.sh`:
```sh
go is already installed, do you want to update? (Y/N): y
Updating go
Error: go not installed
```

**Testing done on this change**:
```sh
Installing go
==> Fetching downloads for: go
✔︎ Bottle Manifest go (1.25.7_1)                       Downloaded    7.5KB/  7.5KB
✔︎ Bottle go (1.25.7_1)                                Downloaded   57.5MB/ 57.5MB
...
```

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a, just setup

**Does this PR introduce any user-facing change?**:
no

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
n/a, ran `make setup` and everything works normally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.