### PR TITLE
fix: address pre-existing drift-detection issues amplified by periodic reconciliation

### DIFF
--- a/docs/guides/drift-detection.md
+++ b/docs/guides/drift-detection.md
@@ -70,7 +70,7 @@ Cross-account RAM sharing associations tied to the original service will not car
 
 Each periodic reconciliation makes multiple VPC Lattice API calls per resource. For clusters with many routes or policies, shorter intervals will result in higher API call volume. Choose an interval that balances recovery time against API usage for your environment.
 
-Most managers diff the live state against the desired state on each pass and skip mutation calls when nothing has drifted. In the common case where a resource is already in sync, a periodic reconcile makes only read calls (e.g. `GetAuthPolicy`, `GetServiceNetworkVpcAssociation`); the corresponding `Put`/`Update` calls only fire when drift is detected. There are two known exceptions where a mutation fires on every pass regardless of drift: target registration (the route controller calls `RegisterTargets` with the full desired set each time) and access log subscriptions (the access log policy controller calls `UpdateAccessLogSubscription` once the source matches). These are pre-existing patterns and may be tightened in follow-up work.
+Most managers diff the live state against the desired state on each pass and skip mutation calls when nothing has drifted. In the common case where a resource is already in sync, a periodic reconcile makes only read calls (e.g. `GetAuthPolicy`, `GetServiceNetworkVpcAssociation`, `ListTargets`); the corresponding `Put`/`Update`/`Register` calls only fire when drift is detected.
 
 ### Controller coverage
 

--- a/docs/guides/drift-detection.md
+++ b/docs/guides/drift-detection.md
@@ -68,7 +68,9 @@ Cross-account RAM sharing associations tied to the original service will not car
 
 ### API usage
 
-Each periodic reconciliation makes multiple VPC Lattice API calls per resource (FindService, ListListeners, ListRules, ListTargetGroups, etc.). For clusters with many routes, shorter intervals will result in higher API call volume. Choose an interval that balances recovery time against API usage for your environment.
+Each periodic reconciliation makes multiple VPC Lattice API calls per resource. For clusters with many routes or policies, shorter intervals will result in higher API call volume. Choose an interval that balances recovery time against API usage for your environment.
+
+Most managers diff the live state against the desired state on each pass and skip mutation calls when nothing has drifted. In the common case where a resource is already in sync, a periodic reconcile makes only read calls (e.g. `GetAuthPolicy`, `GetServiceNetworkVpcAssociation`); the corresponding `Put`/`Update` calls only fire when drift is detected. There are two known exceptions where a mutation fires on every pass regardless of drift: target registration (the route controller calls `RegisterTargets` with the full desired set each time) and access log subscriptions (the access log policy controller calls `UpdateAccessLogSubscription` once the source matches). These are pre-existing patterns and may be tightened in follow-up work.
 
 ### Controller coverage
 

--- a/pkg/controllers/iamauthpolicy_controller.go
+++ b/pkg/controllers/iamauthpolicy_controller.go
@@ -191,7 +191,21 @@ func (c *IAMAuthPolicyController) reconcileUpsert(ctx context.Context, k8sPolicy
 	}
 	statusPolicy, err := c.pm.Put(ctx, modelPolicy)
 	if err != nil {
-		return services.IgnoreNotFound(err)
+		// The underlying VPC Lattice resource (Service or ServiceNetwork) does
+		// not exist. This can happen if it was deleted out-of-band, or — for
+		// Gateway-targeted policies — if the ServiceNetwork has not yet been
+		// created (the gateway controller does not create ServiceNetworks).
+		// Surface this as a non-Accepted condition rather than silently
+		// succeeding; preserve the existing resource-id annotation so any
+		// previously-tracked resource can still be cleaned up if it returns.
+		if services.IsNotFoundError(err) {
+			msg := fmt.Sprintf("VPC Lattice %s %q not found", modelPolicy.Type, resourceName)
+			if statusErr := c.ph.UpdateAcceptedCondition(ctx, k8sPolicy, gwv1.PolicyReasonInvalid, msg); statusErr != nil {
+				return statusErr
+			}
+			return nil
+		}
+		return err
 	}
 	err = c.handleLatticeResourceChange(ctx, k8sPolicy, statusPolicy)
 	if err != nil {

--- a/pkg/controllers/iamauthpolicy_controller_test.go
+++ b/pkg/controllers/iamauthpolicy_controller_test.go
@@ -18,10 +18,12 @@ import (
 	latticetypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -87,7 +89,9 @@ func Test_IAMAuthPolicy_PeriodicRequeue(t *testing.T) {
 
 	// Stub the manager's Lattice calls so Put() returns a successful status.
 	// For a Gateway target, Put() routes through putSn and calls:
-	//   FindServiceNetwork -> PutAuthPolicyWithContext -> UpdateServiceNetworkWithContext
+	//   FindServiceNetwork -> GetAuthPolicy -> PutAuthPolicy -> UpdateServiceNetwork
+	// We stub GetAuthPolicy to return State=Inactive so the manager's
+	// in-sync short-circuit does not fire and the rewrite path is exercised.
 	mockLattice.EXPECT().FindServiceNetwork(gomock.Any(), "test-gateway").Return(
 		&mocks.ServiceNetworkInfo{
 			SvcNetwork: latticetypes.ServiceNetworkSummary{
@@ -95,6 +99,10 @@ func Test_IAMAuthPolicy_PeriodicRequeue(t *testing.T) {
 				Name: aws.String("test-gateway"),
 				Arn:  aws.String("arn:aws:vpc-lattice:us-west-2:123456789012:servicenetwork/sn-1234"),
 			},
+		}, nil)
+	mockLattice.EXPECT().GetAuthPolicy(gomock.Any(), gomock.Any()).Return(
+		&vpclattice.GetAuthPolicyOutput{
+			State: latticetypes.AuthPolicyStateInactive,
 		}, nil)
 	mockLattice.EXPECT().PutAuthPolicy(gomock.Any(), gomock.Any()).Return(
 		&vpclattice.PutAuthPolicyOutput{}, nil)
@@ -121,4 +129,107 @@ func Test_IAMAuthPolicy_PeriodicRequeue(t *testing.T) {
 	// matching pkg/runtime/reconcile_test.go::Test_NilError_WithReconcileInterval.
 	assert.GreaterOrEqual(t, result.RequeueAfter, interval)
 	assert.LessOrEqual(t, result.RequeueAfter, time.Duration(float64(interval)*1.2))
+}
+
+// Test_IAMAuthPolicy_LatticeResourceNotFound verifies that when the underlying
+// VPC Lattice resource (Service or ServiceNetwork) is missing, reconcile sets
+// the policy's Accepted condition to Invalid with a descriptive message rather
+// than silently succeeding. It also verifies the resource-id annotation is
+// preserved (not stomped to empty), so that recovery is possible once the
+// upstream resource returns.
+//
+// This case is primarily reachable for Gateway-targeted policies, because
+// service networks are not recreated by drift detection. Without this branch,
+// the controller reports Accepted=True while not actually applying the policy.
+func Test_IAMAuthPolicy_LatticeResourceNotFound(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	k8sScheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(k8sScheme)
+	gwv1.Install(k8sScheme)
+	anv1alpha1.Install(k8sScheme)
+
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "amazon-vpc-lattice",
+		},
+	}
+
+	// Seed the policy with a previously-applied resource id so we can assert
+	// it is preserved across the NotFound branch.
+	const previouslyAppliedResId = "sn-previously-applied"
+	iap := &anv1alpha1.IAMAuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				IAMAuthPolicyAnnotationResId:   previouslyAppliedResId,
+				IAMAuthPolicyAnnotationType:    "ServiceNetwork",
+				IAMAuthPolicyAnnotationResName: "test-gateway",
+			},
+		},
+		Spec: anv1alpha1.IAMAuthPolicySpec{
+			Policy: `{"Version":"2012-10-17","Statement":[]}`,
+			TargetRef: &gwv1alpha2.NamespacedPolicyTargetReference{
+				Group: gwv1.GroupName,
+				Kind:  "Gateway",
+				Name:  "test-gateway",
+			},
+		},
+	}
+
+	k8sClient := testclient.NewClientBuilder().
+		WithScheme(k8sScheme).
+		WithObjects(iap, gw).
+		WithStatusSubresource(&anv1alpha1.IAMAuthPolicy{}).
+		Build()
+
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud := pkg_aws.NewMockCloud(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	// Simulate the underlying ServiceNetwork being deleted out-of-band: the
+	// manager's Find* call returns a NotFound. PutAuthPolicy and
+	// UpdateServiceNetwork must not be called in this path.
+	mockLattice.EXPECT().FindServiceNetwork(gomock.Any(), "test-gateway").Return(
+		nil, mocks.NewNotFoundError("Service network", "test-gateway"))
+
+	mockEventRecorder := mock_client.NewMockEventRecorder(c)
+	mockEventRecorder.EXPECT().Event(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	r := &IAMAuthPolicyController{
+		log:           gwlog.FallbackLogger,
+		client:        k8sClient,
+		pm:            deploy.NewIAMAuthPolicyManager(mockCloud),
+		ph:            policy.NewIAMAuthPolicyHandler(gwlog.FallbackLogger, k8sClient),
+		cloud:         mockCloud,
+		eventRecorder: mockEventRecorder,
+	}
+
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "test-namespace"},
+	})
+	assert.NoError(t, err)
+
+	// Reload and verify the policy's Accepted condition is False/Invalid with
+	// a message that names the missing resource type and resource name.
+	got := &anv1alpha1.IAMAuthPolicy{}
+	assert.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(iap), got))
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, string(gwv1.PolicyConditionAccepted))
+	assert.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, string(gwv1.PolicyReasonInvalid), cond.Reason)
+	assert.Contains(t, cond.Message, "test-gateway")
+
+	// The previously-applied resource-id annotation must not be stomped to
+	// empty; otherwise the controller loses the handle to the resource it
+	// previously managed.
+	assert.Equal(t, previouslyAppliedResId, got.Annotations[IAMAuthPolicyAnnotationResId])
 }

