### PR TITLE
ci(dependabot): ignore k8s deps and group other upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,18 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      # Manage these manually — they must be upgraded in lockstep and often contain breaking changes
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "sigs.k8s.io/gateway-api"
+      # Still ignore patch-only bumps for everything else
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -19,8 +29,16 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      - dependency-name: "sigs.k8s.io/gateway-api"
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
k8s dependencies need to be upgraded all at once, so this change removes them from dependabot. Other upgrades will be grouped to minimize noise

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
n/a

**Testing done on this change**:
n/a, just CI

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a

**Does this PR introduce any user-facing change?**:
no

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.