### PR TITLE
Integration test improvements

### DIFF
--- a/.github/workflows/validate-merge-queue-e2e-test.yaml
+++ b/.github/workflows/validate-merge-queue-e2e-test.yaml
@@ -122,6 +122,13 @@ jobs:
         run: |
           kubectl apply -f files/controller-installation/gatewayclass.yaml
 
+      - name: Wait for controller to be ready
+        run: |
+          kubectl rollout status deployment \
+            -l app.kubernetes.io/instance=gateway-api-controller \
+            --namespace aws-application-networking-system \
+            --timeout=120s
+
       - name: Run test
         run: |
           make e2e-test
@@ -144,6 +151,16 @@ jobs:
       - name: Run drift detection tests
         run: |
           RECONCILE_DEFAULT_RESYNC_SECONDS=60 make drift-e2e-test
+
+      - name: Dump controller logs on failure
+        if: failure()
+        run: |
+          echo "=== Controller pods ==="
+          kubectl get pods -n aws-application-networking-system -o wide || true
+          echo "=== Controller logs ==="
+          kubectl logs -n aws-application-networking-system -l app.kubernetes.io/instance=gateway-api-controller --tail=200 || true
+          echo "=== Previous container logs (if crashed) ==="
+          kubectl logs -n aws-application-networking-system -l app.kubernetes.io/instance=gateway-api-controller --previous --tail=50 || true
 
       - name: Cleanup
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -117,16 +117,13 @@ e2e-test-namespace := "e2e-test"
 e2e-test: ## Run e2e tests against cluster pointed to by ~/.kube/config
 	@kubectl create namespace $(e2e-test-namespace) > /dev/null 2>&1 || true # ignore already exists error
 	LOG_LEVEL=debug
-	cd test && go test \
-		-p 1 \
-		-count 1 \
-		-timeout 120m \
+	cd test && go run github.com/onsi/ginkgo/v2/ginkgo \
+		--procs=4 \
+		--timeout=120m \
+		--focus="${FOCUS}" \
+		--skip="${SKIP}" \
 		-v \
-		./suites/integration/... \
-		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.skip="${SKIP}" \
-		--ginkgo.timeout=120m \
-		--ginkgo.v
+		./suites/integration/...
 
 .SILENT:
 .PHONY: e2e-clean

--- a/test/pkg/test/framework.go
+++ b/test/pkg/test/framework.go
@@ -148,7 +148,7 @@ func NewFramework(ctx context.Context, log gwlog.Logger, testNamespace string) *
 	framework.Cloud = anaws.NewDefaultCloudWithTagging(framework.LatticeClient, framework.TaggingClient, cloudConfig)
 	framework.DefaultTags = framework.Cloud.DefaultTags()
 	SetDefaultEventuallyTimeout(5 * time.Minute)
-	SetDefaultEventuallyPollingInterval(10 * time.Second)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
 	return framework
 }
 

--- a/test/pkg/test/metadata.go
+++ b/test/pkg/test/metadata.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	randomdata "github.com/Pallinder/go-randomdata"
 	"github.com/imdario/mergo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,5 +44,5 @@ func RandomName() string {
 	sequentialNumberLock.Lock()
 	defer sequentialNumberLock.Unlock()
 	sequentialNumber++
-	return strings.ToLower(fmt.Sprintf("%s-%d-%s", randomdata.SillyName()[:5], sequentialNumber, randomdata.Alphanumeric(10)))
+	return strings.ToLower(fmt.Sprintf("%s-p%d-%d-%s", randomdata.SillyName()[:5], ginkgo.GinkgoParallelProcess(), sequentialNumber, randomdata.Alphanumeric(10)))
 }

--- a/test/suites/integration/allowed_routes_test.go
+++ b/test/suites/integration/allowed_routes_test.go
@@ -16,7 +16,7 @@ import (
 	vpclattice "github.com/aws/aws-sdk-go-v2/service/vpclattice"
 )
 