--- a/pkg/deploy/lattice/access_log_subscription_manager.go
+++ b/pkg/deploy/lattice/access_log_subscription_manager.go
@@ -151,6 +151,21 @@ func (m *defaultAccessLogSubscriptionManager) Update(
 		return m.replaceAccessLogSubscription(ctx, accessLogSubscription)
 	}
 
+	// Skip the rewrite if Lattice already reports the desired destination ARN.
+	// Tags still need to be reconciled in case they have drifted, but
+	// Tagging.UpdateTags itself diffs and only writes when needed.
+	// This avoids a steady-state UpdateAccessLogSubscription call on every
+	// drift-detection pass when nothing has actually drifted.
+	if aws.ToString(getALSOutput.DestinationArn) == accessLogSubscription.Spec.DestinationArn {
+		err = m.cloud.Tagging().UpdateTags(ctx, *getALSOutput.Arn, accessLogSubscription.Spec.AdditionalTags, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update tags for access log subscription %s: %w", *getALSOutput.Arn, err)
+		}
+		return &lattice.AccessLogSubscriptionStatus{
+			Arn: *getALSOutput.Arn,
+		}, nil
+	}
+
 	// Source is not modified, try to update destinationArn in the existing ALS
 	updateALSInput := &vpclattice.UpdateAccessLogSubscriptionInput{
 		AccessLogSubscriptionIdentifier: aws.String(accessLogSubscription.Status.Arn),

--- a/pkg/deploy/lattice/access_log_subscription_manager_test.go
+++ b/pkg/deploy/lattice/access_log_subscription_manager_test.go
@@ -317,13 +317,42 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 		assert.True(t, services.IsNotFoundError(err))
 	})
 
-	t.Run("Update_ALSWithSameDestinationType_UpdatesALSAndReturnsSuccess", func(t *testing.T) {
+	t.Run("Update_ALSAlreadyInSync_SkipsUpdateAndReturnsSuccess", func(t *testing.T) {
+		// When the live destination ARN matches the desired one, the manager
+		// should skip UpdateAccessLogSubscription entirely and only reconcile
+		// tags. This avoids a redundant mutation call on every reconcile when
+		// nothing has drifted.
 		accessLogSubscription := simpleAccessLogSubscription(core.UpdateEvent)
 		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
 			Arn: accessLogSubscriptionArn,
 		}
 
 		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
+		// UpdateAccessLogSubscription must not be called.
+
+		mockTagging.EXPECT().UpdateTags(ctx, accessLogSubscriptionArn, gomock.Any(), nil).Return(nil)
+
+		mgr := NewAccessLogSubscriptionManager(gwlog.FallbackLogger, cloud)
+		resp, err := mgr.Update(ctx, accessLogSubscription)
+		assert.Nil(t, err)
+		assert.Equal(t, accessLogSubscriptionArn, resp.Arn)
+	})
+
+	t.Run("Update_ALSWithDifferentDestination_UpdatesALSAndReturnsSuccess", func(t *testing.T) {
+		// Live destination differs from desired: UpdateAccessLogSubscription
+		// must be called.
+		accessLogSubscription := simpleAccessLogSubscription(core.UpdateEvent)
+		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
+			Arn: accessLogSubscriptionArn,
+		}
+		driftedGetALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+			Arn:            aws.String(accessLogSubscriptionArn),
+			ResourceArn:    aws.String(serviceNetworkArn),
+			DestinationArn: aws.String(cloudWatchDestinationArn),
+		}
+
+		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(driftedGetALSOutput, nil)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 		mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(updateALSOutput, nil)
 
@@ -341,6 +370,14 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
 			Arn: accessLogSubscriptionArn,
 		}
