### PR TITLE
make ServiceNetwork CRD optional

### DIFF
--- a/cmd/aws-application-networking-k8s/main.go
+++ b/cmd/aws-application-networking-k8s/main.go
@@ -285,9 +285,15 @@ func main() {
 		setupLog.Fatalf("vpc association policy controller setup failed: %s", err)
 	}
 
-	err = controllers.RegisterServiceNetworkController(ctrlLog.Named("service-network"), cloud, finalizerManager, mgr)
-	if err != nil {
-		setupLog.Fatalf("service network controller setup failed: %s", err)
+	if ok, err := k8s.IsGVKSupported(mgr, anv1alpha1.GroupVersion.String(), "ServiceNetwork"); err != nil {
+		setupLog.Fatalf("error checking ServiceNetwork CRD: %s", err)
+	} else if ok {
+		err = controllers.RegisterServiceNetworkController(ctrlLog.Named("service-network"), cloud, finalizerManager, mgr)
+		if err != nil {
+			setupLog.Fatalf("service network controller setup failed: %s", err)
+		}
+	} else {
+		setupLog.Infof("ServiceNetwork CRD not installed, skipping controller registration")
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/docs/api-types/service-network.md
+++ b/docs/api-types/service-network.md
@@ -8,6 +8,16 @@ It provides a Kubernetes native way to create and delete service networks, as an
 The ServiceNetwork CRD only manages service network creation and deletion. VPC association is managed by
 [VpcAssociationPolicy](vpc-association-policy.md) and IAM auth is managed by [IAMAuthPolicy](iam-auth-policy.md).
 
+### Prerequisites
+
+The ServiceNetwork CRD is optional. To use it, install the CRD:
+
+```bash
+kubectl apply -f config/crds/bases/application-networking.k8s.aws_servicenetworks.yaml
+```
+
+If the CRD is not installed, the controller will start normally and skip ServiceNetwork functionality.
+
 ### Key Behaviors
 
 - **Cluster scoped**: Matches VPC Lattice's account level resource model. The service network name comes from `.metadata.name`.

--- a/docs/contributing/developer.md
+++ b/docs/contributing/developer.md
@@ -62,6 +62,7 @@ kubectl apply -f config/crds/bases/application-networking.k8s.aws_targetgrouppol
 kubectl apply -f config/crds/bases/application-networking.k8s.aws_vpcassociationpolicies.yaml
 kubectl apply -f config/crds/bases/application-networking.k8s.aws_accesslogpolicies.yaml
 kubectl apply -f config/crds/bases/application-networking.k8s.aws_iamauthpolicies.yaml
+kubectl apply -f config/crds/bases/application-networking.k8s.aws_servicenetworks.yaml  # optional
 ```
 
 When e2e tests are terminated during execution, it might break clean-up stage and resources will leak. To delete dangling resources manually use cleanup script:


### PR DESCRIPTION
Testing

- Before change without ServiceNetwork CRD
```
2026-04-15T23:43:03.210Z	ERROR	runtime.controller-runtime.source.Kind	wait/loop.go:53	if kind is a CRD, it should be installed before calling Start	{"kind": "ServiceNetwork.application-networking.k8s.aws", "error": "no matches for kind \"ServiceNetwork\" in version \"application-networking.k8s.aws/v1alpha1\""}
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1
	/home/vbedi/go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/loop.go:53
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	/home/vbedi/go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/loop.go:54
k8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel
	/home/vbedi/go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/poll.go:33
sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1
```

- After change with ServiceNetwork CRD
```
REGION=us-west-2 CLUSTER_VPC_ID=vpc-fake CLUSTER_NAME=test AWS_ACCOUNT_ID=123456789012 DEV_MODE=true go run cmd/aws-application-networking-k8s/main.go
2026-04-15T23:39:53.904Z	INFO	setup	runtime/proc.go:290	init config	{"VpcId": "vpc-fake", "Region": "us-west-2", "AccountId": "123456789012", "DefaultServiceNetwork": "", "ClusterName": "test", "LogLevel": "info", "DisableTaggingServiceAPI": false}
2026-04-15T23:39:53.904Z	INFO	setup	runtime/proc.go:290	Webhook is disabled, value: ''
2026-04-15T23:39:53.926Z	INFO	setup	runtime/proc.go:290	ServiceNetwork CRD not installed, skipping controller registration
2026-04-15T23:39:53.926Z	INFO	setup	runtime/proc.go:290	starting manager
```