### PR TITLE
add user agent for all sdk calls

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"maps"
+
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
-	"maps"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/metrics"
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
@@ -64,6 +65,8 @@ func NewCloud(log gwlog.Logger, cfg CloudConfig, metricsRegisterer prometheus.Re
 	if err != nil {
 		return nil, err
 	}
+
+	addUserAgentHandler(sess)
 
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		if r.Error != nil {
@@ -236,4 +239,9 @@ func (c *defaultCloud) isOwner(managedBy string) bool {
 
 func getManagedByTag(cfg CloudConfig) string {
 	return fmt.Sprintf("%s/%s/%s", cfg.AccountId, cfg.ClusterName, cfg.VpcId)
+}
+
+// addUserAgentHandler appends the controller identifier to the User-Agent header on all AWS API calls.
+func addUserAgentHandler(sess *session.Session) {
+	sess.Handlers.Build.PushBack(request.MakeAddToUserAgentFreeFormHandler("amazon-vpc-lattice-gateway-api-controller"))
 }

--- a/pkg/aws/cloud_test.go
+++ b/pkg/aws/cloud_test.go
@@ -1,16 +1,16 @@
 package aws
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
-
-	"context"
-	"fmt"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 )
@@ -194,4 +194,18 @@ func Test_TryOwnFromTags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddUserAgentHandler(t *testing.T) {
+	sess, err := session.NewSession(&aws.Config{Region: aws.String("us-east-1")})
+	assert.NoError(t, err)
+
+	addUserAgentHandler(sess)
+
+	svc := vpclattice.New(sess)
+	req, _ := svc.ListServicesRequest(&vpclattice.ListServicesInput{})
+	req.Build()
+
+	ua := req.HTTPRequest.Header.Get("User-Agent")
+	assert.Contains(t, ua, "amazon-vpc-lattice-gateway-api-controller")
 }


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
Adds a custom user agent suffic (`amazon-vpc-lattice-gateway-api-controller`) to all AWS API calls made by the controller. This allows identifying traffic originating from this controller for debugging and metrics purposes.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
N/A

**Testing done on this change**:
Unit test added and passing (`TestAddUserAgentHandler`)

**Automation added to e2e**:
N/A

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No breaking changes.

**Does this PR introduce any user-facing change?**:
No.

release-note
NONE

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
N/A, no e2e tests impacted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.