+		// Live destination differs from desired so the diff check passes
+		// and we reach the UpdateAccessLogSubscription call that returns
+		// ConflictException, triggering the create-then-delete flow.
+		driftedGetALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+			Arn:            aws.String(accessLogSubscriptionArn),
+			ResourceArn:    aws.String(serviceNetworkArn),
+			DestinationArn: aws.String(cloudWatchDestinationArn),
+		}
 		updateALSErr := &types.ConflictException{
 			ResourceType: aws.String("ACCESS_LOG_SUBSCRIPTION"),
 		}
@@ -348,7 +385,7 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 			Arn: aws.String(newAccessLogSubscriptionArn),
 		}
 
-		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(driftedGetALSOutput, nil)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 		mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(nil, updateALSErr)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
@@ -424,12 +461,19 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
 			Arn: accessLogSubscriptionArn,
 		}
+		// Drifted live destination so the diff check passes and we reach
+		// the UpdateAccessLogSubscription call that returns NotFound.
+		driftedGetALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+			Arn:            aws.String(accessLogSubscriptionArn),
+			ResourceArn:    aws.String(serviceNetworkArn),
+			DestinationArn: aws.String(cloudWatchDestinationArn),
+		}
 		updateALSError := &types.ResourceNotFoundException{
 			ResourceType: aws.String("ACCESS_LOG_SUBSCRIPTION"),
 		}
 		createALSOutput.Arn = aws.String(newAccessLogSubscriptionArn)
 
-		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(driftedGetALSOutput, nil)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 		mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(nil, updateALSError)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
@@ -461,9 +505,16 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
 			Arn: accessLogSubscriptionArn,
 		}
+		// Drifted live destination so the diff check passes and we reach
+		// the UpdateAccessLogSubscription call that returns AccessDenied.
+		driftedGetALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+			Arn:            aws.String(accessLogSubscriptionArn),
+			ResourceArn:    aws.String(serviceNetworkArn),
+			DestinationArn: aws.String(cloudWatchDestinationArn),
+		}
 		updateALSError := &types.AccessDeniedException{}
 
-		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(driftedGetALSOutput, nil)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 		mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(nil, updateALSError)
 
@@ -478,11 +529,18 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
 			Arn: accessLogSubscriptionArn,
 		}
+		// Drifted live destination so the diff check passes and we reach
+		// the UpdateAccessLogSubscription call that returns NotFound.
+		driftedGetALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+			Arn:            aws.String(accessLogSubscriptionArn),
+			ResourceArn:    aws.String(serviceNetworkArn),
+			DestinationArn: aws.String(cloudWatchDestinationArn),
+		}
 		updateALSError := &types.ResourceNotFoundException{
 			ResourceType: aws.String("SERVICE_NETWORK"),
 		}
 
-		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(driftedGetALSOutput, nil)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 		mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(nil, updateALSError)
 
@@ -497,11 +555,18 @@ func TestAccessLogSubscriptionManager(t *testing.T) {
 		accessLogSubscription.Status = &lattice.AccessLogSubscriptionStatus{
 			Arn: accessLogSubscriptionArn,
 		}
+		// Drifted live destination so the diff check passes and we reach
+		// the UpdateAccessLogSubscription call that returns NotFound.
+		driftedGetALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+			Arn:            aws.String(accessLogSubscriptionArn),
+			ResourceArn:    aws.String(serviceNetworkArn),
+			DestinationArn: aws.String(cloudWatchDestinationArn),
+		}
 		updateALSError := &types.ResourceNotFoundException{
 			ResourceType: aws.String("SERVICE"),
 		}
 
-		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+		mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(driftedGetALSOutput, nil)
 		mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 		mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(nil, updateALSError)
 
