### PR TITLE
feat: extend drift detection to IAMAuthPolicy and VpcAssociationPolicy

### DIFF
--- a/docs/guides/drift-detection.md
+++ b/docs/guides/drift-detection.md
@@ -15,12 +15,12 @@ When drift detection is enabled, the controller schedules a periodic re-reconcil
 - **Targets** (pod registrations) — re-registered if deregistered out-of-band
 - **Service network service associations** — restored if removed
 - **Access log subscriptions** — restored if removed
+- **IAM auth policies** — restored if deleted, `AWS_IAM` auth type re-applied if reverted
+- **VPC associations** — recreated if deleted, security-group drift reverted
 
 The following resources are **not** currently covered by drift detection:
 
 - **Service networks** — the gateway controller checks for existence but does not create or modify service networks
-- **IAM auth policies** — uses a different reconciliation path
-- **VPC association policies** — uses a different reconciliation path
 
 A random jitter of 0-20% is added to each requeue interval to prevent all resources from reconciling at the same instant (thundering herd), particularly at controller startup.
 
@@ -72,6 +72,10 @@ Each periodic reconciliation makes multiple VPC Lattice API calls per resource (
 
 ### Controller coverage
 
-Drift detection applies to all controllers that use the shared `HandleReconcileError` function. The route controller provides the most comprehensive coverage, reconciling services, listeners, rules, target groups, targets, and service network associations on each pass. The access log policy controller also benefits, restoring access log subscriptions.
+Drift detection applies to all controllers that use the shared `HandleReconcileError` function. The route controller provides the most comprehensive coverage, reconciling services, listeners, rules, target groups, targets, and service network associations on each pass. The access log policy controller restores access log subscriptions. The IAM auth policy controller restores deleted auth policies and re-applies the `AWS_IAM` auth type if reverted. The VPC association policy controller recreates the VPC association if deleted and reverts security-group drift.
 
-The gateway controller receives periodic requeues but only verifies service network existence — it does not create or modify service networks. The IAM auth policy and VPC association policy controllers use a different reconciliation path and are not currently covered.
+The gateway controller receives periodic requeues but only verifies service network existence — it does not create or modify service networks.
+
+### Policy controllers and target-resource lifecycle
+
+Drift detection on the IAM auth policy and VPC association policy controllers operates on the policy-managed Lattice resource (auth policy, SNVA). It does not extend to the underlying service network or service that the policy targets — those are owned by other controllers or by the user. If the target resource is deleted out-of-band, the policy controller will surface a status condition rather than recreate the target.

--- a/pkg/controllers/iamauthpolicy_controller.go
+++ b/pkg/controllers/iamauthpolicy_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	policy "github.com/aws/aws-application-networking-k8s/pkg/k8s/policyhelper"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	corev1 "k8s.io/api/core/v1"
@@ -89,10 +91,26 @@ func (c *IAMAuthPolicyController) Reconcile(ctx context.Context, req ctrl.Reques
 		gwlog.EndReconcileTrace(ctx, c.log)
 	}()
 
+	recErr := c.reconcile(ctx, req)
+	if recErr != nil {
+		c.log.Infow(ctx, "reconcile error", "name", req.Name, "message", recErr.Error())
+	}
+	res, retryErr := lattice_runtime.HandleReconcileError(recErr)
+	if res.RequeueAfter != 0 {
+		c.log.Infow(ctx, "requeue request", "name", req.Name, "requeueAfter", res.RequeueAfter)
+	} else if retryErr != nil && !errors.Is(retryErr, reconcile.TerminalError(nil)) {
+		c.log.Infow(ctx, "requeue request using exponential backoff", "name", req.Name)
+	} else if retryErr == nil {
+		c.log.Infow(ctx, "reconciled", "name", req.Name)
+	}
+	return res, retryErr
+}
+
+func (c *IAMAuthPolicyController) reconcile(ctx context.Context, req ctrl.Request) error {
 	k8sPolicy := &anv1alpha1.IAMAuthPolicy{}
 	err := c.client.Get(ctx, req.NamespacedName, k8sPolicy)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return client.IgnoreNotFound(err)
 	}
 
 	c.eventRecorder.Event(k8sPolicy, corev1.EventTypeNormal, k8s.ReconcilingEvent, "Started reconciling")