-var _ = Describe("AllowedRoutes Test", Ordered, func() {
+var _ = Describe("AllowedRoutes Test", Serial, Ordered, func() {
 	var (
 		diffNS    = "diff-namespace"
 		labeledNS = "labeled-namespace"

--- a/test/suites/integration/byoc_test.go
+++ b/test/suites/integration/byoc_test.go
@@ -32,7 +32,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ = Describe("Bring your own certificate (BYOC)", Ordered, func() {
+var _ = Describe("Bring your own certificate (BYOC)", Serial, Ordered, func() {
 
 	const (
 		hostedZoneName = "e2e-test.com"

--- a/test/suites/integration/cert_discovery_test.go
+++ b/test/suites/integration/cert_discovery_test.go
@@ -7,6 +7,7 @@ import (
 
 	"slices"
 
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
@@ -25,7 +26,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ = Describe("ACM certificate discovery", Ordered, func() {
+var _ = Describe("ACM certificate discovery", Serial, Ordered, func() {
 
 	const (
 		hostedZoneName = "cert-discovery-e2e.com"
@@ -143,11 +144,25 @@ var _ = Describe("ACM certificate discovery", Ordered, func() {
 
 		testFramework.ExpectDeletedThenNotFound(context.TODO(), httpRoute, service, deployment)
 
+		// Wait for the Lattice service to be deleted before removing the gateway listener.
+		Eventually(func() error {
+			_, err := testFramework.LatticeClient.FindService(ctx, fmt.Sprintf("%s-%s", httpRoute.Name, httpRoute.Namespace))
+			if err != nil {
+				if services.IsNotFoundError(err) {
+					return nil // confirmed deleted
+				}
+				return err // transient error — retry
+			}
+			return fmt.Errorf("lattice service for route %s still exists", httpRoute.Name)
+		}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+		log.Infof(ctx, "lattice service deleted")
+
 		removeGatewayCertDiscoveryListener()
 		log.Infof(ctx, "removed cert-discovery listener from gateway")
 
-		err = deleteCert(acmClient, certArn)
-		Expect(err).To(BeNil())
+		Eventually(func() error {
+			return deleteCert(acmClient, certArn)
+		}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		log.Infof(ctx, "removed cert from acm, arn: %s", certArn)
 	})
 })

--- a/test/suites/integration/drift_detection_test.go
+++ b/test/suites/integration/drift_detection_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -78,12 +79,19 @@ var _ = Describe("Drift detection", Ordered, func() {
 			g.Expect(err).ToNot(HaveOccurred())
 		}).WithTimeout(4 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
-		// Wait for drift detection to recreate it with a new ID
+		// Wait for drift detection to recreate the service and its association
 		Eventually(func(g Gomega) {
 			recreated := testFramework.GetVpcLatticeService(ctx, route)
 			g.Expect(recreated).ToNot(BeNil())
 			g.Expect(recreated.Status).To(Equal(types.ServiceStatusActive))
 			g.Expect(aws.ToString(recreated.Id)).ToNot(Equal(originalId))
+
+			assocResp, err := testFramework.LatticeClient.ListServiceNetworkServiceAssociationsAsList(ctx,
+				&vpclattice.ListServiceNetworkServiceAssociationsInput{
+					ServiceIdentifier: recreated.Id,
+				})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(assocResp).ToNot(BeEmpty())
 		}).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
 	})
 
@@ -602,6 +610,9 @@ var _ = Describe("VpcAssociationPolicy Drift detection", Serial, Ordered, func()
 	})
 
 	AfterAll(func() {
+		if vap == nil && sgId == "" {
+			return
+		}
 		// Delete the VAP first. The controller will tear down the SNVA and
 		// only remove the finalizer once the SNVA is fully gone, so the test
 		// SGs become safe to delete after the VAP is NotFound.
@@ -629,7 +640,10 @@ var _ = Describe("VpcAssociationPolicy Drift detection", Serial, Ordered, func()
 				VpcIdentifier:            &config.VpcID,
 				Tags:                     testFramework.Cloud.DefaultTags(),
 			})
-			Expect(err).To(BeNil())
+			var ce *types.ConflictException
+			if err != nil && !errors.As(err, &ce) {
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			Eventually(func(g Gomega) {
 				associated, _, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)

--- a/test/suites/integration/iamauthpolicy_test.go
+++ b/test/suites/integration/iamauthpolicy_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("IAM Auth Policy", Ordered, func() {
+var _ = Describe("IAM Auth Policy", Serial, Ordered, func() {
 
 	const (
 		AllowAllInvoke = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"vpc-lattice-svcs:Invoke","Resource":"*"}]}`

--- a/test/suites/integration/ram_share_test.go
+++ b/test/suites/integration/ram_share_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
@@ -48,6 +47,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 	var (
 		clients              *testClients
 		secondaryTestRoleArn string
+		createdGateways      []string
 	)
 
 	BeforeAll(func() {
@@ -116,6 +116,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 		}
 		err := testFramework.Create(ctx, gateway)
 		Expect(err).ToNot(HaveOccurred())
+		createdGateways = append(createdGateways, gateway.Name)
 
 		Eventually(func(g Gomega) {
 			// Policy status should be Accepted
@@ -157,6 +158,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 		}
 		err := testFramework.Create(ctx, gateway)
 		Expect(err).ToNot(HaveOccurred())
+		createdGateways = append(createdGateways, gateway.Name)
 
 		Eventually(func(g Gomega) {
 			// Policy status should be Accepted
@@ -206,6 +208,7 @@ var _ = Describe("RAM Share", Ordered, func() {
 		}
 		err = testFramework.Create(ctx, gateway)
 		Expect(err).ToNot(HaveOccurred())
+		createdGateways = append(createdGateways, gateway.Name)
 
 		Eventually(func(g Gomega) {
 			// Policy status should be Accepted
@@ -224,15 +227,14 @@ var _ = Describe("RAM Share", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		// Delete gateways in test namespace except the framework gateway
-		gws := &gwv1.GatewayList{}
-		err := testFramework.Client.List(ctx, gws, client.InNamespace(k8snamespace))
-		Expect(err).To(BeNil())
-		for _, gw := range gws.Items {
-			if gw.Name != testGateway.Name {
-				testFramework.ExpectDeletedThenNotFound(ctx, &gw)
-			}
+		// Delete only gateways created by this test suite
+		for _, name := range createdGateways {
+			gw := &gwv1.Gateway{}
+			gw.Name = name
+			gw.Namespace = k8snamespace
+			testFramework.ExpectDeletedThenNotFound(ctx, gw)
 		}
+		createdGateways = nil
 	})
 
 	AfterAll(func() {

--- a/test/suites/integration/servicenetwork_test.go
+++ b/test/suites/integration/servicenetwork_test.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -222,17 +223,27 @@ var _ = Describe("ServiceNetwork CRD delete blocked by association", Serial, Ord
 	const svcName = "test-svc-block-e2e"
 
 	AfterAll(func() {
-		// Clean up association first to unblock SN deletion
-		if snssaId != nil {
-			testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
-				ServiceNetworkServiceAssociationIdentifier: snssaId,
-			})
-			Eventually(func(g Gomega) {
-				_, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
-					ServiceNetworkServiceAssociationIdentifier: snssaId,
+		// Clean up all associations on the SN to unblock deletion
+		if snInfo, err := testFramework.LatticeClient.FindServiceNetwork(ctx, snName); err == nil && snInfo != nil {
+			assocs, _ := testFramework.LatticeClient.ListServiceNetworkServiceAssociationsAsList(ctx,
+				&vpclattice.ListServiceNetworkServiceAssociationsInput{
+					ServiceNetworkIdentifier: snInfo.SvcNetwork.Id,
 				})
-				g.Expect(err).To(HaveOccurred())
-			}).Should(Succeed())
+			for _, a := range assocs {
+				testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx,
+					&vpclattice.DeleteServiceNetworkServiceAssociationInput{
+						ServiceNetworkServiceAssociationIdentifier: a.Id,
+					})
+			}
+			if len(assocs) > 0 {
+				Eventually(func(g Gomega) {
+					remaining, _ := testFramework.LatticeClient.ListServiceNetworkServiceAssociationsAsList(ctx,
+						&vpclattice.ListServiceNetworkServiceAssociationsInput{
+							ServiceNetworkIdentifier: snInfo.SvcNetwork.Id,
+						})
+					g.Expect(remaining).To(BeEmpty())
+				}).Should(Succeed())
+			}
 		}
 		if serviceId != nil {
 			Eventually(func() error {
@@ -280,12 +291,20 @@ var _ = Describe("ServiceNetwork CRD delete blocked by association", Serial, Ord
 			snId = updated.Status.ServiceNetworkID
 		}).Should(Succeed())
 
-		// Create a Lattice service via SDK and wait for it to be active
-		svcResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
-			Name: aws.String(svcName),
-		})
-		Expect(err).ToNot(HaveOccurred())
-		serviceId = svcResp.Id
+		// Create a Lattice service via SDK (or reuse existing from a previous failed run)
+		existingSvc, err := testFramework.LatticeClient.FindService(ctx, svcName)
+		if err != nil && !services.IsNotFoundError(err) {
+			Expect(err).ToNot(HaveOccurred(), "failed to look up existing service")
+		}
+		if existingSvc != nil {
+			serviceId = existingSvc.Id
+		} else {
+			svcResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+				Name: aws.String(svcName),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			serviceId = svcResp.Id
+		}
 
 		Eventually(func(g Gomega) {
 			svc, err := testFramework.LatticeClient.FindService(ctx, svcName)

--- a/test/suites/integration/standalone_annotation_precedence_test.go
+++ b/test/suites/integration/standalone_annotation_precedence_test.go
@@ -21,7 +21,7 @@ const (
 	LatticeServiceArnKey    = "application-networking.k8s.aws/lattice-service-arn"
 )
 
-var _ = Describe("Standalone Annotation Precedence and Inheritance", Ordered, func() {
+var _ = Describe("Standalone Annotation Precedence and Inheritance", Serial, Ordered, func() {
 
 	Context("Gateway-level annotation inheritance", func() {
 		var (

--- a/test/suites/integration/standalone_transition_test.go
+++ b/test/suites/integration/standalone_transition_test.go
@@ -22,7 +22,7 @@ const (
 	LatticeServiceArnAnnotation    = "application-networking.k8s.aws/lattice-service-arn"
 )
 
-var _ = Describe("Standalone Service Transition Scenarios", Ordered, func() {
+var _ = Describe("Standalone Service Transition Scenarios", Serial, Ordered, func() {
 
 	Context("Transition from standalone to service network mode", func() {
 		var (

--- a/test/suites/integration/suite_test.go
+++ b/test/suites/integration/suite_test.go
@@ -51,6 +51,14 @@ var _ = SynchronizedBeforeSuite(func() {
 	testServiceNetwork = testFramework.GetServiceNetwork(ctx, testGateway)
 
 	testFramework.Log.Infof(ctx, "Expecting VPC %s and service network %s association", vpcId, *testServiceNetwork.Id)
+	// Create VPC association if it doesn't exist (idempotent — ignores ConflictException)
+	_, err := testFramework.LatticeClient.CreateServiceNetworkVpcAssociation(ctx, &vpclattice.CreateServiceNetworkVpcAssociationInput{
+		ServiceNetworkIdentifier: testServiceNetwork.Id,
+		VpcIdentifier:            &vpcId,
+	})
+	if err != nil {
+		testFramework.Log.Infof(ctx, "CreateServiceNetworkVpcAssociation returned: %v (may be expected ConflictException)", err)
+	}
 	Eventually(func(g Gomega) {
 		associated, _, _ := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, vpcId, testServiceNetwork)
 		g.Expect(associated).To(BeTrue())

--- a/test/suites/integration/tlsroute_serviceexport_test.go
+++ b/test/suites/integration/tlsroute_serviceexport_test.go
@@ -37,7 +37,7 @@ var _ = Describe("TLSRoute Service Export/Import Test", Ordered, func() {
 	)
 
 	It("Create k8s resource", func() {
-		httpsDeployment1, httpsSvc1 = testFramework.NewHttpsApp(test.HTTPsAppOptions{Name: "my-https-1", Namespace: k8snamespace})
+		httpsDeployment1, httpsSvc1 = testFramework.NewHttpsApp(test.HTTPsAppOptions{Name: "my-https-export-1", Namespace: k8snamespace})
 		policy = createTCPTargetGroupPolicy(httpsSvc1)
 		testFramework.ExpectCreated(ctx, policy)
 		serviceImport = testFramework.CreateServiceImport(httpsSvc1)
@@ -110,7 +110,7 @@ var _ = Describe("TLSRoute Service Export/Import Test", Ordered, func() {
 			log.Printf("Executing command [%s] \n", cmd)
 			stdout, _, err := testFramework.PodExec(pod, cmd)
 			g.Expect(err).To(BeNil())
-			g.Expect(stdout).To(ContainSubstring("my-https-1 handler pod"))
+			g.Expect(stdout).To(ContainSubstring("my-https-export-1 handler pod"))
 		}).Should(Succeed())
 	})
 

--- a/test/suites/integration/vpc_association_policy_test.go
+++ b/test/suites/integration/vpc_association_policy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
@@ -29,47 +30,60 @@ var _ = Describe("Test vpc association policy", Serial, Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		// Create security group
-		describeVpcOutput, err := testFramework.Ec2Client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
-			VpcIds: []string{test.CurrentClusterVpcId},
-		})
-		Expect(err).To(BeNil())
-		sourceVPC := describeVpcOutput.Vpcs[0]
-		createSgOutput, err := testFramework.Ec2Client.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
-			Description: aws.String("k8s-test-lattice-snva-sg"),
-			GroupName:   aws.String("k8s-test-lattice-snva-sg"),
-			VpcId:       aws.String(test.CurrentClusterVpcId),
-		})
-		Expect(err).To(BeNil())
-		sgId = v1alpha1.SecurityGroupId(*createSgOutput.GroupId)
-
-		// Create security group inbound rules
-		_, err = testFramework.Ec2Client.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
-			GroupId: createSgOutput.GroupId,
-			IpPermissions: []ec2types.IpPermission{
-				{ // SG Rule to allow HTTP
-					IpProtocol: aws.String("tcp"),
-					IpRanges: []ec2types.IpRange{
-						{
-							CidrIp: sourceVPC.CidrBlock,
-						},
-					},
-					FromPort: aws.Int32(80),
-					ToPort:   aws.Int32(80),
-				},
-				{ // SG Rule to allow HTTPS
-					IpProtocol: aws.String("tcp"),
-					IpRanges: []ec2types.IpRange{
-						{
-							CidrIp: sourceVPC.CidrBlock,
-						},
-					},
-					FromPort: aws.Int32(443),
-					ToPort:   aws.Int32(443),
-				},
+		// Look up existing SG first (idempotent — handles leaked SG from prior failed run)
+		describeSgOutput, err := testFramework.Ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters: []ec2types.Filter{
+				{Name: aws.String("group-name"), Values: []string{"k8s-test-lattice-snva-sg"}},
+				{Name: aws.String("vpc-id"), Values: []string{test.CurrentClusterVpcId}},
 			},
 		})
 		Expect(err).To(BeNil())
+
+		if len(describeSgOutput.SecurityGroups) > 0 {
+			sgId = v1alpha1.SecurityGroupId(*describeSgOutput.SecurityGroups[0].GroupId)
+		} else {
+			describeVpcOutput, err := testFramework.Ec2Client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+				VpcIds: []string{test.CurrentClusterVpcId},
+			})
+			Expect(err).To(BeNil())
+			sourceVPC := describeVpcOutput.Vpcs[0]
+
+			createSgOutput, err := testFramework.Ec2Client.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+				Description: aws.String("k8s-test-lattice-snva-sg"),
+				GroupName:   aws.String("k8s-test-lattice-snva-sg"),
+				VpcId:       aws.String(test.CurrentClusterVpcId),
+			})
+			Expect(err).To(BeNil())
+			sgId = v1alpha1.SecurityGroupId(*createSgOutput.GroupId)
+
+			// Create security group inbound rules only for newly created SG
+			_, err = testFramework.Ec2Client.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+				GroupId: createSgOutput.GroupId,
+				IpPermissions: []ec2types.IpPermission{
+					{ // SG Rule to allow HTTP
+						IpProtocol: aws.String("tcp"),
+						IpRanges: []ec2types.IpRange{
+							{
+								CidrIp: sourceVPC.CidrBlock,
+							},
+						},
+						FromPort: aws.Int32(80),
+						ToPort:   aws.Int32(80),
+					},
+					{ // SG Rule to allow HTTPS
+						IpProtocol: aws.String("tcp"),
+						IpRanges: []ec2types.IpRange{
+							{
+								CidrIp: sourceVPC.CidrBlock,
+							},
+						},
+						FromPort: aws.Int32(443),
+						ToPort:   aws.Int32(443),
+					},
+				},
+			})
+			Expect(err).To(BeNil())
+		}
 	})
 
 	It("Create the VpcAssociationPolicy with a SecurityGroupId and additional tags, expecting the ServiceNetworkVpcAssociation with a security group and additional tags", func() {
@@ -121,14 +135,17 @@ var _ = Describe("Test vpc association policy", Serial, Ordered, func() {
 	})
 
 	It("Update VpcAssociationPolicy with additional tags changed and attempting to override aws managed tags", func() {
-		testFramework.Get(ctx, types.NamespacedName{
-			Namespace: vpcAssociationPolicy.Namespace,
-			Name:      vpcAssociationPolicy.Name,
-		}, vpcAssociationPolicy)
-
-		vpcAssociationPolicy.ObjectMeta.Annotations["application-networking.k8s.aws/tags"] = "Environment=Prod,Project=MyApp-v2,Team=DevOps,application-networking.k8s.aws/ManagedBy=test-override"
-
-		testFramework.ExpectUpdated(ctx, vpcAssociationPolicy)
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			if err := testFramework.Get(ctx, types.NamespacedName{
+				Namespace: vpcAssociationPolicy.Namespace,
+				Name:      vpcAssociationPolicy.Name,
+			}, vpcAssociationPolicy); err != nil {
+				return err
+			}
+			vpcAssociationPolicy.ObjectMeta.Annotations["application-networking.k8s.aws/tags"] = "Environment=Prod,Project=MyApp-v2,Team=DevOps,application-networking.k8s.aws/ManagedBy=test-override"
+			return testFramework.Client.Update(ctx, vpcAssociationPolicy)
+		})
+		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func(g Gomega) {
 			associated, snva, err := testFramework.IsVpcAssociatedWithServiceNetwork(ctx, test.CurrentClusterVpcId, testServiceNetwork)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
main changes:
- setup changes for running tests in parallel
- flakiness fixes (races, conflicts)
- cleanup leaked resources / next run will reuse existing resources

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:
previous failures in merge queue

**Testing done on this change**:
ran make e2e tests

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
no


**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
n/a, test changes

**Does this PR introduce any user-facing change?**:
no

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:

```
Ran 151 of 159 Specs in 2873.509 seconds
SUCCESS! -- 151 Passed | 0 Failed | 0 Pending | 8 Skipped


Ginkgo ran 1 suite in 47m59.984858792s
Test Suite Passed

---

Ran 8 of 159 Specs in 750.802 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 151 Skipped
--- PASS: TestIntegration (750.81s)
PASS
ok      github.com/aws/aws-application-networking-k8s/test/suites/integration   751.849s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.