@@ -619,10 +684,12 @@ func Test_AccessLogSubscriptionManager_WithAdditionalTags_Update(t *testing.T) {
 	getALSInput := &vpclattice.GetAccessLogSubscriptionInput{
 		AccessLogSubscriptionIdentifier: aws.String(accessLogSubscriptionArn),
 	}
+	// Drifted live destination so the diff check passes and the test
+	// continues to exercise the UpdateAccessLogSubscription path.
 	getALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
 		Arn:            aws.String(accessLogSubscriptionArn),
 		ResourceArn:    aws.String(serviceNetworkArn),
-		DestinationArn: aws.String(s3DestinationArn),
+		DestinationArn: aws.String(cloudWatchDestinationArn),
 	}
 	updateALSInput := &vpclattice.UpdateAccessLogSubscriptionInput{
 		AccessLogSubscriptionIdentifier: aws.String(accessLogSubscriptionArn),
@@ -636,6 +703,65 @@ func Test_AccessLogSubscriptionManager_WithAdditionalTags_Update(t *testing.T) {
 	mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
 	mockLattice.EXPECT().UpdateAccessLogSubscription(ctx, updateALSInput).Return(updateALSOutput, nil)
 
+	mockTagging.EXPECT().UpdateTags(ctx, accessLogSubscriptionArn, accessLogSubscription.Spec.AdditionalTags, nil).Return(nil)
+
+	mgr := NewAccessLogSubscriptionManager(gwlog.FallbackLogger, cloud)
+	resp, err := mgr.Update(ctx, accessLogSubscription)
+	assert.Nil(t, err)
+	assert.Equal(t, accessLogSubscriptionArn, resp.Arn)
+}
+
+// Test_AccessLogSubscriptionManager_AlreadyInSync_TagsStillReconciled covers
+// the in-sync skip path: when the live destination matches the desired one,
+// UpdateAccessLogSubscription is skipped but tag drift is still reconciled
+// via Tagging.UpdateTags. This protects the contract that operator-managed
+// tags continue to converge even when the access log subscription itself is
+// already in sync.
+func Test_AccessLogSubscriptionManager_AlreadyInSync_TagsStillReconciled(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+	mockLattice := services.NewMockLattice(c)
+	mockTagging := services.NewMockTagging(c)
+	cloud := an_aws.NewDefaultCloudWithTagging(mockLattice, mockTagging, TestCloudConfig)
+
+	accessLogSubscription := &lattice.AccessLogSubscription{
+		Spec: lattice.AccessLogSubscriptionSpec{
+			SourceType:        lattice.ServiceNetworkSourceType,
+			SourceName:        sourceName,
+			DestinationArn:    s3DestinationArn,
+			ALPNamespacedName: accessLogPolicyNamespacedName,
+			EventType:         core.UpdateEvent,
+			AdditionalTags: services.Tags{
+				"Environment": "Prod",
+			},
+		},
+		Status: &lattice.AccessLogSubscriptionStatus{
+			Arn: accessLogSubscriptionArn,
+		},
+	}
+
+	serviceNetworkInfo := &services.ServiceNetworkInfo{
+		SvcNetwork: types.ServiceNetworkSummary{
+			Arn:  aws.String(serviceNetworkArn),
+			Name: aws.String(sourceName),
+		},
+	}
+
+	getALSInput := &vpclattice.GetAccessLogSubscriptionInput{
+		AccessLogSubscriptionIdentifier: aws.String(accessLogSubscriptionArn),
+	}
+	// Live destination matches desired: no UpdateAccessLogSubscription should
+	// be called.
+	getALSOutput := &vpclattice.GetAccessLogSubscriptionOutput{
+		Arn:            aws.String(accessLogSubscriptionArn),
+		ResourceArn:    aws.String(serviceNetworkArn),
+		DestinationArn: aws.String(s3DestinationArn),
+	}
+
+	mockLattice.EXPECT().GetAccessLogSubscription(ctx, getALSInput).Return(getALSOutput, nil)
+	mockLattice.EXPECT().FindServiceNetwork(ctx, sourceName).Return(serviceNetworkInfo, nil)
+	// UpdateAccessLogSubscription must not be called.
 	mockTagging.EXPECT().UpdateTags(ctx, accessLogSubscriptionArn, accessLogSubscription.Spec.AdditionalTags, nil).Return(nil)
 
 	mgr := NewAccessLogSubscriptionManager(gwlog.FallbackLogger, cloud)

--- a/pkg/deploy/lattice/iamauthpolicy_manager.go
+++ b/pkg/deploy/lattice/iamauthpolicy_manager.go
@@ -2,10 +2,14 @@ package lattice
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 )
@@ -35,6 +39,20 @@ func (m *IAMAuthPolicyManager) putSn(ctx context.Context, policy model.IAMAuthPo
 		return model.IAMAuthPolicyStatus{}, err
 	}
 	resourceId := *sn.SvcNetwork.Id
+
+	// Skip the rewrite if Lattice already reflects the desired auth policy
+	// and AuthType=AWS_IAM. AuthPolicyState is "Active" only when both are
+	// true. This avoids a steady-state stream of PutAuthPolicy and
+	// UpdateServiceNetwork mutation calls on every drift-detection pass when
+	// nothing has actually drifted.
+	inSync, err := m.isAuthPolicyInSync(ctx, resourceId, policy.Policy)
+	if err != nil {
+		return model.IAMAuthPolicyStatus{}, err
+	}
+	if inSync {
+		return model.IAMAuthPolicyStatus{ResourceId: resourceId}, nil
+	}
+
 	err = m.putPolicy(ctx, resourceId, policy.Policy)
 	if err != nil {
 		return model.IAMAuthPolicyStatus{}, err
@@ -52,6 +70,16 @@ func (m *IAMAuthPolicyManager) putSvc(ctx context.Context, policy model.IAMAuthP
 		return model.IAMAuthPolicyStatus{}, err
 	}
 	resourceId := *svc.Id
+
+	// See putSn for the rationale; same skip-if-already-in-sync logic.
+	inSync, err := m.isAuthPolicyInSync(ctx, resourceId, policy.Policy)
+	if err != nil {
+		return model.IAMAuthPolicyStatus{}, err
+	}
+	if inSync {
+		return model.IAMAuthPolicyStatus{ResourceId: resourceId}, nil
+	}
+
 	err = m.putPolicy(ctx, resourceId, policy.Policy)
 	if err != nil {
 		return model.IAMAuthPolicyStatus{}, err
@@ -61,6 +89,61 @@ func (m *IAMAuthPolicyManager) putSvc(ctx context.Context, policy model.IAMAuthP
 		return model.IAMAuthPolicyStatus{}, err
 	}
 	return model.IAMAuthPolicyStatus{ResourceId: resourceId}, nil
+}
+
+// isAuthPolicyInSync reports whether the given resource (service or service
+// network) already has the desired auth policy attached and AuthType=AWS_IAM.
+// It returns false (i.e. "needs rewrite") if the resource has no policy
+// attached, if AuthType is not AWS_IAM, or if the attached policy doc is not
+// semantically equivalent to the desired one.
+//
+// Errors from GetAuthPolicy are surfaced to the caller, with one exception:
+// a NotFound response is treated as "needs rewrite" rather than an error.
+// This handles the case where GetAuthPolicy returns NotFound for a resource
+// that exists but has never had a policy attached. Note that the API may
+// also return success with an empty Policy field for the same case.
+//
+// Conservative on uncertainty: any unexpected shape (e.g. policy document
+// that won't parse as JSON) is treated as drifted, which costs at most one
+// extra rewrite. Never prefer skipping over rewriting when in doubt — a
+// silent skip when we should have written would leave the user's auth
+// policy not applied.
+func (m *IAMAuthPolicyManager) isAuthPolicyInSync(ctx context.Context, resourceId, desiredPolicy string) (bool, error) {
+	out, err := m.cloud.Lattice().GetAuthPolicy(ctx, &vpclattice.GetAuthPolicyInput{
+		ResourceIdentifier: &resourceId,
+	})
+	if err != nil {
+		if services.IsNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if out.State != types.AuthPolicyStateActive {
+		return false, nil
+	}
+	return policyDocsEqual(aws.ToString(out.Policy), desiredPolicy), nil
+}
+
+// policyDocsEqual compares two IAM-style JSON policy documents for semantic
+// equality. Whitespace and key ordering do not affect the result; list
+// ordering does (lists are treated as ordered, the conservative choice — if
+// Lattice ever returns a list in a different order than the user wrote it,
+// we'll do one extra rewrite, which is harmless).
+//
+// Returns false if either side is empty or fails to parse as JSON. Never
+// panics.
+func policyDocsEqual(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	var aDoc, bDoc any
+	if err := json.Unmarshal([]byte(a), &aDoc); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bDoc); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(aDoc, bDoc)
 }
 
 func (m *IAMAuthPolicyManager) putPolicy(ctx context.Context, id, policy string) error {

--- a/pkg/deploy/lattice/iamauthpolicy_manager_test.go
+++ b/pkg/deploy/lattice/iamauthpolicy_manager_test.go
@@ -1,1 +1,321 @@
 package lattice
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mocks_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
+	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+const testPolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"vpc-lattice-svcs:Invoke","Resource":"*"}]}`
+
+// Test_policyDocsEqual covers the JSON-aware policy comparator. The comparator
+// is the load-bearing piece of the diff-before-write optimization: a false
+// positive (returning true when docs really differ) would make the controller
+// silently skip a Put that the user wanted to happen, leaving the policy not
+// applied. So the test explicitly covers identity, harmless variations
+// (whitespace, key order), genuine differences, and malformed inputs.
+func Test_policyDocsEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{
+			name: "identical strings",
+			a:    testPolicyDoc,
+			b:    testPolicyDoc,
+			want: true,
+		},
+		{
+			name: "same content with different whitespace and indentation",
+			a:    testPolicyDoc,
+			b: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Principal": "*",
+						"Action": "vpc-lattice-svcs:Invoke",
+						"Resource": "*"
+					}
+				]
+			}`,
+			want: true,
+		},
+		{
+			name: "same content with different top-level key order",
+			a:    `{"Version":"2012-10-17","Statement":[]}`,
+			b:    `{"Statement":[],"Version":"2012-10-17"}`,
+			want: true,
+		},
+		{
+			name: "same content with different statement key order",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"vpc-lattice-svcs:Invoke","Resource":"*","Principal":"*"}]}`,
+			b:    testPolicyDoc,
+			want: true,
+		},
+		{
+			name: "different effect",
+			a:    `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"vpc-lattice-svcs:Invoke","Resource":"*"}]}`,
+			b:    `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":"*","Action":"vpc-lattice-svcs:Invoke","Resource":"*"}]}`,
+			want: false,
+		},
+		{
+			name: "different number of statements",
+			a:    testPolicyDoc,
+			b:    `{"Version":"2012-10-17","Statement":[]}`,
+			want: false,
+		},
+		{
+			// Lists are intentionally compared as ordered. If Lattice ever
+			// returns Action lists in a different order than the user wrote,
+			// we'll do one extra rewrite — that's harmless and preferable to
+			// the false-positive risk of unconditional list normalization.
+			name: "list ordering treated as significant",
+			a:    `{"Action":["a","b"]}`,
+			b:    `{"Action":["b","a"]}`,
+			want: false,
+		},
+		{
+			name: "first arg empty",
+			a:    "",
+			b:    testPolicyDoc,
+			want: false,
+		},
+		{
+			name: "second arg empty",
+			a:    testPolicyDoc,
+			b:    "",
+			want: false,
+		},
+		{
+			name: "first arg malformed JSON",
+			a:    "{not json",
+			b:    testPolicyDoc,
+			want: false,
+		},
+		{
+			name: "second arg malformed JSON",
+			a:    testPolicyDoc,
+			b:    "{not json",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, policyDocsEqual(tt.a, tt.b))
+		})
+	}
+}
+
+// Test_IAMAuthPolicyManager_Put_ServiceNetwork_InSync verifies the
+// diff-before-write optimization for a Gateway-targeted (ServiceNetwork)
+// policy: when Lattice already reports State=Active and the same policy doc,
+// neither PutAuthPolicy nor UpdateServiceNetwork is called.
+//
+// The test uses gomock's strict expectations to prove the calls are absent —
+// any unexpected call to a write API would fail the test.
+func Test_IAMAuthPolicyManager_Put_ServiceNetwork_InSync(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, "test-gateway").Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: types.ServiceNetworkSummary{Id: aws.String("sn-1234")},
+		}, nil)
+	mockLattice.EXPECT().GetAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.GetAuthPolicyOutput{
+			Policy: aws.String(testPolicyDoc),
+			State:  types.AuthPolicyStateActive,
+		}, nil)
+	// PutAuthPolicy and UpdateServiceNetwork must not be called.
+
+	mgr := NewIAMAuthPolicyManager(mockCloud)
+	status, err := mgr.Put(ctx, model.IAMAuthPolicy{
+		Type:   model.ServiceNetworkType,
+		Name:   "test-gateway",
+		Policy: testPolicyDoc,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sn-1234", status.ResourceId)
+}
+
+// Test_IAMAuthPolicyManager_Put_Service_InSync mirrors the ServiceNetwork
+// test for an HTTPRoute/GRPCRoute-targeted (Service) policy.
+func Test_IAMAuthPolicyManager_Put_Service_InSync(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	mockLattice.EXPECT().FindService(ctx, "test-service").Return(
+		&types.ServiceSummary{Id: aws.String("svc-5678")}, nil)
+	mockLattice.EXPECT().GetAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.GetAuthPolicyOutput{
+			Policy: aws.String(testPolicyDoc),
+			State:  types.AuthPolicyStateActive,
+		}, nil)
+	// PutAuthPolicy and UpdateService must not be called.
+
+	mgr := NewIAMAuthPolicyManager(mockCloud)
+	status, err := mgr.Put(ctx, model.IAMAuthPolicy{
+		Type:   model.ServiceType,
+		Name:   "test-service",
+		Policy: testPolicyDoc,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "svc-5678", status.ResourceId)
+}
+
+// Test_IAMAuthPolicyManager_Put_Drifted_PolicyDoc covers the case where the
+// resource has AuthType=AWS_IAM (State=Active) but the attached policy
+// document differs from the desired one. The rewrite path must still fire.
+func Test_IAMAuthPolicyManager_Put_Drifted_PolicyDoc(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, "test-gateway").Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: types.ServiceNetworkSummary{Id: aws.String("sn-1234")},
+		}, nil)
+	mockLattice.EXPECT().GetAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.GetAuthPolicyOutput{
+			Policy: aws.String(`{"Version":"2012-10-17","Statement":[]}`), // different from desired
+			State:  types.AuthPolicyStateActive,
+		}, nil)
+	mockLattice.EXPECT().PutAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.PutAuthPolicyOutput{}, nil)
+	mockLattice.EXPECT().UpdateServiceNetwork(ctx, gomock.Any()).Return(
+		&vpclattice.UpdateServiceNetworkOutput{}, nil)
+
+	mgr := NewIAMAuthPolicyManager(mockCloud)
+	status, err := mgr.Put(ctx, model.IAMAuthPolicy{
+		Type:   model.ServiceNetworkType,
+		Name:   "test-gateway",
+		Policy: testPolicyDoc,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sn-1234", status.ResourceId)
+}
+
+// Test_IAMAuthPolicyManager_Put_Drifted_AuthType covers the case where the
+// policy document matches but the resource's AuthType is not AWS_IAM
+// (State=Inactive). Both calls must still fire — we don't bother
+// distinguishing partial drift, see putSn comment.
+func Test_IAMAuthPolicyManager_Put_Drifted_AuthType(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, "test-gateway").Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: types.ServiceNetworkSummary{Id: aws.String("sn-1234")},
+		}, nil)
+	mockLattice.EXPECT().GetAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.GetAuthPolicyOutput{
+			Policy: aws.String(testPolicyDoc),
+			State:  types.AuthPolicyStateInactive,
+		}, nil)
+	mockLattice.EXPECT().PutAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.PutAuthPolicyOutput{}, nil)
+	mockLattice.EXPECT().UpdateServiceNetwork(ctx, gomock.Any()).Return(
+		&vpclattice.UpdateServiceNetworkOutput{}, nil)
+
+	mgr := NewIAMAuthPolicyManager(mockCloud)
+	status, err := mgr.Put(ctx, model.IAMAuthPolicy{
+		Type:   model.ServiceNetworkType,
+		Name:   "test-gateway",
+		Policy: testPolicyDoc,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sn-1234", status.ResourceId)
+}
+
+// Test_IAMAuthPolicyManager_Put_GetAuthPolicy_NotFound covers the case where
+// GetAuthPolicy returns ResourceNotFoundException (no policy ever attached).
+// The manager treats this as "needs rewrite" rather than an error.
+func Test_IAMAuthPolicyManager_Put_GetAuthPolicy_NotFound(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, "test-gateway").Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: types.ServiceNetworkSummary{Id: aws.String("sn-1234")},
+		}, nil)
+	mockLattice.EXPECT().GetAuthPolicy(ctx, gomock.Any()).Return(
+		nil, mocks.NewNotFoundError("auth policy", "sn-1234"))
+	mockLattice.EXPECT().PutAuthPolicy(ctx, gomock.Any()).Return(
+		&vpclattice.PutAuthPolicyOutput{}, nil)
+	mockLattice.EXPECT().UpdateServiceNetwork(ctx, gomock.Any()).Return(
+		&vpclattice.UpdateServiceNetworkOutput{}, nil)
+
+	mgr := NewIAMAuthPolicyManager(mockCloud)
+	status, err := mgr.Put(ctx, model.IAMAuthPolicy{
+		Type:   model.ServiceNetworkType,
+		Name:   "test-gateway",
+		Policy: testPolicyDoc,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "sn-1234", status.ResourceId)
+}
+
+// Test_IAMAuthPolicyManager_Put_GetAuthPolicy_OtherError verifies that an
+// unexpected error from GetAuthPolicy is bubbled up rather than swallowed.
+// We must not skip the rewrite based on an inconclusive read.
+func Test_IAMAuthPolicyManager_Put_GetAuthPolicy_OtherError(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockCloud := mocks_aws.NewMockCloud(c)
+	mockLattice := mocks.NewMockLattice(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, "test-gateway").Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: types.ServiceNetworkSummary{Id: aws.String("sn-1234")},
+		}, nil)
+	getErr := errors.New("throttled")
+	mockLattice.EXPECT().GetAuthPolicy(ctx, gomock.Any()).Return(nil, getErr)
+	// PutAuthPolicy and UpdateServiceNetwork must not be called.
+
+	mgr := NewIAMAuthPolicyManager(mockCloud)
+	_, err := mgr.Put(ctx, model.IAMAuthPolicy{
+		Type:   model.ServiceNetworkType,
+		Name:   "test-gateway",
+		Policy: testPolicyDoc,
+	})
+	assert.ErrorIs(t, err, getErr)
+}