@@ -100,20 +118,19 @@ func (c *IAMAuthPolicyController) Reconcile(ctx context.Context, req ctrl.Reques
 	c.log.Infow(ctx, "reconcile IAM policy", "req", req, "targetRef", k8sPolicy.Spec.TargetRef)
 	isDelete := !k8sPolicy.DeletionTimestamp.IsZero()
 
-	var res ctrl.Result
 	if isDelete {
-		res, err = c.reconcileDelete(ctx, k8sPolicy)
+		err = c.reconcileDelete(ctx, k8sPolicy)
 	} else {
-		res, err = c.reconcileUpsert(ctx, k8sPolicy)
+		err = c.reconcileUpsert(ctx, k8sPolicy)
 	}
 	if err != nil {
 		c.eventRecorder.Event(k8sPolicy, corev1.EventTypeWarning, k8s.FailedReconcileEvent, fmt.Sprintf("Reconcile failed: %s", err))
-		return ctrl.Result{}, err
+		return err
 	}
 
 	err = c.client.Update(ctx, k8sPolicy)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	c.eventRecorder.Event(k8sPolicy, corev1.EventTypeNormal, k8s.ReconciledEvent, "Successfully reconciled")
@@ -123,10 +140,10 @@ func (c *IAMAuthPolicyController) Reconcile(ctx context.Context, req ctrl.Reques
 		"targetRef", k8sPolicy.Spec.TargetRef,
 		"isDeleted", isDelete,
 	)
-	return res, nil
+	return nil
 }
 