--- a/pkg/deploy/lattice/targets_manager.go
+++ b/pkg/deploy/lattice/targets_manager.go
@@ -77,8 +77,58 @@ func (s *defaultTargetsManager) Update(ctx context.Context, modelTargets *model.
 	}
 
 	err1 := s.deregisterTargets(ctx, modelTg, staleTargets)
-	err2 := s.registerTargets(ctx, modelTg, modelTargets.Spec.TargetList)
+
+	// Skip RegisterTargets when every desired target is already registered in
+	// a non-draining state. RegisterTargets is idempotent server-side, so
+	// re-registering already-present targets is a no-op that nonetheless emits
+	// a mutation API call (and CloudTrail event) on every reconcile. With
+	// drift detection enabled this fires on every periodic pass. A desired
+	// target that is currently Draining is treated as "needs registration" so
+	// it gets resurrected.
+	var err2 error
+	if s.needToRegisterTargets(modelTargets, latticeTargets) {
+		err2 = s.registerTargets(ctx, modelTg, modelTargets.Spec.TargetList)
+	} else {
+		s.log.Debugf(ctx, "All %d desired targets already registered for target group %s, skipping RegisterTargets",
+			len(modelTargets.Spec.TargetList), modelTg.Status.Id)
+	}
 	return errors.Join(err1, err2)