-func (c *IAMAuthPolicyController) reconcileDelete(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (ctrl.Result, error) {
+func (c *IAMAuthPolicyController) reconcileDelete(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) error {
 	err := c.ph.ValidateTargetRef(ctx, k8sPolicy)
 	if err == nil {
 		existingModel, _ := c.getLatticeAnnotation(k8sPolicy)
@@ -134,35 +151,35 @@ func (c *IAMAuthPolicyController) reconcileDelete(ctx context.Context, k8sPolicy
 
 		_, err := c.pm.Delete(ctx, modelPolicy)
 		if err != nil {
-			return ctrl.Result{}, services.IgnoreNotFound(err)
+			return services.IgnoreNotFound(err)
 		}
 	}
 	err = c.handleLatticeResourceChange(ctx, k8sPolicy, model.IAMAuthPolicyStatus{})
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 	c.removeFinalizer(k8sPolicy)
-	return ctrl.Result{}, nil
+	return nil
 }
 
-func (c *IAMAuthPolicyController) reconcileUpsert(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) (ctrl.Result, error) {
+func (c *IAMAuthPolicyController) reconcileUpsert(ctx context.Context, k8sPolicy *anv1alpha1.IAMAuthPolicy) error {
 	reason, err := c.ph.ValidateAndUpdateCondition(ctx, k8sPolicy)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 	if reason != policy.ReasonAccepted {
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	resourceName, err := c.targetRefToResourceName(ctx, k8sPolicy)
 	if err != nil {
 		if k8s.IsInvalidServiceNameOverrideError(err) {
 			if statusErr := c.ph.UpdateAcceptedCondition(ctx, k8sPolicy, gwv1.PolicyReasonInvalid, err.Error()); statusErr != nil {
-				return ctrl.Result{}, statusErr
+				return statusErr
 			}
-			return ctrl.Result{}, nil
+			return nil
 		}
-		return ctrl.Result{}, err
+		return err
 	}
 
 	modelPolicy := model.NewIAMAuthPolicy(k8sPolicy, resourceName)
@@ -170,18 +187,18 @@ func (c *IAMAuthPolicyController) reconcileUpsert(ctx context.Context, k8sPolicy
 	c.addFinalizer(k8sPolicy)
 	err = c.client.Update(ctx, k8sPolicy)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 	statusPolicy, err := c.pm.Put(ctx, modelPolicy)
 	if err != nil {
-		return reconcile.Result{}, services.IgnoreNotFound(err)
+		return services.IgnoreNotFound(err)
 	}
 	err = c.handleLatticeResourceChange(ctx, k8sPolicy, statusPolicy)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 	c.updateLatticeAnnotaion(k8sPolicy, statusPolicy.ResourceId, modelPolicy.Type, modelPolicy.Name)
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func (c *IAMAuthPolicyController) removeFinalizer(k8sPolicy *anv1alpha1.IAMAuthPolicy) {

--- a/pkg/controllers/vpcassociationpolicy_controller.go
+++ b/pkg/controllers/vpcassociationpolicy_controller.go
@@ -2,12 +2,13 @@ package controllers
 
 import (
 	"context"
-	"time"
+	"errors"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
@@ -17,6 +18,7 @@ import (
 	deploy "github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	policy "github.com/aws/aws-application-networking-k8s/pkg/k8s/policyhelper"
+	lattice_runtime "github.com/aws/aws-application-networking-k8s/pkg/runtime"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 )
@@ -61,10 +63,26 @@ func (c *vpcAssociationPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 		gwlog.EndReconcileTrace(ctx, c.log)
 	}()
 
+	recErr := c.reconcile(ctx, req)
+	if recErr != nil {
+		c.log.Infow(ctx, "reconcile error", "name", req.Name, "message", recErr.Error())
+	}
+	res, retryErr := lattice_runtime.HandleReconcileError(recErr)
+	if res.RequeueAfter != 0 {
+		c.log.Infow(ctx, "requeue request", "name", req.Name, "requeueAfter", res.RequeueAfter)
+	} else if retryErr != nil && !errors.Is(retryErr, reconcile.TerminalError(nil)) {
+		c.log.Infow(ctx, "requeue request using exponential backoff", "name", req.Name)
+	} else if retryErr == nil {
+		c.log.Infow(ctx, "reconciled", "name", req.Name)
+	}
+	return res, retryErr
+}
+
+func (c *vpcAssociationPolicyReconciler) reconcile(ctx context.Context, req ctrl.Request) error {
 	k8sPolicy := &anv1alpha1.VpcAssociationPolicy{}
 	err := c.client.Get(ctx, req.NamespacedName, k8sPolicy)
 	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return client.IgnoreNotFound(err)
 	}
 	c.log.Infow(ctx, "reconcile", "req", req, "targetRef", k8sPolicy.Spec.TargetRef)
 
@@ -77,8 +95,7 @@ func (c *vpcAssociationPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 		err = c.upsert(ctx, k8sPolicy)
 	}
 	if err != nil {
-		c.log.Infof(ctx, "reconcile error, retry in 30 sec: %s", err)
-		return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+		return err
 	}
 
 	c.log.Infow(ctx, "reconciled vpc association policy",
@@ -86,7 +103,7 @@ func (c *vpcAssociationPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 		"targetRef", k8sPolicy.Spec.TargetRef,
 		"isDeleted", isDelete,
 	)
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func (c *vpcAssociationPolicyReconciler) upsert(ctx context.Context, k8sPolicy *anv1alpha1.VpcAssociationPolicy) error {

--- a/pkg/controllers/vpcassociationpolicy_controller_test.go
+++ b/pkg/controllers/vpcassociationpolicy_controller_test.go
@@ -5,16 +5,12 @@ import (
 	"testing"
 	"time"
 
-	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
-	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
-	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	deploy "github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
+	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	policy "github.com/aws/aws-application-networking-k8s/pkg/k8s/policyhelper"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,14 +23,15 @@ import (
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-// Test_IAMAuthPolicy_PeriodicRequeue verifies that on a successful reconcile of
-// an accepted IAMAuthPolicy, the controller flows through HandleReconcileError
-// and schedules a periodic requeue at the configured drift-detection interval.
+// Test_VpcAssociationPolicy_PeriodicRequeue verifies that on a successful
+// reconcile of an accepted VpcAssociationPolicy, the controller flows through
+// HandleReconcileError and schedules a periodic requeue at the configured
+// drift-detection interval.
 //
 // This protects against future regressions where the reconcile flow stops
 // going through HandleReconcileError, which would silently disable drift
-// detection for IAMAuthPolicy.
-func Test_IAMAuthPolicy_PeriodicRequeue(t *testing.T) {
+// detection for VpcAssociationPolicy.
+func Test_VpcAssociationPolicy_PeriodicRequeue(t *testing.T) {
 	originalInterval := config.ReconcileDefaultResyncInterval
 	defer func() { config.ReconcileDefaultResyncInterval = originalInterval }()
 	interval := 5 * time.Minute
@@ -59,13 +56,12 @@ func Test_IAMAuthPolicy_PeriodicRequeue(t *testing.T) {
 		},
 	}
 
-	iap := &anv1alpha1.IAMAuthPolicy{
+	vap := &anv1alpha1.VpcAssociationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-policy",
 			Namespace: "test-namespace",
 		},
-		Spec: anv1alpha1.IAMAuthPolicySpec{
-			Policy: `{"Version":"2012-10-17","Statement":[]}`,
+		Spec: anv1alpha1.VpcAssociationPolicySpec{
 			TargetRef: &gwv1alpha2.NamespacedPolicyTargetReference{
 				Group: gwv1.GroupName,
 				Kind:  "Gateway",
@@ -76,40 +72,24 @@ func Test_IAMAuthPolicy_PeriodicRequeue(t *testing.T) {
 
 	k8sClient := testclient.NewClientBuilder().
 		WithScheme(k8sScheme).
-		WithObjects(iap, gw).
-		WithStatusSubresource(&anv1alpha1.IAMAuthPolicy{}).
+		WithObjects(vap, gw).
+		WithStatusSubresource(&anv1alpha1.VpcAssociationPolicy{}).
 		Build()
 
-	mockLattice := mocks.NewMockLattice(c)
-	mockCloud := pkg_aws.NewMockCloud(c)
-	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+	// Stub the manager so UpsertVpcAssociation returns a successful ARN.
+	mockSNManager := deploy.NewMockServiceNetworkManager(c)
+	mockSNManager.EXPECT().UpsertVpcAssociation(gomock.Any(), "test-gateway", gomock.Any(), gomock.Any()).Return(
+		"arn:aws:vpc-lattice:us-west-2:123456789012:servicenetworkvpcassociation/snva-1234", nil)
 
-	// Stub the manager's Lattice calls so Put() returns a successful status.
-	// For a Gateway target, Put() routes through putSn and calls:
-	//   FindServiceNetwork -> PutAuthPolicyWithContext -> UpdateServiceNetworkWithContext
-	mockLattice.EXPECT().FindServiceNetwork(gomock.Any(), "test-gateway").Return(
-		&mocks.ServiceNetworkInfo{
-			SvcNetwork: vpclattice.ServiceNetworkSummary{
-				Id:   aws.String("sn-1234"),
-				Name: aws.String("test-gateway"),
-				Arn:  aws.String("arn:aws:vpc-lattice:us-west-2:123456789012:servicenetwork/sn-1234"),
-			},
-		}, nil)
-	mockLattice.EXPECT().PutAuthPolicyWithContext(gomock.Any(), gomock.Any()).Return(
-		&vpclattice.PutAuthPolicyOutput{}, nil)
-	mockLattice.EXPECT().UpdateServiceNetworkWithContext(gomock.Any(), gomock.Any()).Return(
-		&vpclattice.UpdateServiceNetworkOutput{}, nil)
+	mockFinalizer := k8s.NewMockFinalizerManager(c)
+	mockFinalizer.EXPECT().AddFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	mockEventRecorder := mock_client.NewMockEventRecorder(c)
-	mockEventRecorder.EXPECT().Event(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-
-	r := &IAMAuthPolicyController{
-		log:           gwlog.FallbackLogger,
-		client:        k8sClient,
-		pm:            deploy.NewIAMAuthPolicyManager(mockCloud),
-		ph:            policy.NewIAMAuthPolicyHandler(gwlog.FallbackLogger, k8sClient),
-		cloud:         mockCloud,
-		eventRecorder: mockEventRecorder,
+	r := &vpcAssociationPolicyReconciler{
+		log:              gwlog.FallbackLogger,
+		client:           k8sClient,
+		finalizerManager: mockFinalizer,
+		manager:          mockSNManager,
+		ph:               policy.NewVpcAssociationPolicyHandler(gwlog.FallbackLogger, k8sClient),
 	}
 
 	result, err := r.Reconcile(ctx, reconcile.Request{

--- a/test/suites/integration/drift_detection_test.go
+++ b/test/suites/integration/drift_detection_test.go
@@ -4,17 +4,24 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
+	"github.com/aws/aws-application-networking-k8s/pkg/controllers"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 var _ = Describe("Drift detection", Ordered, func() {
@@ -296,6 +303,344 @@ var _ = Describe("Drift detection", Ordered, func() {
 				deployment,
 				service,
 			)
+		}
+	})
+})
+
+var _ = Describe("IAMAuthPolicy Drift detection", Ordered, func() {
+	const (
+		driftPolicyName = "drift-iam-auth-policy"
+		driftAppName    = "drift-iam-auth"
+		// Same All-Allow document used in iamauthpolicy_test.go.
+		allowAllInvoke = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"vpc-lattice-svcs:Invoke","Resource":"*"}]}`
+	)
+
+	var (
+		deployment   *appsv1.Deployment
+		k8sService   *v1.Service
+		httpRoute    *gwv1.HTTPRoute
+		policy       *anv1alpha1.IAMAuthPolicy
+		latticeSvcId string
+		resourceId   string
+	)
+
+	BeforeAll(func() {
+		if config.ReconcileDefaultResyncInterval <= 0 {
+			Skip("RECONCILE_DEFAULT_RESYNC_SECONDS not set or 0, skipping drift detection tests")
+		}
+
+		deployment, k8sService = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:      driftAppName,
+			Namespace: k8snamespace,
+		})
+		httpRoute = testFramework.NewHttpRoute(testGateway, k8sService, "Service")
+		testFramework.ExpectCreated(ctx, deployment, k8sService, httpRoute)
+
+		// Wait for the Lattice service backing the route to be active.
+		latticeSvc := testFramework.GetVpcLatticeService(ctx, core.NewHTTPRoute(*httpRoute))
+		latticeSvcId = aws.StringValue(latticeSvc.Id)
+
+		// Create the IAMAuthPolicy targeting the route. The controller will
+		// flip the service's auth type to AWS_IAM and put the policy doc.
+		policy = &anv1alpha1.IAMAuthPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      driftPolicyName,
+				Namespace: k8snamespace,
+			},
+			Spec: anv1alpha1.IAMAuthPolicySpec{
+				Policy: allowAllInvoke,
+				TargetRef: &gwv1alpha2.NamespacedPolicyTargetReference{
+					Group: gwv1.GroupName,
+					Kind:  "HTTPRoute",
+					Name:  gwv1.ObjectName(httpRoute.Name),
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, policy)
+
+		// Wait for the policy to be Accepted and the resource-id annotation to
+		// be populated. After this point, the lattice auth policy doc is set
+		// and the service auth type is AWS_IAM.
+		Eventually(func(g Gomega) {
+			p := &anv1alpha1.IAMAuthPolicy{}
+			g.Expect(testFramework.Client.Get(ctx, client.ObjectKeyFromObject(policy), p)).To(Succeed())
+			g.Expect(GetPolicyStatusReason(p)).To(Equal(gwv1.PolicyReasonAccepted))
+			g.Expect(p.Annotations[controllers.IAMAuthPolicyAnnotationType]).To(Equal(model.ServiceType))
+			g.Expect(p.Annotations[controllers.IAMAuthPolicyAnnotationResId]).ToNot(BeEmpty())
+			resourceId = p.Annotations[controllers.IAMAuthPolicyAnnotationResId]
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+		// Sanity check: the annotation resource id is the lattice service id.
+		Expect(resourceId).To(Equal(latticeSvcId))
+	})
+
+	It("recreates an auth policy deleted out-of-band", func() {
+		Expect(resourceId).ToNot(BeEmpty())
+
+		// Sanity check: auth policy doc is set on the lattice service.
+		existing, err := testFramework.LatticeClient.GetAuthPolicy(
+			&vpclattice.GetAuthPolicyInput{ResourceIdentifier: &resourceId})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(aws.StringValue(existing.Policy)).To(Equal(allowAllInvoke))
+
+		// Delete the auth policy out-of-band.
+		_, err = testFramework.LatticeClient.DeleteAuthPolicy(
+			&vpclattice.DeleteAuthPolicyInput{ResourceIdentifier: &resourceId})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify deletion took effect. The Lattice GetAuthPolicy API may
+		// return either a not-found error or an output with an empty Policy
+		// when no policy is attached, so accept both.
+		deleted, _ := testFramework.LatticeClient.GetAuthPolicy(
+			&vpclattice.GetAuthPolicyInput{ResourceIdentifier: &resourceId})
+		Expect(aws.StringValue(deleted.Policy)).To(BeEmpty())
+
+		// Wait for drift detection to restore the auth policy.
+		timeout := 2*config.ReconcileDefaultResyncInterval + 60*time.Second
+		Eventually(func(g Gomega) {
+			out, err := testFramework.LatticeClient.GetAuthPolicy(
+				&vpclattice.GetAuthPolicyInput{ResourceIdentifier: &resourceId})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(aws.StringValue(out.Policy)).To(Equal(allowAllInvoke))
+		}).WithTimeout(timeout).WithPolling(15 * time.Second).Should(Succeed())
+	})
+
+	It("re-enables AWS_IAM auth type when flipped to NONE", func() {
+		Expect(latticeSvcId).ToNot(BeEmpty())
+
+		// Sanity check: service auth type is AWS_IAM.
+		svc, err := testFramework.LatticeClient.GetService(
+			&vpclattice.GetServiceInput{ServiceIdentifier: &latticeSvcId})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(aws.StringValue(svc.AuthType)).To(Equal(vpclattice.AuthTypeAwsIam))
+
+		// Flip the service auth type to NONE out-of-band.
+		_, err = testFramework.LatticeClient.UpdateService(&vpclattice.UpdateServiceInput{
+			ServiceIdentifier: &latticeSvcId,
+			AuthType:          aws.String(vpclattice.AuthTypeNone),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify the change took effect.
+		flipped, err := testFramework.LatticeClient.GetService(
+			&vpclattice.GetServiceInput{ServiceIdentifier: &latticeSvcId})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(aws.StringValue(flipped.AuthType)).To(Equal(vpclattice.AuthTypeNone))
+
+		// Wait for drift detection to restore AWS_IAM.
+		timeout := 2*config.ReconcileDefaultResyncInterval + 60*time.Second
+		Eventually(func(g Gomega) {
+			s, err := testFramework.LatticeClient.GetService(
+				&vpclattice.GetServiceInput{ServiceIdentifier: &latticeSvcId})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(aws.StringValue(s.AuthType)).To(Equal(vpclattice.AuthTypeAwsIam))
+		}).WithTimeout(timeout).WithPolling(15 * time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		// Order matters: delete the policy first so the controller can reset
+		// the lattice service's auth type before the route deletion tears the
+		// service down.
+		if policy != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, policy)
+		}
+		if httpRoute != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, httpRoute, deployment, k8sService)
+		}
+	})
+})
+
+var _ = Describe("VpcAssociationPolicy Drift detection", Ordered, func() {
+	const (
+		driftVapName      = "drift-vpc-association-policy"
+		driftVapSGName    = "k8s-test-drift-vap-sg"
+		driftVapSGAltName = "k8s-test-drift-vap-sg-alt"
+	)
+
+	var (
+		vap     *anv1alpha1.VpcAssociationPolicy
+		sgId    anv1alpha1.SecurityGroupId
+		altSgId anv1alpha1.SecurityGroupId
+	)
+
+	BeforeAll(func() {
+		if config.ReconcileDefaultResyncInterval <= 0 {
+			Skip("RECONCILE_DEFAULT_RESYNC_SECONDS not set or 0, skipping drift detection tests")
+		}
+
+		// Create two test security groups in the cluster VPC: one used by the
+		// VAP and one used to exercise SG drift out-of-band.
+		createSg, err := testFramework.Ec2Client.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
+			Description: aws.String(driftVapSGName),
+			GroupName:   aws.String(driftVapSGName),
+			VpcId:       aws.String(test.CurrentClusterVpcId),
+		})
+		Expect(err).To(BeNil())
+		sgId = anv1alpha1.SecurityGroupId(aws.StringValue(createSg.GroupId))
+
+		createAltSg, err := testFramework.Ec2Client.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
+			Description: aws.String(driftVapSGAltName),
+			GroupName:   aws.String(driftVapSGAltName),
+			VpcId:       aws.String(test.CurrentClusterVpcId),
+		})
+		Expect(err).To(BeNil())
+		altSgId = anv1alpha1.SecurityGroupId(aws.StringValue(createAltSg.GroupId))
+
+		// Create the VpcAssociationPolicy targeting the test gateway. The
+		// controller drives the SNVA to be active with our SG.
+		vap = &anv1alpha1.VpcAssociationPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      driftVapName,
+				Namespace: k8snamespace,
+			},
+			Spec: anv1alpha1.VpcAssociationPolicySpec{
+				TargetRef: &gwv1alpha2.NamespacedPolicyTargetReference{
+					Group:     gwv1.GroupName,
+					Kind:      "Gateway",
+					Name:      gwv1.ObjectName(testGateway.Name),
+					Namespace: lo.ToPtr(gwv1.Namespace(k8snamespace)),
+				},
+				SecurityGroupIds: []anv1alpha1.SecurityGroupId{sgId},
+				AssociateWithVpc: lo.ToPtr(true),
+			},
+		}
+		testFramework.ExpectCreated(ctx, vap)
+
+		// Wait for the SNVA to be active and to reflect the configured SG.
+		Eventually(func(g Gomega) {
+			associated, snva, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(err).To(BeNil())
+			g.Expect(associated).To(BeTrue())
+			out, err := testFramework.LatticeClient.GetServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: snva.Id,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(out.SecurityGroupIds).To(HaveLen(1))
+			g.Expect(aws.StringValue(out.SecurityGroupIds[0])).To(Equal(string(sgId)))
+		}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+	})
+
+	It("recreates the SNVA deleted out-of-band", func() {
+		// Capture the currently-active SNVA id.
+		associated, snva, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+		Expect(err).To(BeNil())
+		Expect(associated).To(BeTrue())
+		originalId := aws.StringValue(snva.Id)
+		Expect(originalId).ToNot(BeEmpty())
+
+		// Delete the SNVA out-of-band.
+		_, err = testFramework.LatticeClient.DeleteServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.DeleteServiceNetworkVpcAssociationInput{
+			ServiceNetworkVpcAssociationIdentifier: snva.Id,
+		})
+		Expect(err).To(BeNil())
+
+		// Wait for the original SNVA to be fully gone. Lattice does not
+		// expose a "DELETED" status: deletion completes when the SNVA no
+		// longer appears in the list of associations for this VPC.
+		Eventually(func(g Gomega) {
+			list, err := testFramework.LatticeClient.ListServiceNetworkVpcAssociationsAsList(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{
+				ServiceNetworkIdentifier: testServiceNetwork.Id,
+				VpcIdentifier:            aws.String(test.CurrentClusterVpcId),
+			})
+			g.Expect(err).To(BeNil())
+			for _, a := range list {
+				g.Expect(aws.StringValue(a.Id)).ToNot(Equal(originalId))
+			}
+		}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+		// Wait for drift detection to recreate an active SNVA with a new id.
+		timeout := 2*config.ReconcileDefaultResyncInterval + 60*time.Second
+		Eventually(func(g Gomega) {
+			associated, snva, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(err).To(BeNil())
+			g.Expect(associated).To(BeTrue())
+			g.Expect(aws.StringValue(snva.Id)).ToNot(Equal(originalId))
+		}).WithTimeout(timeout).WithPolling(15 * time.Second).Should(Succeed())
+	})
+
+	It("restores security groups drifted out-of-band", func() {
+		// Make sure the SNVA currently reflects the policy's SG. The previous
+		// test may have just recreated the SNVA, so wait for convergence.
+		var snvaId *string
+		Eventually(func(g Gomega) {
+			associated, snva, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+			g.Expect(err).To(BeNil())
+			g.Expect(associated).To(BeTrue())
+			out, err := testFramework.LatticeClient.GetServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: snva.Id,
+			})
+			g.Expect(err).To(BeNil())
+			ids := lo.Map(out.SecurityGroupIds, func(s *string, _ int) string { return aws.StringValue(s) })
+			g.Expect(ids).To(ConsistOf(string(sgId)))
+			snvaId = snva.Id
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+		Expect(snvaId).ToNot(BeNil())
+
+		// Drift the SG list out-of-band.
+		_, err := testFramework.LatticeClient.UpdateServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.UpdateServiceNetworkVpcAssociationInput{
+			ServiceNetworkVpcAssociationIdentifier: snvaId,
+			SecurityGroupIds:                       []*string{aws.String(string(altSgId))},
+		})
+		Expect(err).To(BeNil())
+
+		// Verify the drift took effect (the SNVA now reflects the alt SG).
+		Eventually(func(g Gomega) {
+			out, err := testFramework.LatticeClient.GetServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: snvaId,
+			})
+			g.Expect(err).To(BeNil())
+			ids := lo.Map(out.SecurityGroupIds, func(s *string, _ int) string { return aws.StringValue(s) })
+			g.Expect(ids).To(ConsistOf(string(altSgId)))
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+		// Wait for drift detection to restore the policy's SG list.
+		timeout := 2*config.ReconcileDefaultResyncInterval + 60*time.Second
+		Eventually(func(g Gomega) {
+			out, err := testFramework.LatticeClient.GetServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: snvaId,
+			})
+			g.Expect(err).To(BeNil())
+			ids := lo.Map(out.SecurityGroupIds, func(s *string, _ int) string { return aws.StringValue(s) })
+			g.Expect(ids).To(ConsistOf(string(sgId)))
+		}).WithTimeout(timeout).WithPolling(15 * time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		// Delete the VAP first. The controller will tear down the SNVA and
+		// only remove the finalizer once the SNVA is fully gone, so the test
+		// SGs become safe to delete after the VAP is NotFound.
+		if vap != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, vap)
+		}
+		if sgId != "" {
+			_, err := testFramework.Ec2Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+				GroupId: aws.String(string(sgId)),
+			})
+			Expect(err).To(BeNil())
+		}
+		if altSgId != "" {
+			_, err := testFramework.Ec2Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+				GroupId: aws.String(string(altSgId)),
+			})
+			Expect(err).To(BeNil())
+		}
+
+		// Recreate the SNVA manually to restore the cluster's network state
+		// without the policy. Mirrors the cleanup pattern in
+		// vpc_association_policy_test.go.
+		if testServiceNetwork != nil {
+			_, err := testFramework.Cloud.Lattice().CreateServiceNetworkVpcAssociationWithContext(ctx, &vpclattice.CreateServiceNetworkVpcAssociationInput{
+				ServiceNetworkIdentifier: testServiceNetwork.Id,
+				VpcIdentifier:            &config.VpcID,
+				Tags:                     testFramework.Cloud.DefaultTags(),
+			})
+			Expect(err).To(BeNil())
+
+			Eventually(func(g Gomega) {
+				associated, _, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)
+				g.Expect(err).To(BeNil())
+				g.Expect(associated).To(BeTrue())
+			}).WithTimeout(5 * time.Minute).Should(Succeed())
 		}
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix:**

Extends drift detection coverage to IAMAuthPolicy and VpcAssociationPolicy controllers (follow-up to #938).

**What does this PR do / Why do we need it:**

Route reconcile results for both policy controllers through HandleReconcileError so they participate in periodic re-reconciliation when RECONCILE_DEFAULT_RESYNC_SECONDS is enabled.

Both controllers previously returned ctrl.Result{} directly from Reconcile, bypassing the shared helper that schedules periodic requeues. This meant out-of-band changes to Lattice auth policies or VPC associations were never detected.

**Changes:**

- IAMAuthPolicyController: extract reconcile body into private method, wire through HandleReconcileError, add unit test for periodic requeue.
- VpcAssociationPolicyReconciler: same refactor, remove the hard-coded 30s error retry in favor of the standard error handling path.
- Add e2e drift detection tests for both controllers (auth policy deletion/revert, SNVA deletion, security group drift).
- Update drift-detection.md with new coverage.

⚠️ Behavior change: VpcAssociationPolicy no longer retries errors at a fixed 30-second interval. Transient errors (e.g. SNVA in pending state) now retry at 10s via NewRetryError(). Other errors use controller-runtime's default exponential backoff. This brings the controller in line with all other controllers in the project.

No new API calls are introduced per reconcile pass — periodic requeues call the same existing Put/UpsertVpcAssociation paths.

**Testing done on this change:**

- make test passes (all unit tests green including new Test_IAMAuthPolicy_PeriodicRequeue and Test_VpcAssociationPolicy_PeriodicRequeue).
- golangci-lint run ./pkg/controllers/... passes with 0 issues.
- E2e drift detection tests run against live EKS cluster (us-east-2) with RECONCILE_DEFAULT_RESYNC_SECONDS=60:
- IAMAuthPolicy: auth policy deletion recovery ✅, auth-type revert recovery ✅
- VpcAssociationPolicy: SNVA deletion recovery ✅, security-group drift recovery ✅
- Manual testing: deleted auth policy and SNVA via AWS console, confirmed controller restored both within ~60s.

Automation added to e2e on drift_detection_test.go:
Describe("IAMAuthPolicy Drift detection") — 2 test cases
Describe("VpcAssociationPolicy Drift detection") — 2 test cases
These run automatically via make drift-e2e-test (existing CI workflow validate-merge-queue-e2e-test.yaml).

**Will this PR introduce any new dependencies?:**

No. No new APIs, no new imports beyond what's already in the project.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?:**

No breaking upgrade/downgrade issues. When RECONCILE_DEFAULT_RESYNC_SECONDS is unset (default), behavior is identical to before. The VPC association retry timing change applies regardless but is a consistency improvement, not a regression.

**Does this PR introduce any user-facing change?:**

Yes.

VpcAssociationPolicy: The controller no longer retries errors at a fixed 30-second interval. Transient errors now retry at 10 seconds; other errors use controller-runtime's default exponential backoff.

Drift detection now covers IAMAuthPolicy and VpcAssociationPolicy when RECONCILE_DEFAULT_RESYNC_SECONDS is enabled. Out-of-band changes to IAM auth policies, auth types, VPC associations, and security group assignments are automatically detected and reverted.

**Do all end-to-end tests successfully pass when running make e2e-test?:**

```
Ran 4 of 159 Specs in 650.424 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 155 Skipped
--- PASS: TestIntegration (650.43s)
PASS
ok  github.com/aws/aws-application-networking-k8s/test/suites/integration  651.757s
```

(Ran with --ginkgo.focus="Drift detection" to target the relevant tests.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.