+}
+
+// needToRegisterTargets reports whether RegisterTargets must be called. It
+// returns true if any desired target is not already present in the live set
+// in a non-draining state. A desired target that is present but Draining is
+// considered to need registration so that it is resurrected.
+//
+// Note the deliberate asymmetry with findStaleTargets: stale detection
+// *excludes* draining targets (Lattice is already removing them, no need to
+// deregister again), whereas registration *includes* desired-but-draining
+// targets (we want them back).
+func (s *defaultTargetsManager) needToRegisterTargets(
+	modelTargets *model.Targets,
+	listTargetsOutput []types.TargetSummary) bool {
+
+	nonDrainingLive := utils.NewSet[model.Target]()
+	for _, target := range listTargetsOutput {
+		if string(target.Status) == string(types.TargetStatusDraining) {
+			continue
+		}
+		nonDrainingLive.Put(model.Target{
+			TargetIP: aws.ToString(target.Id),
+			Port:     int64(aws.ToInt32(target.Port)),
+		})
+	}
+
+	for _, target := range modelTargets.Spec.TargetList {
+		ipPort := model.Target{
+			TargetIP: target.TargetIP,
+			Port:     target.Port,
+		}
+		if !nonDrainingLive.Contains(ipPort) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *defaultTargetsManager) findStaleTargets(

--- a/pkg/deploy/lattice/targets_manager_test.go
+++ b/pkg/deploy/lattice/targets_manager_test.go
@@ -335,4 +335,109 @@ func TestTargetsManager(t *testing.T) {
 
 		assert.Nil(t, err)
 	})
+
+	t.Run("all desired targets already registered, skips RegisterTargets", func(t *testing.T) {
+		mt := model.Target{TargetIP: "192.0.2.10", Port: int64(8080), Ready: true}
+		inSyncModelTargets := model.Targets{
+			Spec: model.TargetsSpec{
+				StackTargetGroupId: "tg-stack-id",
+				TargetList:         []model.Target{mt},
+			},
+		}
+		existingTargets := []types.TargetSummary{
+			{
+				Id:     aws.String(mt.TargetIP),
+				Port:   aws.Int32(int32(mt.Port)),
+				Status: types.TargetStatusHealthy,
+			},
+		}
+
+		// Only ListTargets is expected. No RegisterTargets and no
+		// DeregisterTargets should be called when the live set already
+		// matches the desired set.
+		mockLattice.EXPECT().ListTargetsAsList(ctx, gomock.Any()).Return(existingTargets, nil)
+
+		targetsManager := NewTargetsManager(gwlog.FallbackLogger, mockCloud)
+		err := targetsManager.Update(ctx, &inSyncModelTargets, &modelTg)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("desired target present but draining is re-registered", func(t *testing.T) {
+		mt := model.Target{TargetIP: "192.0.2.10", Port: int64(8080), Ready: true}
+		drainingModelTargets := model.Targets{
+			Spec: model.TargetsSpec{
+				StackTargetGroupId: "tg-stack-id",
+				TargetList:         []model.Target{mt},
+			},
+		}
+		// The desired target exists in Lattice but is Draining: it must be
+		// resurrected via RegisterTargets, and must NOT be deregistered
+		// (findStaleTargets excludes draining targets).
+		existingTargets := []types.TargetSummary{
+			{
+				Id:     aws.String(mt.TargetIP),
+				Port:   aws.Int32(int32(mt.Port)),
+				Status: types.TargetStatusDraining,
+			},
+		}
+		registerInput := &vpclattice.RegisterTargetsInput{
+			TargetGroupIdentifier: aws.String("tg-id"),
+			Targets: []types.Target{
+				{Id: aws.String(mt.TargetIP), Port: aws.Int32(int32(mt.Port))},
+			},
+		}
+
+		mockLattice.EXPECT().ListTargetsAsList(ctx, gomock.Any()).Return(existingTargets, nil)
+		mockLattice.EXPECT().RegisterTargets(ctx, registerInput).Return(registerTargetsOutput, nil)
+
+		targetsManager := NewTargetsManager(gwlog.FallbackLogger, mockCloud)
+		err := targetsManager.Update(ctx, &drainingModelTargets, &modelTg)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("extra live target deregistered while desired set skips register", func(t *testing.T) {
+		mt := model.Target{TargetIP: "192.0.2.10", Port: int64(8080), Ready: true}
+		extra := model.Target{TargetIP: "192.0.2.99", Port: int64(8080)}
+		desiredModelTargets := model.Targets{
+			Spec: model.TargetsSpec{
+				StackTargetGroupId: "tg-stack-id",
+				TargetList:         []model.Target{mt},
+			},
+		}
+		// Live set has the desired target (Healthy) plus an extra one that is
+		// no longer desired. The extra must be deregistered; the register path
+		// must be skipped because every desired target is already present.
+		existingTargets := []types.TargetSummary{
+			{
+				Id:     aws.String(mt.TargetIP),
+				Port:   aws.Int32(int32(mt.Port)),
+				Status: types.TargetStatusHealthy,
+			},
+			{
+				Id:     aws.String(extra.TargetIP),
+				Port:   aws.Int32(int32(extra.Port)),
+				Status: types.TargetStatusHealthy,
+			},
+		}
+		deregisterInput := &vpclattice.DeregisterTargetsInput{
+			TargetGroupIdentifier: aws.String(modelTg.Status.Id),
+			Targets: []types.Target{
+				{Id: aws.String(extra.TargetIP), Port: aws.Int32(int32(extra.Port))},
+			},
+		}
+		deregisterOutput := &vpclattice.DeregisterTargetsOutput{
+			Successful: deregisterInput.Targets,
+		}
+
+		mockLattice.EXPECT().ListTargetsAsList(ctx, gomock.Any()).Return(existingTargets, nil)
+		mockLattice.EXPECT().DeregisterTargets(ctx, deregisterInput).Return(deregisterOutput, nil)
+		// RegisterTargets must not be called.
+
+		targetsManager := NewTargetsManager(gwlog.FallbackLogger, mockCloud)
+		err := targetsManager.Update(ctx, &desiredModelTargets, &modelTg)
+
+		assert.Nil(t, err)
+	})
 }

--- a/test/suites/integration/drift_detection_test.go
+++ b/test/suites/integration/drift_detection_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -621,15 +622,35 @@ var _ = Describe("VpcAssociationPolicy Drift detection", Serial, Ordered, func()
 			Expect(err).To(BeNil())
 		}
 
-		// Recreate the SNVA manually to restore the cluster's network state
-		// without the policy.
+		// Restore the cluster's baseline network state: test-gateway must end
+		// up associated with the cluster VPC (other suites rely on this).
+		// With drift detection enabled, the controller may have already
+		// recreated the association by the time this runs, and VPC Lattice
+		// permits only one association per VPC/service-network pair. So make
+		// this idempotent: only create the association if one does not already
+		// exist, and tolerate a ConflictException from a check-then-create
+		// race.
 		if testServiceNetwork != nil {
-			_, err := testFramework.Cloud.Lattice().CreateServiceNetworkVpcAssociation(ctx, &vpclattice.CreateServiceNetworkVpcAssociationInput{
+			existing, err := testFramework.LatticeClient.ListServiceNetworkVpcAssociationsAsList(ctx, &vpclattice.ListServiceNetworkVpcAssociationsInput{
 				ServiceNetworkIdentifier: testServiceNetwork.Id,
 				VpcIdentifier:            &config.VpcID,
-				Tags:                     testFramework.Cloud.DefaultTags(),
 			})
 			Expect(err).To(BeNil())
+
+			if len(existing) == 0 {
+				_, err := testFramework.Cloud.Lattice().CreateServiceNetworkVpcAssociation(ctx, &vpclattice.CreateServiceNetworkVpcAssociationInput{
+					ServiceNetworkIdentifier: testServiceNetwork.Id,
+					VpcIdentifier:            &config.VpcID,
+					Tags:                     testFramework.Cloud.DefaultTags(),
+				})
+				// A concurrent reconcile may have created the association
+				// between our list check and this create; that is the desired
+				// end state, so tolerate the conflict.
+				var ce *types.ConflictException
+				if err != nil && !errors.As(err, &ce) {
+					Expect(err).To(BeNil())
+				}
+			}
 
 			Eventually(func(g Gomega) {
 				associated, _, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)


### PR DESCRIPTION
**What type of PR is this?**

bug

(Three correctness/efficiency fixes plus a test-stability fix, all stemming from
behaviors that became significant once periodic reconciliation / drift detection
was introduced in #938 and extended in #953.)

**Which issue does this PR fix**:

N/A — follow-up to #938 and #953. No tracking issue; repro steps below.

**What does this PR do / Why do we need it**:

When `RECONCILE_DEFAULT_RESYNC_SECONDS` is enabled, every controller using the
shared `HandleReconcileError` re-reconciles on a fixed interval. Several
pre-existing behaviors that were harmless when reconcile only fired on
Kubernetes events become problematic when they fire on every interval. This PR
addresses four of them:

1. **IAMAuthPolicy: silent failure when the underlying Lattice resource is
   missing.** `IAMAuthPolicyController.reconcileUpsert` wrapped `pm.Put` errors
   in `services.IgnoreNotFound`, so a deleted underlying VPC Lattice service or
   service network produced a *successful* reconcile, an `Accepted=True` status
   condition, and an emptied resource-id annotation. The user saw a healthy
   policy that was not actually being applied. The `Put` NotFound path now sets
   `Accepted=False`/`Invalid` with a descriptive message and preserves the
   existing annotation. The `IgnoreNotFound` on the delete paths (idempotent
   delete) is intentional and preserved.

2. **IAMAuthPolicy: unconditional rewrite every reconcile.** `putSn`/`putSvc`
   always called `PutAuthPolicy` + `UpdateService`/`UpdateServiceNetwork`
   regardless of drift, i.e. two mutation calls per policy on every periodic
   pass. The manager now calls `GetAuthPolicy` first and skips both writes when
   `AuthPolicyState` is `Active` and the live policy document is semantically
   equal to the desired one (whitespace/key-order-insensitive JSON comparison;
   conservative — any uncertainty falls back to rewriting).

3. **AccessLogPolicy: unconditional `UpdateAccessLogSubscription` every
   reconcile.** When the source matched, the manager always called
   `UpdateAccessLogSubscription` even if the destination ARN was already
   correct. It now skips that call when the destination is in sync; tag drift is
   still reconciled via the (already diff-aware) `Tagging.UpdateTags`.

4. **Route targets: unconditional `RegisterTargets` every reconcile.**
   `TargetsManager.Update` always re-registered the full desired target set.
   It now skips `RegisterTargets` when every desired target is already
   registered in a non-draining state (a desired-but-draining target is still
   re-registered so it is resurrected). `RegisterTargets` is idempotent
   server-side, so this is a pure call-volume reduction with no change to
   converged state.

Also fixes a flaky e2e cleanup: the `VpcAssociationPolicy Drift detection`
`AfterAll` unconditionally recreated the baseline `test-gateway` VPC association
and 409'd ("VPC has already been associated to a service network") on clusters
where the association already existed. The cleanup is now idempotent.

**If an issue # is not available please add repro steps and logs**:

With `RECONCILE_DEFAULT_RESYNC_SECONDS=60` and an `IAMAuthPolicy` targeting a
Gateway whose VPC Lattice service network is then deleted out-of-band:

- Before: `kubectl get iamauthpolicy` shows `Accepted=True`, the resource-id
  annotation is emptied, and the controller logs a successful reconcile every
  interval while applying nothing.
- After: the policy's `Accepted` condition flips to `False`/`Invalid` with a
  message naming the missing resource, and the annotation is preserved.

For #2/#3/#4, before this change CloudTrail shows a steady stream of
`PutAuthPolicy`/`UpdateService`/`UpdateAccessLogSubscription`/`RegisterTargets`
write events every interval even with no drift; after, those calls only occur
when the live state actually differs.

**Testing done on this change**:

- `go vet ./...`, `gofmt`, and `go test ./pkg/...` all pass.
- `golangci-lint run` (CI-pinned v2.11.3) passes on all changed files.
- Unit tests added (see below).
- Controller run locally against an EKS cluster (us-east-2) with
  `RECONCILE_DEFAULT_RESYNC_SECONDS=60`; controller logs confirm the new
  diff-before-write behavior live: IAMAuthPolicy reconciles issue `GetAuthPolicy`
  and then skip `PutAuthPolicy`/`UpdateService` when in sync; rule manager logs
  "rule unchanged, no updates required"; VpcAssociationPolicy reconciles without
  redundant `UpdateServiceNetworkVpcAssociation`.
- Focused drift e2e against the live cluster (`--ginkgo.focus="Drift detection"`,
  `RECONCILE_DEFAULT_RESYNC_SECONDS=60`):
  - IAMAuthPolicy Drift detection — auth policy deletion recovery ✅, auth-type
    revert recovery ✅
  - VpcAssociationPolicy Drift detection — SNVA deletion recovery ✅,
    security-group drift recovery ✅ (including the fixed `AfterAll`; focused
    re-run: 2 Passed, 0 Failed)

**Automation added to e2e**:

No new e2e specs. The new manager-level behavior is covered by unit tests, and
the existing drift e2e suite exercises the IAMAuthPolicy and VpcAssociationPolicy
drift-recovery paths these changes sit under. New unit tests:

- `Test_IAMAuthPolicy_LatticeResourceNotFound` — asserts `Accepted=False`/`Invalid`
  and annotation preservation when the Lattice resource is missing.
- `pkg/deploy/lattice/iamauthpolicy_manager_test.go` (new) — `policyDocsEqual`
  cases (identity, whitespace, key order, malformed JSON, empty,
  list-order-significance) and `Put` behavior across in-sync (Service and
  ServiceNetwork), policy-doc drift, auth-type drift, GetAuthPolicy NotFound, and
  GetAuthPolicy other-error.
- Access log subscription manager — in-sync skip, in-sync-with-tag-drift, and
  drifted-destination update cases.
- Targets manager — all-in-sync skip, draining resurrection, and
  extra-live-target deregister while skipping register.

**Will this PR introduce any new dependencies?**:

No. No new APIs or imports. One additional read API call per reconcile for
IAMAuthPolicy (`GetAuthPolicy`) and access log subscriptions
(`GetAccessLogSubscription`, already called) in exchange for eliminating
mutation calls when nothing has drifted. Net effect in steady state: fewer
total write calls; reads unchanged or +1.

**Will this break upgrades or downgrades. Has updating a running cluster been
tested?**:

No breaking changes. When `RECONCILE_DEFAULT_RESYNC_SECONDS` is unset (default),
reconcile frequency is unchanged. The IAMAuthPolicy status-condition change is
only observable in the previously-silent failure case (Lattice resource missing),
where the new behavior is strictly more correct. No CRD or API changes.

**Does this PR introduce any user-facing change?**:

Yes — an IAMAuthPolicy whose underlying VPC Lattice resource has been deleted
out-of-band now reports `Accepted=False` (reason `Invalid`) instead of silently
reporting `Accepted=True`.

```release-note
IAMAuthPolicy now reports a non-Accepted status condition when its underlying VPC
Lattice resource is missing, instead of reporting Accepted while applying nothing.
Drift-detection reconciles for IAM auth policies, access log subscriptions, and
route targets now skip redundant VPC Lattice mutation calls when the live state
already matches the desired state, reducing API call volume when
RECONCILE_DEFAULT_RESYNC_SECONDS is enabled.
```

Do all end-to-end tests successfully pass when running make e2e-test?:

Ran the drift-detection suite (the suite relevant to these changes) against a live EKS cluster in us-east-2 with RECONCILE_DEFAULT_RESYNC_SECONDS=60:

Will run 8 of 159 specs
IAMAuthPolicy Drift detection recreates an auth policy deleted out-of-band • [42s]
IAMAuthPolicy Drift detection re-enables AWS_IAM auth type when flipped to NONE • [60s]
VpcAssociationPolicy Drift detection recreates the SNVA deleted out-of-band [Serial] • [129s]
VpcAssociationPolicy Drift detection restores security groups drifted out-of-band [Serial] • [269s]
SUCCESS! (VpcAssociationPolicy focused re-run: 2 Passed | 0 Failed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


