### PR TITLE
feat: extend ServiceImport to reference external target groups by ARN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ e2e-test: ## Run e2e tests against cluster pointed to by ~/.kube/config
 		--timeout=120m \
 		--focus="${FOCUS}" \
 		--skip="${SKIP}" \
+		--label-filter="${LABEL}" \
 		-v \
 		./suites/integration/...
 

--- a/docs/api-types/service-import.md
+++ b/docs/api-types/service-import.md
@@ -2,33 +2,42 @@
 
 ## Introduction
 
-`ServiceImport` is a resource referring to a Service outside the cluster, paired with [`ServiceExport`](service-export.md)
-resource defined in the other clusters.
+`ServiceImport` is a resource referring to a Service or VPC Lattice target group outside the cluster. It can be paired with a [`ServiceExport`](service-export.md) resource defined in another cluster, or pointed directly at an externally owned VPC Lattice target group via annotation.
 
-Just like Services, ServiceImports can be a backend reference of HTTPRoutes, GRPCRoutes, and TLSRoutes. Along with the
-cluster's own Services (and ServiceImports from even more clusters), you can distribute the traffic across multiple VPCs
-and clusters.
+Just like Services, ServiceImports can be a backend reference of HTTPRoutes, GRPCRoutes, and TLSRoutes. Along with the cluster's own Services (and ServiceImports from even more clusters), you can distribute traffic across multiple VPCs, multiple clusters, or between an EKS native backend and a pre existing VPC Lattice target group that points at non EKS workloads (ECS, Lambda, EC2, ALB).
 
-Note that ServiceImport is not the implementation of Kubernetes [Multicluster Service APIs](https://multicluster.sigs.k8s.io/concepts/multicluster-services-api/);
-instead AWS Gateway API Controller uses its own version of the resource for the purpose of Gateway API integration.
+Note that ServiceImport is not the implementation of Kubernetes [Multicluster Service APIs](https://multicluster.sigs.k8s.io/concepts/multicluster-services-api/); instead AWS Gateway API Controller uses its own version of the resource for the purpose of Gateway API integration.
 
+The controller resolves a ServiceImport to a VPC Lattice target group in one of three mutually exclusive modes, selected by which annotations are present:
+
+| Mode | Annotations on ServiceImport | Resolution |
+|---|---|---|
+| Mode 1 — Default name | _(none)_ | The controller finds a target group created by a `ServiceExport`, matched by the exported service name and namespace carried in the target group's tags. The exported service name defaults to the ServiceImport's own name, so a matching `ServiceExport` must exist for that name. |
+| Mode 2 — Tag discovery | Any of `export-name`, `aws-vpc`, `aws-eks-cluster-name` | Same `ServiceExport` tag matching as Mode 1. The difference is that `export-name` overrides which exported service name the controller looks up. It no longer has to equal the ServiceImport's own name (Mode 1's default) and can target a `ServiceExport` published under a different name. `aws-vpc` / `aws-eks-cluster-name` further narrow the match to a specific VPC or cluster (typically a `ServiceExport` in another cluster). |
+| Mode 3 — Direct external target group | `target-group-arn` | The controller resolves directly to the supplied target group ARN, regardless of who owns it. No `ServiceExport` is required. |
 
 ### Limitations
 * ServiceImport shares the limitations of [ServiceExport](service-export.md).
 * ServiceImport can only be used as a backendRef in a route (HTTPRoute, GRPCRoute, or TLSRoute); sending traffic directly is not supported.
-* BackendRef ports pointing to ServiceImport is not respected. Use [port annotation](service-export.md#annotations) of ServiceExport instead.
+* BackendRef ports pointing to ServiceImport are not respected. Use the [port annotation](service-export.md#annotations) of ServiceExport instead.
+* Under Mode 3, the external target group is treated as reference only: the controller never tags it with `ManagedBy`, never registers targets on it, and never deletes it. Lifecycle remains the responsibility of whoever originally created it.
 
 ### Annotations
-* `application-networking.k8s.aws/export-name`  
-  (Optional) When specified, the controller will find the target group created by the named ServiceExport instead of
-  matching by the ServiceImport's own name. See [ServiceExport](service-export.md) for the corresponding `service-name` annotation.
+* `application-networking.k8s.aws/export-name`<br>
+  (Optional, Mode 2) When specified, the controller will find the target group created by the named ServiceExport instead of matching by the ServiceImport's own name. See [ServiceExport](service-export.md) for the corresponding `service-name` annotation.
 
-* `application-networking.k8s.aws/aws-eks-cluster-name`  
-  (Optional) When specified, the controller will only find target groups exported from the cluster.
-* `application-networking.k8s.aws/aws-vpc`  
-  (Optional) When specified, the controller will only find target groups exported from the cluster with the provided VPC ID.
+* `application-networking.k8s.aws/aws-eks-cluster-name`<br>
+  (Optional, Mode 2) When specified, the controller will only find target groups exported from the named cluster.
+
+* `application-networking.k8s.aws/aws-vpc`<br>
+  (Optional, Mode 2) When specified, the controller will only find target groups exported from the cluster with the provided VPC ID.
+
+* `application-networking.k8s.aws/target-group-arn`<br>
+  (Optional, Mode 3) When specified, the controller resolves this ServiceImport directly to the supplied VPC Lattice target group ARN. Mutually exclusive with the Mode 2 annotations above. See [Mode 3 — Direct external target group reference](#mode-3-direct-external-target-group-reference).
 
 ## Example Configuration
+
+### Mode 1 / Mode 2 — Importing a `ServiceExport`
 
 The following yaml imports `service-1` exported from the designated cluster.
 ```yaml
@@ -39,7 +48,11 @@ metadata:
   annotations:
     application-networking.k8s.aws/aws-eks-cluster-name: "service-1-owner-cluster"
     application-networking.k8s.aws/aws-vpc: "service-1-owner-vpc-id"
-spec: {}
+spec:
+  type: ClusterSetIP
+  ports:
+  - port: 80
+    protocol: TCP
 ```
 
 The following example HTTPRoute directs traffic to the above ServiceImport.
@@ -109,3 +122,38 @@ spec:
 ```
 
 For a complete multi-cluster example, see [Cross-Cluster Routing with Same Service Names](../guides/advanced-configurations.md#cross-cluster-routing-with-same-service-names).
+
+## Mode 3 — Direct external target group reference
+
+When the `application-networking.k8s.aws/target-group-arn` annotation is present, the controller resolves the ServiceImport directly to the supplied VPC Lattice target group ARN. No `ServiceExport` is involved.
+
+Mode 3 exists mainly to migrate traffic from a non EKS workload to an EKS backend with weighted routing. For the full migration guide see [Migrate to EKS with weighted routing](../guides/migrate-to-eks.md).
+
+### Annotation
+
+* `application-networking.k8s.aws/target-group-arn`<br>
+  Full ARN of the VPC Lattice target group, e.g. `arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0abc123def4567890`. <br> Region and account are not validated against the controller's running region/account by ARN parsing. However, the controller's Lattice client is pinned to its configured region, so a cross region ARN will not resolve today and surfaces as `ExternalTargetGroupNotFound`. A cross account target group only resolves if it is reachable by the controller (e.g. RAM shared) and the controller's IAM principal can read it.
+
+### Example Configuration
+
+The following yaml references a pre existing VPC Lattice target group by ARN.
+```yaml
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: orders-legacy-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0abc123def4567890"
+spec:
+  type: ClusterSetIP
+  ports:
+  - port: 80
+    protocol: TCP
+```
+
+## See also
+
+* [Migrate to EKS with weighted routing](../guides/migrate-to-eks.md) 
+* [Service Name Override](../guides/service-name-override.md)
+* [ServiceExport](service-export.md)

--- a/docs/guides/grpc.md
+++ b/docs/guides/grpc.md
@@ -138,7 +138,11 @@ You can route gRPC traffic to services running in other clusters using `ServiceE
      name: greeter-grpc-server
      annotations:
        application-networking.k8s.aws/aws-eks-cluster-name: "exporting-cluster-name"
-   spec: {}
+   spec:
+     type: ClusterSetIP
+     ports:
+       - port: 50051
+         protocol: TCP
    ```
 
 2. *Create a GRPCRoute* referencing the ServiceImport:

--- a/docs/guides/migrate-to-eks.md
+++ b/docs/guides/migrate-to-eks.md
@@ -1,0 +1,534 @@
+# Migrate to EKS with weighted routing
+
+This guide shows how to migrate a VPC Lattice service's targets from EC2, ECS, ALB, or Lambda to EKS. The controller registers your EKS pods as a new target group on the existing service, and you shift weighted traffic from the old target group to the EKS one in steps you control. The service keeps the same URL and DNS records throughout. This guide covers the two annotations that make this work, a pre-flight checklist, a worked example for each route type, the limitations to understand first, and how to read the route status when something is wrong. It does not cover cross-account migration, which needs additional IAM and RAM configuration.
+
+VPC Lattice can split traffic across several target groups on one listener rule, and those target groups can point at any compute type. The controller adds an EKS target group alongside your existing one and shifts the weights over time. You keep control of the existing target group the whole way, because the controller never modifies it.
+
+```
+   Before                  During migration            After - Cutover done
+
+ service "orders"          service "orders"             service "orders"
+        |                    |          |                      |
+        v                    v          v                      v
+  external TG @100     external TG @90  EKS TG @10         EKS TG @100
+  (EC2/ECS/ALB/                                       
+   Lambda)                                             
+```
+
+## How the migration works
+
+Two annotations carry the feature, and you need both. The first, `application-networking.k8s.aws/target-group-arn`, goes on a `ServiceImport` and references your existing target group by its ARN. The controller treats the referenced target group as read only. It never tags it, registers targets on it, or deletes it, so you keep full ownership of that resource during the migration and after it.
+
+The second annotation, `application-networking.k8s.aws/service-name-override`, goes on the Route and tells the controller to take over the existing Lattice service of that name instead of creating a new one. The takeover preserves the service's DNS name, its service network association, and its listeners, which is what lets the migrated workload keep the same URL. The rest of this guide refers to this as the controller claiming the service.
+
+The examples below keep the Gateway and Route in the same namespace, the simplest setup, because the Route's `parentRefs` defaults to its own namespace. To split them across namespaces, set `parentRefs[].namespace` on the Route and allow its namespace in the Gateway listener's `allowedRoutes`.
+
+## Read this before you start
+
+Three behaviors are destructive or irreversible once the controller claims an existing service. Read all three before you run any command, because each can damage a production service.
+
+**Claiming a service is permanent, and deleting the Route deletes the service.** On the first reconcile the controller stamps the `application-networking.k8s.aws/ManagedBy` tag on your Lattice service and owns it from then on. The Route's lifecycle becomes the service's: deleting the Route deletes the service (the external target group survives). Delete the Route only when you intend to destroy the service itself. The delete time safety net only protects services that are still untagged, so it will not save one you have already claimed.
+
+**The Route and Gateway become the source of truth for the service's rules and listeners.** Once the controller claims a service, the Route's rules define its rules and the Gateway's listeners define its listeners. On every reconcile the controller deletes any rule or listener on the claimed service that the Route and Gateway do not define. Reproduce every rule you want to keep, and make sure your Gateway covers every listener on the service. Match each Gateway listener's protocol as well as its port, because the controller reuses an existing listener by port alone but deletes by the full port and protocol tuple. See the multi-listener example below.
+
+**A deploy failure after the claim step leaves the service half claimed.** The controller deploys in this order: target group, then targets, then the service claim (where it stamps the ownership tag), then listeners, then rules. A failure at the rule step, such as a quota breach, leaves the service already claimed and any listener the Gateway does not define already deleted, with no automatic revert. Check your quotas before you apply to avoid this.
+
+## Pre-flight checklist
+
+Run these checks before you apply anything, to avoid leaving the service in a broken, partly migrated state.
+
+First, confirm the environment. The Lattice service must live in the same AWS account as the EKS cluster. The service must already be associated with the cluster's VPC through a Service Network VPC Association (SNVA). The service must not already carry the controller's `ManagedBy` tag, because that would mean another controller owns it. Point the EKS Gateway at the same service network your existing service already uses. Claiming a service adds the Gateway's service network to it without removing the one it already has, so a Gateway on a different service network would leave the service associated with two service networks at once. Set your region with `export AWS_REGION=<cluster_region>`, and install the controller first if you have not (see [Controller Installation](deploy.md)).
+
+Next, note your existing service network, service, listeners, and rules. Your Gateway must cover every listener and your Route must reproduce every rule you want to keep, because the controller deletes any the Route and Gateway do not define. Confirm your existing rules use match types the controller supports, because an unsupported match fails the whole Route. The controller supports `Exact` and `PathPrefix` path matches and `Exact` header matches (up to five per rule). It does not support query-parameter matches.
+
+Then check the service against the limits below. The controller does not pre-validate these, so a breach surfaces as a Lattice API error during deploy, after the service is already claimed. If any projected total exceeds the default, request a quota increase first. Confirm the current values for your account in the Service Quotas console.
+
+Project what the service will hold after you apply your Route, because migration roughly doubles its target groups. Each migrating rule that had one backend now forwards to two target groups: the external one plus the new EKS one. So a listener with N rules goes from N to 2N target groups while you run weighted, and the service total grows by one target group per EKS Service backend you add.
+
+| Resource | Default limit |
+|---|---|
+| Rules per listener | 10 |
+| Listeners per service | 2 |
+| Target groups per service | 10 |
+| Targets per target group | 1000 |
+
+Finally, read the [Limitations](#limitations) before you start.
+
+## Example 1: service with single listener and single rule
+
+The simplest shape is a service with one listener and one rule that forwards to a single target group. The example adds the EKS workload as a second backend at 10 percent and claims the service named `orders`. Apply it, confirm the split, then raise the EKS weight in steps.
+
+```
+Before                              After
+service "orders"                    service "orders"
+  listener :80                        listener :80
+    / -> legacy TG @100                 / -> legacy TG @90 + EKS @10
+```
+
+First apply a Gateway.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-service-network
+  namespace: production
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+```
+
+```bash
+kubectl get gateway my-service-network -n production   # wait for PROGRAMMED=True
+```
+
+Next, create a `ServiceImport` that references your existing target group by ARN.
+
+```yaml
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: orders-legacy-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0abc123def4567890"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+```
+
+Finally, apply the `HTTPRoute`. It claims the `orders` service and splits traffic 90/10 between the external target group and the EKS Service.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: orders
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/service-name-override: "orders"
+spec:
+  parentRefs:
+    - name: my-service-network
+  rules:
+    - backendRefs:
+        - name: orders-legacy-tg
+          kind: ServiceImport
+          weight: 90
+        - name: orders-eks
+          kind: Service
+          port: 80
+          weight: 10
+```
+
+The `ServiceImport` references the external target group by ARN; see the [ServiceImport reference](../api-types/service-import.md) for the annotation contract and the placeholder `spec`. On the Route, `service-name-override: "orders"` claims the service, and the two weighted backends split traffic in proportion to their weights, so 90 and 10 sends 90 percent to the external target group and 10 percent to EKS.
+
+To shift traffic, edit the weights on the Route and reapply. The rule updates in place, so its id stays stable. When EKS is ready for all traffic, remove the `ServiceImport` backendRef so the rule forwards only to EKS. To roll back at any point, add it back (or raise its weight). The external target group is never touched and stays in your account.
+
+## Example 2: service with single listener and multiple rules
+
+A service that routes by path can migrate each path on its own timeline. Give each path its own rule, its own external target group through a separate `ServiceImport`, and its own weights. The example below migrates `/api/users` and `/api/orders` independently, so one can reach 100 percent on EKS while the other stays at 90/10.
+
+```
+Before                              After
+service "orders"                    service "orders"
+  listener :80                        listener :80
+    /api/users  -> users TG @100        /api/users  -> users TG @90 + users EKS @10
+    /api/orders -> orders TG @100       /api/orders -> orders TG @90 + orders EKS @10
+```
+
+First apply a Gateway.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-service-network
+  namespace: production
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+```
+
+Next, create one `ServiceImport` per external target group.
+
+```yaml
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: users-legacy-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0aaa111aaa111aaaa"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: orders-legacy-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0bbb222bbb222bbbb"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+```
+
+Finally, apply the `HTTPRoute`. Each rule matches a path and splits that path's traffic 90/10 between its external target group and its EKS Service.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: orders
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/service-name-override: "orders"
+spec:
+  parentRefs:
+    - name: my-service-network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/users
+      backendRefs:
+        - name: users-legacy-tg
+          kind: ServiceImport
+          weight: 90
+        - name: users-eks
+          kind: Service
+          port: 80
+          weight: 10
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/orders
+      backendRefs:
+        - name: orders-legacy-tg
+          kind: ServiceImport
+          weight: 90
+        - name: orders-eks
+          kind: Service
+          port: 80
+          weight: 10
+```
+
+Shift and promote each path independently, the same way as Example 1.
+
+## Example 3: service with multiple listeners
+
+When your existing service has more than one listener, use a single Route that sets no `sectionName`. Such a Route attaches to every Gateway listener, which puts every listener in the Route's stack and protects them all from deletion. The Gateway must declare every listener your service has. The controller writes the same rules onto every listener, so this shape fits when your listeners serve the same routing.
+
+```
+Before                              After
+service "orders"                    service "orders"
+  listener :80                        listener :80
+    /v1 -> v1 TG @100                   /v1 -> v1 TG @90 + v1 EKS @10
+    /v2 -> v2 TG @100                   /v2 -> v2 TG @90 + v2 EKS @10
+  listener :8080                      listener :8080
+    /v1 -> v1 TG @100                   /v1 -> v1 TG @90 + v1 EKS @10
+    /v2 -> v2 TG @100                   /v2 -> v2 TG @90 + v2 EKS @10
+```
+
+First apply a Gateway that declares every listener.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-service-network
+  namespace: production
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    - name: http-admin
+      protocol: HTTP
+      port: 8080
+```
+
+Next, create one `ServiceImport` per external target group.
+
+```yaml
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: orders-v1-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0aaa111aaa111aaaa"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: orders-v2-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0bbb222bbb222bbbb"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+```
+
+Finally, apply a single `HTTPRoute` with no `sectionName`, so it attaches to both listeners.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: orders
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/service-name-override: "orders"
+spec:
+  parentRefs:
+    - name: my-service-network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1
+      backendRefs:
+        - name: orders-v1-tg
+          kind: ServiceImport
+          weight: 90
+        - name: orders-v1-eks
+          kind: Service
+          port: 80
+          weight: 10
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2
+      backendRefs:
+        - name: orders-v2-tg
+          kind: ServiceImport
+          weight: 90
+        - name: orders-v2-eks
+          kind: Service
+          port: 80
+          weight: 10
+```
+
+The controller writes the same rule set onto each listener. Do not split this into two Routes that each pin one listener with `sectionName`. The controller evaluates each Route's listeners on its own, so each Route would delete the listener the other one claims, and the two would delete each other's listener on every reconcile.
+
+## Example 4: gRPC service
+
+A GRPCRoute migration follows the same weighted backend pattern as the HTTP examples, with two protocol differences. Your gRPC listeners on Lattice use the HTTPS protocol, so the Gateway listeners are HTTPS. Lattice has no native gRPC match, so the controller translates a gRPC method match into an HTTP match: it sets the method to `POST` and the path to `/<service>/<method>`, matched case sensitively. Your existing rules must already use that shape.
+
+```
+Before                              After
+service "echo" (HTTPS)              service "echo" (HTTPS)
+  listener :443                       listener :443
+    EchoService/V1 -> v1 TG @100        EchoService/V1 -> v1 TG @90 + v1 EKS @10
+    EchoService/V2 -> v2 TG @100        EchoService/V2 -> v2 TG @90 + v2 EKS @10
+```
+
+First apply a Gateway with HTTPS listeners.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-service-network
+  namespace: production
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+```
+
+Next, create one `ServiceImport` per external target group.
+
+```yaml
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: echo-v1-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0aaa111aaa111aaaa"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+---
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: echo-v2-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0bbb222bbb222bbbb"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 80
+      protocol: TCP
+```
+
+Finally, apply the `GRPCRoute`. Each rule matches a gRPC method and splits its traffic 90/10.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: echo
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/service-name-override: "echo"
+spec:
+  parentRefs:
+    - name: my-service-network
+  rules:
+    - matches:
+        - method:
+            service: echo.EchoService
+            method: V1
+      backendRefs:
+        - name: echo-v1-tg
+          kind: ServiceImport
+          weight: 90
+        - name: echo-v1-eks
+          kind: Service
+          port: 80
+          weight: 10
+    - matches:
+        - method:
+            service: echo.EchoService
+            method: V2
+      backendRefs:
+        - name: echo-v2-tg
+          kind: ServiceImport
+          weight: 90
+        - name: echo-v2-eks
+          kind: Service
+          port: 80
+          weight: 10
+```
+
+The EKS target groups here come up with health checks off, because the controller enables them by default only for HTTP/1.1. Attach a [`TargetGroupPolicy`](../api-types/target-group-policy.md) with `healthCheck.enabled: true` to turn them on.
+
+## Example 5: TLS passthrough service
+
+TLS passthrough has no rules, so the weighted forward lives on the listener's default action, and claiming the service updates that default action. TLS passthrough has three setup requirements. Your Lattice service needs a `CustomDomainName`, since Lattice requires one for a TLS passthrough listener. The Route's `spec.hostnames` must be set and match that domain; a TLSRoute without hostnames also cannot be deleted (see the [Limitations](#limitations)). The existing default action must be a forward, not a fixed response.
+
+```
+Before                              After
+service "orders" (TLS)              service "orders" (TLS)
+  listener :443                       listener :443
+    default -> legacy TG @100           default -> legacy TG @90 + EKS @10
+```
+
+First apply a Gateway with a TLS passthrough listener.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-service-network
+  namespace: production
+spec:
+  gatewayClassName: amazon-vpc-lattice
+  listeners:
+    - name: tls
+      protocol: TLS
+      port: 443
+      tls:
+        mode: Passthrough
+```
+
+Next, create a `ServiceImport` for the external target group.
+
+```yaml
+apiVersion: application-networking.k8s.aws/v1alpha1
+kind: ServiceImport
+metadata:
+  name: orders-legacy-tg
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/target-group-arn: "arn:aws:vpc-lattice:us-east-2:123456789012:targetgroup/tg-0abc123def4567890"
+spec:
+  type: ClusterSetIP
+  ports:
+    - port: 443
+      protocol: TCP
+```
+
+Finally, apply the `TLSRoute`. It has a single rule with no path match, and `hostnames` must match the service's custom domain name.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: orders
+  namespace: production
+  annotations:
+    application-networking.k8s.aws/service-name-override: "orders"
+spec:
+  parentRefs:
+    - name: my-service-network
+  hostnames:
+    - orders.example.com
+  rules:
+    - backendRefs:
+        - name: orders-legacy-tg
+          kind: ServiceImport
+          weight: 90
+        - name: orders-eks
+          kind: Service
+          port: 443
+          weight: 10
+```
+
+The EKS target group here comes up with health checks off, because TLS backends are TCP and the controller enables checks by default only for HTTP/1.1. Attach a [`TargetGroupPolicy`](../api-types/target-group-policy.md) with `healthCheck.enabled: true` to turn them on.
+
+## Limitations
+
+These are the limitations to know before you migrate.
+
+- **The controller does not change the default action on HTTP and HTTPS listeners.** Unmatched requests keep going wherever your listener already sent them. If that is a target group, the controller does not manage it.
+
+- **A TLSRoute without `spec.hostnames` cannot be deleted and gets stuck in `Terminating`.** The controller rejects it on every reconcile, including delete, so its finalizer is never removed. Always set `spec.hostnames` (Example 5 shows this). Such a Route never claimed a service, so it is safe to clear its finalizer: `kubectl patch tlsroute <name> -n <ns> --type=merge -p '{"metadata":{"finalizers":[]}}'`.
+
+- **Health checks are off by default on TCP, HTTP/2, and gRPC target groups.** Only HTTP/1.1 enables them automatically. Attach a [`TargetGroupPolicy`](../api-types/target-group-policy.md) with `healthCheck.enabled: true` to turn them on for the other types.
+
+- **The controller creates path matches as case sensitive.** If your existing rules use case insensitive path matching, check them before you migrate, because the claimed rules will start matching case sensitively.
+
+## See also
+
+- [ServiceImport](../api-types/service-import.md)
+- [HTTPRoute](../api-types/http-route.md)
+- [GRPCRoute](../api-types/grpc-route.md)
+- [TLSRoute](../api-types/tls-route.md)
+- [TargetGroupPolicy](../api-types/target-group-policy.md)
+- [Service Name Override](service-name-override.md)
+- [TLS Passthrough](tls-passthrough.md)
+- [Controller Installation](deploy.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - Drift Detection: guides/drift-detection.md
     - Additional Tags: guides/additional-tags.md
     - Service Name Override: guides/service-name-override.md
+    - Migrate to EKS: guides/migrate-to-eks.md
     - Controller Metrics: guides/metrics.md
   - API Specification: api-reference.md
   - API Reference:

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -52,8 +52,11 @@ type Cloud interface {
 	IsArnManaged(ctx context.Context, arn string) (bool, error)
 
 	// check ownership and acquire if it is not owned by anyone.
-	TryOwn(ctx context.Context, arn string) (bool, error)
-	TryOwnFromTags(ctx context.Context, arn string, tags services.Tags) (bool, error)
+	// When isDeleting=true, an untagged resource is treated as NOT owned
+	// instead of being auto adopted. This prevents teardown paths from claiming and then
+	// deleting customer created resources the controller never legitimately owned
+	TryOwn(ctx context.Context, arn string, isDeleting bool) (bool, error)
+	TryOwnFromTags(ctx context.Context, arn string, tags services.Tags, isDeleting bool) (bool, error)
 
 	// MergeTags creates a new tag map by merging baseTags and additionalTags.
 	// BaseTags will override additionalTags for any duplicate keys.
@@ -203,21 +206,23 @@ func (c *defaultCloud) IsArnManaged(ctx context.Context, arn string) (bool, erro
 	return c.isOwner(c.GetManagedByFromTags(tags)), nil
 }
 
-func (c *defaultCloud) TryOwn(ctx context.Context, arn string) (bool, error) {
-	// For resources that need backwards compatibility - not having managedBy is considered as owned by controller.
+func (c *defaultCloud) TryOwn(ctx context.Context, arn string, isDeleting bool) (bool, error) {
 	tags, err := c.getTags(ctx, arn)
 	if err != nil {
 		return false, err
 	}
-	return c.TryOwnFromTags(ctx, arn, tags)
+	return c.TryOwnFromTags(ctx, arn, tags, isDeleting)
 }
 
-func (c *defaultCloud) TryOwnFromTags(ctx context.Context, arn string, tags services.Tags) (bool, error) {
+func (c *defaultCloud) TryOwnFromTags(ctx context.Context, arn string, tags services.Tags, isDeleting bool) (bool, error) {
 	// For resources that need backwards compatibility - not having managedBy is considered as owned by controller.
 	managedBy := c.GetManagedByFromTags(tags)
 	if managedBy == "" {
-		err := c.ownResource(ctx, arn)
-		if err != nil {
+		// skip own by controller if route is being delete to prevent invalid route from owning and deleting customer service
+		if isDeleting {
+			return false, nil
+		}
+		if err := c.ownResource(ctx, arn); err != nil {
 			return false, err
 		}
 		return true, nil

--- a/pkg/aws/cloud_mocks.go
+++ b/pkg/aws/cloud_mocks.go
@@ -169,31 +169,31 @@ func (mr *MockCloudMockRecorder) Tagging() *gomock.Call {
 }
 
 // TryOwn mocks base method.
-func (m *MockCloud) TryOwn(ctx context.Context, arn string) (bool, error) {
+func (m *MockCloud) TryOwn(ctx context.Context, arn string, isDeleting bool) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TryOwn", ctx, arn)
+	ret := m.ctrl.Call(m, "TryOwn", ctx, arn, isDeleting)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TryOwn indicates an expected call of TryOwn.
-func (mr *MockCloudMockRecorder) TryOwn(ctx, arn any) *gomock.Call {
+func (mr *MockCloudMockRecorder) TryOwn(ctx, arn, isDeleting any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryOwn", reflect.TypeOf((*MockCloud)(nil).TryOwn), ctx, arn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryOwn", reflect.TypeOf((*MockCloud)(nil).TryOwn), ctx, arn, isDeleting)
 }
 
 // TryOwnFromTags mocks base method.
-func (m *MockCloud) TryOwnFromTags(ctx context.Context, arn string, tags services.Tags) (bool, error) {
+func (m *MockCloud) TryOwnFromTags(ctx context.Context, arn string, tags services.Tags, isDeleting bool) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TryOwnFromTags", ctx, arn, tags)
+	ret := m.ctrl.Call(m, "TryOwnFromTags", ctx, arn, tags, isDeleting)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TryOwnFromTags indicates an expected call of TryOwnFromTags.
-func (mr *MockCloudMockRecorder) TryOwnFromTags(ctx, arn, tags any) *gomock.Call {
+func (mr *MockCloudMockRecorder) TryOwnFromTags(ctx, arn, tags, isDeleting any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryOwnFromTags", reflect.TypeOf((*MockCloud)(nil).TryOwnFromTags), ctx, arn, tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryOwnFromTags", reflect.TypeOf((*MockCloud)(nil).TryOwnFromTags), ctx, arn, tags, isDeleting)
 }

--- a/pkg/aws/cloud_test.go
+++ b/pkg/aws/cloud_test.go
@@ -142,29 +142,59 @@ func Test_TryOwnFromTags(t *testing.T) {
 	tcs := []struct {
 		name       string
 		tags       services.Tags
+		isDeleting bool
 		owned      bool
 		tryAcquire bool
 		isErr      bool
 	}{
 		{
-			name:       "no ownership tag acquires ownership",
+			name:       "upsert + no ownership tag acquires ownership",
 			tags:       services.Tags{},
+			isDeleting: false,
 			owned:      true,
 			tryAcquire: true,
 			isErr:      false,
 		},
 		{
-			name:       "proper ownership tag considered valid",
+			name:       "delete + no ownership tag does not acquire ownership",
+			tags:       services.Tags{},
+			isDeleting: true,
+			owned:      false,
+			tryAcquire: false,
+			isErr:      false,
+		},
+		{
+			name:       "upsert + proper ownership tag acquires ownership",
 			tags:       cloud.DefaultTags(),
+			isDeleting: false,
 			owned:      true,
 			tryAcquire: false,
 			isErr:      false,
 		},
 		{
-			name: "improper ownership tag considered invalid",
+			name:       "delete + proper ownership tag acquires ownership",
+			tags:       cloud.DefaultTags(),
+			isDeleting: true,
+			owned:      true,
+			tryAcquire: false,
+			isErr:      false,
+		},
+		{
+			name: "upsert + improper ownership tag doesn't acquire ownership",
 			tags: services.Tags{
 				TagManagedBy: "not/this/owner",
 			},
+			isDeleting: false,
+			owned:      false,
+			tryAcquire: false,
+			isErr:      false,
+		},
+		{
+			name: "delete + improper ownership tag doesn't acquire ownership",
+			tags: services.Tags{
+				TagManagedBy: "not/this/owner",
+			},
+			isDeleting: true,
 			owned:      false,
 			tryAcquire: false,
 			isErr:      false,
@@ -182,7 +212,7 @@ func Test_TryOwnFromTags(t *testing.T) {
 			mockLattice.EXPECT().TagResource(gomock.Any(), &vpclattice.TagResourceInput{ResourceArn: aws.String(arn), Tags: cloud.DefaultTags()}).
 				Return(&vpclattice.TagResourceOutput{}, nil).Times(tagResourceCallCount)
 
-			res, err := cloud.TryOwnFromTags(context.Background(), arn, tc.tags)
+			res, err := cloud.TryOwnFromTags(context.Background(), arn, tc.tags, tc.isDeleting)
 
 			assert.Equal(t, tc.owned, res)
 			if tc.isErr {

--- a/pkg/controllers/route_controller.go
+++ b/pkg/controllers/route_controller.go
@@ -110,7 +110,7 @@ func RegisterAllRouteControllers(
 			scheme:           mgr.GetScheme(),
 			finalizerManager: finalizerManager,
 			eventRecorder:    mgr.GetEventRecorderFor(string(routeInfo.routeType) + "route"),
-			modelBuilder:     gateway.NewLatticeServiceBuilder(log, mgrClient, brTgBuilder, certDiscovery),
+			modelBuilder:     gateway.NewLatticeServiceBuilder(log, mgrClient, brTgBuilder, certDiscovery, cloud.Lattice()),
 			stackDeployer:    deploy.NewLatticeServiceStackDeploy(log, cloud, mgrClient),
 			stackMarshaller:  deploy.NewDefaultStackMarshaller(),
 			cloud:            cloud,
@@ -298,6 +298,20 @@ func (r *routeReconciler) findControlledParentRef(ctx context.Context, route cor
 	return gwv1.ParentReference{}, fmt.Errorf("parentRef not found for route %s", route.Name())
 }
 
+func (r *routeReconciler) setResolvedRefsFalse(ctx context.Context, route core.Route, reason, msg string) error {
+	parentRef, err := r.findControlledParentRef(ctx, route)
+	if err != nil {
+		return err
+	}
+	route.Status().UpdateParentRefs(parentRef, config.LatticeGatewayControllerName)
+	route.Status().UpdateRouteCondition(parentRef,
+		r.newCondition(route, gwv1.RouteConditionResolvedRefs, gwv1.RouteConditionReason(reason), msg))
+	if err := r.client.Status().Update(ctx, route.K8sObject()); err != nil {
+		return fmt.Errorf("failed to update route status for %s: %w", reason, err)
+	}
+	return nil
+}
+
 func (r *routeReconciler) reconcileUpsert(ctx context.Context, req ctrl.Request, route core.Route) error {
 	r.log.Infow(ctx, "reconcile, adding or updating", "name", req.Name)
 	r.eventRecorder.Event(route.K8sObject(), corev1.EventTypeNormal,
@@ -378,6 +392,23 @@ func (r *routeReconciler) reconcileUpsert(ctx context.Context, req ctrl.Request,
 				return fmt.Errorf("failed to update route status: %w", statusErr)
 			}
 			return lattice_runtime.NewRequeueNeededAfter("certificate not found, retrying", 1*time.Minute)
+		}
+		switch {
+		case k8s.IsInvalidExternalTargetGroupError(err):
+			if statusErr := r.setResolvedRefsFalse(ctx, route, "InvalidExternalTargetGroup", err.Error()); statusErr != nil {
+				return statusErr
+			}
+			return ErrExternalTargetGroupInvalid
+		case k8s.IsConflictingServiceImportAnnotationsError(err):
+			if statusErr := r.setResolvedRefsFalse(ctx, route, "ConflictingServiceImportAnnotations", err.Error()); statusErr != nil {
+				return statusErr
+			}
+			return ErrConflictingServiceImportConfig
+		case k8s.IsExternalTargetGroupNotFoundError(err):
+			if statusErr := r.setResolvedRefsFalse(ctx, route, "ExternalTargetGroupNotFound", err.Error()); statusErr != nil {
+				return statusErr
+			}
+			return lattice_runtime.NewRequeueNeededAfter("external target group not found, retrying", 1*time.Minute)
 		}
 		return err
 	}
@@ -472,9 +503,11 @@ func (r *routeReconciler) validateBackendRefsIpFamilies(ctx context.Context, rou
 }
 
 var (
-	ErrValidation          = errors.New("validation")
-	ErrParentRefsNotFound  = errors.New("parentRefs are not found")
-	ErrRouteGKNotSupported = errors.New("route GroupKind is not supported")
+	ErrValidation                     = errors.New("validation")
+	ErrParentRefsNotFound             = errors.New("parentRefs are not found")
+	ErrRouteGKNotSupported            = errors.New("route GroupKind is not supported")
+	ErrExternalTargetGroupInvalid     = errors.New("external target group annotation invalid; see route ResolvedRefs status")
+	ErrConflictingServiceImportConfig = errors.New("conflicting ServiceImport annotations; see route ResolvedRefs status")
 )
 
 // Validation for route spec. Will validate and update route status. Returns error if not valid.

--- a/pkg/controllers/route_controller_test.go
+++ b/pkg/controllers/route_controller_test.go
@@ -23,12 +23,15 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/external-dns/endpoint"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -318,7 +321,7 @@ func TestRouteReconciler_ReconcileCreates(t *testing.T) {
 		scheme:           k8sScheme,
 		finalizerManager: mockFinalizer,
 		eventRecorder:    mockEventRecorder,
-		modelBuilder:     gateway.NewLatticeServiceBuilder(gwlog.FallbackLogger, k8sClient, brTgBuilder, nil),
+		modelBuilder:     gateway.NewLatticeServiceBuilder(gwlog.FallbackLogger, k8sClient, brTgBuilder, nil, nil),
 		stackDeployer:    deploy.NewLatticeServiceStackDeploy(gwlog.FallbackLogger, mockCloud, k8sClient),
 		stackMarshaller:  deploy.NewDefaultStackMarshaller(),
 		cloud:            mockCloud,
@@ -761,4 +764,479 @@ func TestRouteReconciler_CertificateNotFound(t *testing.T) {
 	assert.Equal(t, metav1.ConditionFalse, acceptedCond.Status)
 	assert.Equal(t, "CertificateNotFound", acceptedCond.Reason)
 	assert.Contains(t, acceptedCond.Message, "no matching ACM certificate found")
+}
+
+func TestRouteReconciler_ExternalTargetGroupStatusSurfacing(t *testing.T) {
+	const arn = "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06"
+
+	tests := []struct {
+		name           string
+		buildErr       error
+		expectedReason string
+		outcome        string
+		expectedErr    error
+	}{
+		{
+			name:           "malformed ARN -> InvalidExternalTargetGroup, error backoff",
+			buildErr:       k8s.NewInvalidExternalTargetGroupError("not-an-arn", fmt.Errorf("not a valid ARN")),
+			expectedReason: "InvalidExternalTargetGroup",
+			outcome:        "errorBackoff",
+			expectedErr:    ErrExternalTargetGroupInvalid,
+		},
+		{
+			name:           "conflicting annotations -> ConflictingServiceImportAnnotations, error backoff",
+			buildErr:       k8s.NewConflictingServiceImportAnnotationsError("target-group-arn together with export-name"),
+			expectedReason: "ConflictingServiceImportAnnotations",
+			outcome:        "errorBackoff",
+			expectedErr:    ErrConflictingServiceImportConfig,
+		},
+		{
+			name:           "TG not found -> ExternalTargetGroupNotFound, fixed 1-min requeue",
+			buildErr:       k8s.NewExternalTargetGroupNotFoundError(arn, "us-west-2", fmt.Errorf("not found")),
+			expectedReason: "ExternalTargetGroupNotFound",
+			outcome:        "fixedRequeue",
+		},
+		{
+			name:           "transient error -> no condition, bare return",
+			buildErr:       fmt.Errorf("throttled"),
+			expectedReason: "",
+			outcome:        "errorNoCond",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
+
+			k8sScheme := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sScheme)
+			gwv1.Install(k8sScheme)
+			gwv1alpha2.Install(k8sScheme)
+			discoveryv1.AddToScheme(k8sScheme)
+			addOptionalCRDs(k8sScheme)
+
+			gwClass := &gwv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "amazon-vpc-lattice"},
+				Spec:       gwv1.GatewayClassSpec{ControllerName: config.LatticeGatewayControllerName},
+			}
+			gw := &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "ns1"},
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "amazon-vpc-lattice",
+					Listeners:        []gwv1.Listener{{Name: "http", Protocol: "HTTP", Port: 80}},
+				},
+			}
+			route := &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "ns1"},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{{Name: "my-gateway"}},
+					},
+				},
+			}
+
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sScheme).
+				WithObjects(gwClass, gw, route).
+				WithStatusSubresource(&gwv1.HTTPRoute{}).
+				Build()
+
+			mockBuilder := gateway.NewMockLatticeServiceBuilder(c)
+			mockBuilder.EXPECT().Build(gomock.Any(), gomock.Any()).Return(nil, tt.buildErr)
+
+			mockEventRecorder := mock_client.NewMockEventRecorder(c)
+			mockEventRecorder.EXPECT().Event(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+			mockFinalizer := k8s.NewMockFinalizerManager(c)
+			mockFinalizer.EXPECT().AddFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			rc := routeReconciler{
+				routeType:        core.HttpRouteType,
+				log:              gwlog.FallbackLogger,
+				client:           k8sClient,
+				scheme:           k8sScheme,
+				finalizerManager: mockFinalizer,
+				eventRecorder:    mockEventRecorder,
+				modelBuilder:     mockBuilder,
+			}
+
+			routeName := k8s.NamespacedName(route)
+			result, err := rc.Reconcile(ctx, reconcile.Request{NamespacedName: routeName})
+
+			updatedRoute := &gwv1.HTTPRoute{}
+			assert.NoError(t, k8sClient.Get(ctx, routeName, updatedRoute))
+
+			var resolvedRefsCond, acceptedCond *metav1.Condition
+			for _, parent := range updatedRoute.Status.Parents {
+				for i, cond := range parent.Conditions {
+					switch cond.Type {
+					case string(gwv1.RouteConditionResolvedRefs):
+						resolvedRefsCond = &parent.Conditions[i]
+					case string(gwv1.RouteConditionAccepted):
+						acceptedCond = &parent.Conditions[i]
+					}
+				}
+			}
+
+			switch tt.outcome {
+			case "errorNoCond":
+				assert.Error(t, err)
+				assert.Equal(t, time.Duration(0), result.RequeueAfter)
+				if resolvedRefsCond != nil {
+					assert.Equal(t, metav1.ConditionTrue, resolvedRefsCond.Status,
+						"transient error must not flip ResolvedRefs to False")
+				}
+				return
+			case "errorBackoff":
+				assert.ErrorIs(t, err, tt.expectedErr)
+				assert.Equal(t, time.Duration(0), result.RequeueAfter, "sentinel error must not set a fixed RequeueAfter")
+			case "fixedRequeue":
+				assert.NoError(t, err)
+				assert.Equal(t, 1*time.Minute, result.RequeueAfter, "not-found must requeue after a fixed 1 min")
+			default:
+				t.Fatalf("unknown outcome %q", tt.outcome)
+			}
+
+			assert.NotNil(t, resolvedRefsCond, "ResolvedRefs condition must be persisted")
+			assert.Equal(t, metav1.ConditionFalse, resolvedRefsCond.Status)
+			assert.Equal(t, tt.expectedReason, resolvedRefsCond.Reason)
+			assert.Equal(t, route.GetGeneration(), resolvedRefsCond.ObservedGeneration)
+
+			if acceptedCond != nil {
+				assert.NotEqual(t, metav1.ConditionFalse, acceptedCond.Status,
+					"external-TG failure must leave Accepted untouched (not False)")
+			}
+		})
+	}
+}
+
+func TestRouteReconciler_ExternalTargetGroupStatusWriteFailureNotMasked(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	k8sScheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(k8sScheme)
+	gwv1.Install(k8sScheme)
+	gwv1alpha2.Install(k8sScheme)
+	discoveryv1.AddToScheme(k8sScheme)
+	addOptionalCRDs(k8sScheme)
+
+	gwClass := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "amazon-vpc-lattice"},
+		Spec:       gwv1.GatewayClassSpec{ControllerName: config.LatticeGatewayControllerName},
+	}
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "ns1"},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "amazon-vpc-lattice",
+			Listeners:        []gwv1.Listener{{Name: "http", Protocol: "HTTP", Port: 80}},
+		},
+	}
+	route := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "ns1"},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: "my-gateway"}},
+			},
+		},
+	}
+
+	statusUpdateErr := fmt.Errorf("simulated status update failure")
+	k8sClient := testclient.NewClientBuilder().
+		WithScheme(k8sScheme).
+		WithObjects(gwClass, gw, route).
+		WithStatusSubresource(&gwv1.HTTPRoute{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if subResourceName == "status" {
+					return statusUpdateErr
+				}
+				return cl.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	mockBuilder := gateway.NewMockLatticeServiceBuilder(c)
+	mockBuilder.EXPECT().Build(gomock.Any(), gomock.Any()).Return(
+		nil, k8s.NewExternalTargetGroupNotFoundError("arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06", "us-west-2", fmt.Errorf("not found"))).AnyTimes()
+
+	mockEventRecorder := mock_client.NewMockEventRecorder(c)
+	mockEventRecorder.EXPECT().Event(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockFinalizer := k8s.NewMockFinalizerManager(c)
+	mockFinalizer.EXPECT().AddFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	rc := routeReconciler{
+		routeType:        core.HttpRouteType,
+		log:              gwlog.FallbackLogger,
+		client:           k8sClient,
+		scheme:           k8sScheme,
+		finalizerManager: mockFinalizer,
+		eventRecorder:    mockEventRecorder,
+		modelBuilder:     mockBuilder,
+	}
+
+	routeName := k8s.NamespacedName(route)
+	_, err := rc.Reconcile(ctx, reconcile.Request{NamespacedName: routeName})
+
+	assert.Error(t, err)
+}
+
+type noopStackDeployer struct{ deployed bool }
+
+func (d *noopStackDeployer) Deploy(ctx context.Context, stack core.Stack) error {
+	d.deployed = true
+	return nil
+}
+
+func TestRouteReconciler_DeleteRoute_ExternalTgFinalizerNotStranded(t *testing.T) {
+	config.VpcID = "my-vpc"
+	config.ClusterName = "my-cluster"
+
+	const (
+		finalizer = "httproute.k8s.aws/resources"
+		svcImport = "external-import"
+	)
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+	}{
+		{
+			name:        "malformed external-TG ARN on delete -> finalizer removed",
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+		},
+		{
+			name: "conflicting external-TG annotations on delete -> finalizer removed",
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06",
+				k8s.ExportNameAnnotation:     "some-export",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
+
+			k8sScheme := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sScheme)
+			gwv1.Install(k8sScheme)
+			gwv1alpha2.Install(k8sScheme)
+			discoveryv1.AddToScheme(k8sScheme)
+			anv1alpha1.Install(k8sScheme)
+			addOptionalCRDs(k8sScheme)
+
+			gwClass := &gwv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "amazon-vpc-lattice"},
+				Spec:       gwv1.GatewayClassSpec{ControllerName: config.LatticeGatewayControllerName},
+			}
+			gw := &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "ns1"},
+				Spec: gwv1.GatewaySpec{
+					GatewayClassName: "amazon-vpc-lattice",
+					Listeners:        []gwv1.Listener{{Name: "http", Protocol: "HTTP", Port: 80}},
+				},
+			}
+			si := &anv1alpha1.ServiceImport{
+				ObjectMeta: metav1.ObjectMeta{Name: svcImport, Namespace: "ns1", Annotations: tt.annotations},
+			}
+			kind := gwv1.Kind("ServiceImport")
+			now := metav1.Now()
+			route := &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "my-route",
+					Namespace:         "ns1",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{finalizer},
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{{Name: "my-gateway"}},
+					},
+					Rules: []gwv1.HTTPRouteRule{
+						{
+							BackendRefs: []gwv1.HTTPBackendRef{
+								{BackendRef: gwv1.BackendRef{
+									BackendObjectReference: gwv1.BackendObjectReference{
+										Kind: &kind,
+										Name: svcImport,
+									},
+									Weight: aws.Int32(90),
+								}},
+							},
+						},
+					},
+				},
+			}
+
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sScheme).
+				WithObjects(gwClass, gw, si, route).
+				WithStatusSubresource(&gwv1.HTTPRoute{}, &gwv1.Gateway{}).
+				Build()
+
+			mockLattice := mocks.NewMockLattice(c)
+			mockLattice.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ interface{}, _ ...interface{}) (interface{}, error) {
+					t.Fatalf("GetTargetGroup must not be called on the delete path")
+					return nil, nil
+				}).AnyTimes()
+
+			mockEventRecorder := mock_client.NewMockEventRecorder(c)
+			mockEventRecorder.EXPECT().Event(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+			brTgBuilder := gateway.NewBackendRefTargetGroupBuilder(gwlog.FallbackLogger, k8sClient)
+			deployer := &noopStackDeployer{}
+
+			rc := routeReconciler{
+				routeType:        core.HttpRouteType,
+				log:              gwlog.FallbackLogger,
+				client:           k8sClient,
+				scheme:           k8sScheme,
+				finalizerManager: k8s.NewDefaultFinalizerManager(k8sClient),
+				eventRecorder:    mockEventRecorder,
+				modelBuilder:     gateway.NewLatticeServiceBuilder(gwlog.FallbackLogger, k8sClient, brTgBuilder, nil, mockLattice),
+				stackDeployer:    deployer,
+				stackMarshaller:  deploy.NewDefaultStackMarshaller(),
+			}
+
+			routeName := k8s.NamespacedName(route)
+			result, err := rc.Reconcile(ctx, reconcile.Request{NamespacedName: routeName})
+
+			assert.NoError(t, err)
+			assert.Equal(t, time.Duration(0), result.RequeueAfter)
+
+			updated := &gwv1.HTTPRoute{}
+			getErr := k8sClient.Get(ctx, routeName, updated)
+			if getErr == nil {
+				assert.NotContains(t, updated.Finalizers, finalizer,
+					"route finalizer must be removed on delete (not stuck Terminating)")
+			} else {
+				assert.True(t, apierrors.IsNotFound(getErr),
+					"route should be gone after its last finalizer is removed; got: %v", getErr)
+			}
+		})
+	}
+}
+
+func TestRouteReconciler_UpsertRoute_ExternalTgClientReachesGetTargetGroup(t *testing.T) {
+	config.VpcID = "my-vpc"
+	config.ClusterName = "my-cluster"
+
+	const (
+		svcImport = "external-import"
+		arn       = "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06"
+	)
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	k8sScheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(k8sScheme)
+	gwv1.Install(k8sScheme)
+	gwv1alpha2.Install(k8sScheme)
+	discoveryv1.AddToScheme(k8sScheme)
+	anv1alpha1.Install(k8sScheme)
+	addOptionalCRDs(k8sScheme)
+
+	gwClass := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "amazon-vpc-lattice"},
+		Spec:       gwv1.GatewayClassSpec{ControllerName: config.LatticeGatewayControllerName},
+	}
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-gateway", Namespace: "ns1"},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "amazon-vpc-lattice",
+			Listeners:        []gwv1.Listener{{Name: "http", Protocol: "HTTP", Port: 80}},
+		},
+	}
+	si := &anv1alpha1.ServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        svcImport,
+			Namespace:   "ns1",
+			Annotations: map[string]string{k8s.TargetGroupArnAnnotation: arn},
+		},
+	}
+	kind := gwv1.Kind("ServiceImport")
+	route := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "ns1"},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: "my-gateway"}},
+			},
+			Rules: []gwv1.HTTPRouteRule{
+				{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{Kind: &kind, Name: svcImport},
+							Weight:                 aws.Int32(90),
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	k8sClient := testclient.NewClientBuilder().
+		WithScheme(k8sScheme).
+		WithObjects(gwClass, gw, si, route).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &gwv1.Gateway{}).
+		Build()
+
+	var gotIdentifier string
+	gtgCalls := 0
+	mockLattice := mocks.NewMockLattice(c)
+	mockLattice.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, in *vpclattice.GetTargetGroupInput, _ ...func(*vpclattice.Options)) (*vpclattice.GetTargetGroupOutput, error) {
+			gtgCalls++
+			gotIdentifier = aws.ToString(in.TargetGroupIdentifier)
+			return nil, mocks.NewNotFoundError("TargetGroup", arn)
+		}).AnyTimes()
+
+	mockEventRecorder := mock_client.NewMockEventRecorder(c)
+	mockEventRecorder.EXPECT().Event(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockFinalizer := k8s.NewMockFinalizerManager(c)
+	mockFinalizer.EXPECT().AddFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	brTgBuilder := gateway.NewBackendRefTargetGroupBuilder(gwlog.FallbackLogger, k8sClient)
+	rc := routeReconciler{
+		routeType:        core.HttpRouteType,
+		log:              gwlog.FallbackLogger,
+		client:           k8sClient,
+		scheme:           k8sScheme,
+		finalizerManager: mockFinalizer,
+		eventRecorder:    mockEventRecorder,
+		modelBuilder:     gateway.NewLatticeServiceBuilder(gwlog.FallbackLogger, k8sClient, brTgBuilder, nil, mockLattice),
+		stackDeployer:    &noopStackDeployer{},
+		stackMarshaller:  deploy.NewDefaultStackMarshaller(),
+	}
+
+	routeName := k8s.NamespacedName(route)
+	result, err := rc.Reconcile(ctx, reconcile.Request{NamespacedName: routeName})
+
+	assert.Positive(t, gtgCalls, "GetTargetGroup must be called on the real upsert path")
+	assert.Equal(t, arn, gotIdentifier, "GetTargetGroup must be called with the annotation ARN")
+	assert.NoError(t, err)
+	assert.Equal(t, 1*time.Minute, result.RequeueAfter)
+
+	updated := &gwv1.HTTPRoute{}
+	assert.NoError(t, k8sClient.Get(ctx, routeName, updated))
+	var resolvedRefsCond *metav1.Condition
+	for _, parent := range updated.Status.Parents {
+		for i, cond := range parent.Conditions {
+			if cond.Type == string(gwv1.RouteConditionResolvedRefs) {
+				resolvedRefsCond = &parent.Conditions[i]
+			}
+		}
+	}
+	assert.NotNil(t, resolvedRefsCond, "ResolvedRefs condition must be persisted")
+	assert.Equal(t, metav1.ConditionFalse, resolvedRefsCond.Status)
+	assert.Equal(t, "ExternalTargetGroupNotFound", resolvedRefsCond.Reason)
 }

--- a/pkg/deploy/lattice/listener_manager_test.go
+++ b/pkg/deploy/lattice/listener_manager_test.go
@@ -248,6 +248,62 @@ func Test_UpsertListener_Update_TLS_PASSTHROUGHListener(t *testing.T) {
 			},
 			expectUpdateListenerCall: true,
 		},
+		{
+			name: "External target group id matches existing listener, listener not updated",
+			oldLatticeListenerDefaultAction: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: aws.String("tg-0df85aff983932f06"), Weight: aws.Int32(90)},
+					},
+				},
+			},
+			newLatticeListenerDefaultAction: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: aws.String("tg-0df85aff983932f06"), Weight: aws.Int32(90)},
+					},
+				},
+			},
+			newModelListenerDefaultAction: &model.DefaultAction{
+				Forward: &model.RuleAction{
+					TargetGroups: []*model.RuleTargetGroup{
+						{LatticeTgId: "tg-0df85aff983932f06", Weight: 90},
+					},
+				},
+			},
+			expectUpdateListenerCall: false,
+		},
+		{
+			name: "External target group ARN differs from existing listener, listener updated every reconcile",
+			oldLatticeListenerDefaultAction: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: aws.String("tg-0df85aff983932f06"), Weight: aws.Int32(90)},
+					},
+				},
+			},
+			newLatticeListenerDefaultAction: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{
+							TargetGroupIdentifier: aws.String("arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06"),
+							Weight:                aws.Int32(90),
+						},
+					},
+				},
+			},
+			newModelListenerDefaultAction: &model.DefaultAction{
+				Forward: &model.RuleAction{
+					TargetGroups: []*model.RuleTargetGroup{
+						{
+							LatticeTgId: "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06",
+							Weight:      90,
+						},
+					},
+				},
+			},
+			expectUpdateListenerCall: true,
+		},
 	}
 
 	c := gomock.NewController(t)

--- a/pkg/deploy/lattice/rule_manager_test.go
+++ b/pkg/deploy/lattice/rule_manager_test.go
@@ -706,3 +706,112 @@ func Test_RuleManager_WithTakeoverAnnotation_UpdateTags(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "existing-arn", ruleStatus.Arn)
 }
+
+func Test_RuleManager_ExternalTargetGroupIdMatchesExistingRule_NoUpdate(t *testing.T) {
+	const bareId = "tg-0df85aff983932f06"
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+	mockLattice := mocks.NewMockLattice(c)
+	mockTagging := mocks.NewMockTagging(c)
+	cloud := pkg_aws.NewDefaultCloudWithTagging(mockLattice, mockTagging, TestCloudConfig)
+
+	svc := &model.Service{Status: &model.ServiceStatus{Id: "svc-id"}}
+	l := &model.Listener{
+		Spec:   model.ListenerSpec{Port: 80, Protocol: "HTTP"},
+		Status: &model.ListenerStatus{Id: "listener-id"},
+	}
+	r := &model.Rule{
+		Spec: model.RuleSpec{
+			Priority: 1,
+			Method:   "POST",
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					{LatticeTgId: bareId, Weight: 1},
+				},
+			},
+		},
+	}
+
+	mockLattice.EXPECT().GetRulesAsList(ctx, gomock.Any()).Return(
+		[]*vpclattice.GetRuleOutput{
+			{
+				Id:    aws.String("existing-id"),
+				Arn:   aws.String("existing-arn"),
+				Match: &types.RuleMatchMemberHttpMatch{Value: types.HttpMatch{Method: aws.String("POST")}},
+				Action: &types.RuleActionMemberForward{
+					Value: types.ForwardAction{
+						TargetGroups: []types.WeightedTargetGroup{
+							{TargetGroupIdentifier: aws.String(bareId), Weight: aws.Int32(1)},
+						},
+					},
+				},
+				Name:     aws.String("existing-name"),
+				Priority: aws.Int32(1),
+			},
+		}, nil)
+
+	mockTagging.EXPECT().UpdateTags(ctx, "existing-arn", gomock.Nil(), nil).Return(nil)
+
+	mockLattice.EXPECT().UpdateRule(ctx, gomock.Any()).Times(0)
+
+	rm := NewRuleManager(gwlog.FallbackLogger, cloud)
+	ruleStatus, err := rm.Upsert(ctx, r, l, svc)
+	assert.Nil(t, err)
+	assert.Equal(t, "existing-arn", ruleStatus.Arn)
+}
+
+func Test_RuleManager_ExternalTargetGroupArnDiffersFromExistingRule_Updates(t *testing.T) {
+	const (
+		fullArn = "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06"
+		bareId  = "tg-0df85aff983932f06"
+	)
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+	mockLattice := mocks.NewMockLattice(c)
+	mockTagging := mocks.NewMockTagging(c)
+	cloud := pkg_aws.NewDefaultCloudWithTagging(mockLattice, mockTagging, TestCloudConfig)
+
+	svc := &model.Service{Status: &model.ServiceStatus{Id: "svc-id"}}
+	l := &model.Listener{
+		Spec:   model.ListenerSpec{Port: 80, Protocol: "HTTP"},
+		Status: &model.ListenerStatus{Id: "listener-id"},
+	}
+	r := &model.Rule{
+		Spec: model.RuleSpec{
+			Priority: 1,
+			Method:   "POST",
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					{LatticeTgId: fullArn, Weight: 1},
+				},
+			},
+		},
+	}
+	mockLattice.EXPECT().GetRulesAsList(ctx, gomock.Any()).Return(
+		[]*vpclattice.GetRuleOutput{
+			{
+				Id:    aws.String("existing-id"),
+				Arn:   aws.String("existing-arn"),
+				Match: &types.RuleMatchMemberHttpMatch{Value: types.HttpMatch{Method: aws.String("POST")}},
+				Action: &types.RuleActionMemberForward{
+					Value: types.ForwardAction{
+						TargetGroups: []types.WeightedTargetGroup{
+							{TargetGroupIdentifier: aws.String(bareId), Weight: aws.Int32(1)},
+						},
+					},
+				},
+				Name:     aws.String("existing-name"),
+				Priority: aws.Int32(1),
+			},
+		}, nil)
+
+	mockTagging.EXPECT().UpdateTags(ctx, "existing-arn", gomock.Nil(), nil).Return(nil)
+	mockLattice.EXPECT().UpdateRule(ctx, gomock.Any()).Return(
+		&vpclattice.UpdateRuleOutput{Id: aws.String("existing-id"), Arn: aws.String("existing-arn")}, nil).Times(1)
+
+	rm := NewRuleManager(gwlog.FallbackLogger, cloud)
+	_, err := rm.Upsert(ctx, r, l, svc)
+	assert.Nil(t, err)
+}

--- a/pkg/deploy/lattice/service_manager.go
+++ b/pkg/deploy/lattice/service_manager.go
@@ -143,7 +143,7 @@ func svcStatusFromCreateSvcResp(resp *CreateSvcResp) ServiceInfo {
 	return svcInfo
 }
 
-func (m *defaultServiceManager) checkAndUpdateTags(ctx context.Context, svc *Service, svcSum *SvcSummary) error {
+func (m *defaultServiceManager) checkAndUpdateTags(ctx context.Context, svc *Service, svcSum *SvcSummary, isDeleting bool) error {
 	tagsResp, err := m.cloud.Lattice().ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
 		ResourceArn: svcSum.Arn,
 	})
@@ -151,7 +151,7 @@ func (m *defaultServiceManager) checkAndUpdateTags(ctx context.Context, svc *Ser
 		return err
 	}
 
-	owned, err := m.cloud.TryOwnFromTags(ctx, *svcSum.Arn, tagsResp.Tags)
+	owned, err := m.cloud.TryOwnFromTags(ctx, *svcSum.Arn, tagsResp.Tags, isDeleting)
 	if err != nil {
 		return err
 	}
@@ -429,7 +429,7 @@ func (m *defaultServiceManager) Upsert(ctx context.Context, svc *Service) (Servi
 	if svcSum == nil {
 		svcInfo, err = m.createServiceAndAssociate(ctx, svc)
 	} else {
-		err = m.checkAndUpdateTags(ctx, svc, svcSum)
+		err = m.checkAndUpdateTags(ctx, svc, svcSum, false)
 		if err != nil {
 			return ServiceInfo{}, err
 		}
@@ -451,7 +451,7 @@ func (m *defaultServiceManager) Delete(ctx context.Context, svc *Service) error 
 		}
 	}
 
-	err = m.checkAndUpdateTags(ctx, svc, svcSum)
+	err = m.checkAndUpdateTags(ctx, svc, svcSum, true)
 	if err != nil {
 		m.log.Infof(ctx, "Service %s is either invalid or not owned. Skipping VPC Lattice resource deletion.", svc.LatticeServiceName())
 		return nil

--- a/pkg/deploy/lattice/service_manager_test.go
+++ b/pkg/deploy/lattice/service_manager_test.go
@@ -1134,3 +1134,52 @@ func TestDeleteAssociation_ConflictException_ReturnsRetryError(t *testing.T) {
 	var retryErr *lattice_runtime.RequeueNeededAfter
 	assert.True(t, errors.As(err, &retryErr))
 }
+
+func Test_Delete_SkipsServiceNotOwnedByController(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	mockLattice := mocks.NewMockLattice(c)
+	mockTagging := mocks.NewMockTagging(c)
+	cfg := pkg_aws.CloudConfig{VpcId: "vpc-id", AccountId: "account-id", ClusterName: "cluster"}
+	cl := pkg_aws.NewDefaultCloudWithTagging(mockLattice, mockTagging, cfg)
+	ctx := context.Background()
+	m := NewServiceManager(gwlog.FallbackLogger, cl)
+
+	svc := &Service{
+		Spec: model.ServiceSpec{
+			ServiceTagFields: model.ServiceTagFields{
+				RouteName:      "claim-target",
+				RouteNamespace: "ns",
+				RouteType:      core.HttpRouteType,
+			},
+			ServiceNetworkNames: []string{"sn"},
+		},
+	}
+
+	mockLattice.EXPECT().
+		FindService(gomock.Any(), gomock.Any()).
+		Return(&types.ServiceSummary{
+			Arn:    aws.String("arn:aws:vpc-lattice:us-east-2:123456789012:service/svc-claim-target"),
+			Id:     aws.String("svc-id"),
+			Name:   aws.String(svc.LatticeServiceName()),
+			Status: types.ServiceStatusActive,
+		}, nil).
+		Times(1)
+
+	mockLattice.EXPECT().ListTagsForResource(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *vpclattice.ListTagsForResourceInput, _ ...interface{}) (*vpclattice.ListTagsForResourceOutput, error) {
+			return &vpclattice.ListTagsForResourceOutput{Tags: map[string]string{}}, nil
+		}).
+		Times(1)
+
+	mockLattice.EXPECT().DeleteService(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().DeleteServiceNetworkServiceAssociation(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().DeleteListener(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().ListServiceNetworkServiceAssociationsAsList(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().ListListenersAsList(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().TagResource(gomock.Any(), gomock.Any()).Times(0)
+
+	err := m.Delete(ctx, svc)
+	assert.Nil(t, err)
+}

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -68,7 +68,7 @@ func (m *defaultServiceNetworkManager) UpsertVpcAssociation(ctx context.Context,
 
 		if isLocal {
 			// For local networks, check ownership as before
-			owned, err := m.cloud.TryOwn(ctx, *snva.Arn)
+			owned, err := m.cloud.TryOwn(ctx, *snva.Arn, false)
 			if err != nil {
 				return "", err
 			}
@@ -298,7 +298,7 @@ func (m *defaultServiceNetworkManager) Upsert(ctx context.Context, name string, 
 
 	// SN exists, adopt it
 	snArn := aws.ToString(sn.SvcNetwork.Arn)
-	owned, err := m.cloud.TryOwn(ctx, snArn)
+	owned, err := m.cloud.TryOwn(ctx, snArn, false)
 	if err != nil {
 		return model.ServiceNetworkStatus{}, fmt.Errorf("failed to check ownership of ServiceNetwork %s: %w", name, err)
 	}

--- a/pkg/deploy/lattice/target_group_manager_test.go
+++ b/pkg/deploy/lattice/target_group_manager_test.go
@@ -1755,3 +1755,52 @@ func Test_fillDefaultHealthCheckConfig_PolicyIntegration(t *testing.T) {
 		})
 	}
 }
+
+func Test_ResolveRuleTgIds_KeepsResolvedExternalTargetGroupId(t *testing.T) {
+	config.VpcID = "vpc-id"
+	config.ClusterName = "cluster-name"
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	mockLattice := mocks.NewMockLattice(c)
+	mockTagging := mocks.NewMockTagging(c)
+	mockCloud := pkg_aws.NewMockCloud(c)
+	mockCloud.EXPECT().Lattice().Return(mockLattice).AnyTimes()
+	mockCloud.EXPECT().Tagging().Return(mockTagging).AnyTimes()
+
+	mockLattice.EXPECT().ListTargetGroupsAsList(gomock.Any(), gomock.Any()).Times(0)
+	mockTagging.EXPECT().GetTagsForArns(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().DeregisterTargets(gomock.Any(), gomock.Any()).Times(0)
+	mockLattice.EXPECT().DeleteTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+
+	stack := core.NewDefaultStack(core.StackID{Name: "foo", Namespace: "bar"})
+	stackRule := &model.Rule{
+		ResourceMeta: core.NewResourceMeta(stack, "AWS:VPCServiceNetwork::Rule", "rule-id"),
+		Spec: model.RuleSpec{
+			Action: model.RuleAction{
+				TargetGroups: []*model.RuleTargetGroup{
+					{
+						LatticeTgId: "tg-0df85aff983932f06",
+						SvcImportTG: &model.SvcImportTargetGroup{
+							K8SClusterName:      "cluster-name",
+							K8SServiceName:      "svc-name",
+							K8SServiceNamespace: "ns",
+							VpcId:               "vpc-id",
+						},
+						Weight: 90,
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, stack.AddResource(stackRule))
+
+	s := NewTargetGroupManager(gwlog.FallbackLogger, mockCloud, nil)
+	assert.NoError(t, s.ResolveRuleTgIds(ctx, &stackRule.Spec.Action, stack))
+
+	assert.Equal(t, "tg-0df85aff983932f06", stackRule.Spec.Action.TargetGroups[0].LatticeTgId)
+	assert.Empty(t, stackRule.Spec.Action.TargetGroups[0].StackTargetGroupId)
+}

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -568,3 +568,71 @@ func Test_SynthesizeCreate_WithNonServiceExportTargetGroup(t *testing.T) {
 	err = synthesizer.SynthesizeCreate(ctx)
 	assert.NoError(t, err)
 }
+
+func Test_SynthesizeUnusedDelete_ExternalTgRouteRebuild(t *testing.T) {
+	ctx := context.TODO()
+
+	config.VpcID = "vpc-id"
+	config.ClusterName = "cluster-name"
+
+	orphanTg := copyTgOutput(getBaseTg())
+	orphanTg.tgSummary.Arn = aws.String("tg-orphan-arn")
+	orphanTg.tags[model.K8SSourceTypeKey] = string(model.SourceTypeHTTPRoute)
+	orphanTg.tags[model.K8SRouteNameKey] = "route"
+	orphanTg.tags[model.K8SRouteNamespaceKey] = "route-ns"
+	orphanTg.tags[model.K8SProtocolVersionKey] = "HTTP1"
+
+	t.Run("route rebuild succeeds and target group no longer matches, orphan deleted", func(t *testing.T) {
+		c := gomock.NewController(t)
+		defer c.Finish()
+		mockTGManager := NewMockTargetGroupManager(c)
+		mockClient := mock_client.NewMockClient(c)
+		mockSvcBuilder := gateway.NewMockLatticeServiceBuilder(c)
+
+		mockTGManager.EXPECT().List(ctx).Return([]tgListOutput{orphanTg}, nil)
+		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, name apitypes.NamespacedName, route client.Object, _ ...interface{}) error {
+				route.SetName("route")
+				route.SetNamespace("route-ns")
+				return nil
+			},
+		)
+		emptyStack := core.NewDefaultStack(core.StackID{Name: "route", Namespace: "route-ns"})
+		nonMatchingTg := model.TargetGroup{
+			ResourceMeta: core.NewResourceMeta(emptyStack, "AWS:VPCServiceNetwork::TargetGroup", "tg-other"),
+		}
+		emptyStack.AddResource(&nonMatchingTg)
+		mockSvcBuilder.EXPECT().Build(ctx, gomock.Any()).Return(emptyStack, nil)
+		mockTGManager.EXPECT().IsTargetGroupMatch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(false, nil)
+		mockTGManager.EXPECT().Delete(ctx, gomock.Any()).Return(nil)
+
+		synthesizer := NewTargetGroupSynthesizer(
+			gwlog.FallbackLogger, nil, mockClient, mockTGManager, nil, mockSvcBuilder, nil)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
+		assert.Nil(t, err)
+	})
+
+	t.Run("route rebuild errors, orphan kept", func(t *testing.T) {
+		c := gomock.NewController(t)
+		defer c.Finish()
+		mockTGManager := NewMockTargetGroupManager(c)
+		mockClient := mock_client.NewMockClient(c)
+		mockSvcBuilder := gateway.NewMockLatticeServiceBuilder(c)
+
+		mockTGManager.EXPECT().List(ctx).Return([]tgListOutput{orphanTg}, nil)
+		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, name apitypes.NamespacedName, route client.Object, _ ...interface{}) error {
+				route.SetName("route")
+				route.SetNamespace("route-ns")
+				return nil
+			},
+		)
+		mockSvcBuilder.EXPECT().Build(ctx, gomock.Any()).Return(nil, assert.AnError)
+
+		synthesizer := NewTargetGroupSynthesizer(
+			gwlog.FallbackLogger, nil, mockClient, mockTGManager, nil, mockSvcBuilder, nil)
+		_, err := synthesizer.SynthesizeUnusedDelete(ctx)
+		assert.Nil(t, err)
+	})
+}

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -72,7 +72,7 @@ func NewLatticeServiceStackDeploy(
 
 	tgMgr := lattice.NewTargetGroupManager(log, cloud, k8sClient)
 	tgSvcExpBuilder := gateway.NewSvcExportTargetGroupBuilder(log, k8sClient)
-	svcBuilder := gateway.NewLatticeServiceBuilder(log, k8sClient, brTgBuilder, nil)
+	svcBuilder := gateway.NewLatticeServiceBuilder(log, k8sClient, brTgBuilder, nil, nil)
 
 	tgGcOnce.Do(func() {
 		// TODO: need to refactor TG synthesizer. Remove stack from constructor
@@ -255,7 +255,7 @@ func NewTargetGroupStackDeploy(
 		k8sclient:          k8sClient,
 		targetGroupManager: lattice.NewTargetGroupManager(log, cloud, k8sClient),
 		svcExportTgBuilder: gateway.NewSvcExportTargetGroupBuilder(log, k8sClient),
-		svcBuilder:         gateway.NewLatticeServiceBuilder(log, k8sClient, brTgBuilder, nil),
+		svcBuilder:         gateway.NewLatticeServiceBuilder(log, k8sClient, brTgBuilder, nil, nil),
 	}
 }
 

--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -33,6 +33,7 @@ type LatticeServiceModelBuilder struct {
 	client        client.Client
 	brTgBuilder   BackendRefTargetGroupModelBuilder
 	certDiscovery services.CertificateDiscovery
+	lattice       services.Lattice
 }
 
 func NewLatticeServiceBuilder(
@@ -40,12 +41,14 @@ func NewLatticeServiceBuilder(
 	client client.Client,
 	brTgBuilder BackendRefTargetGroupModelBuilder,
 	certDiscovery services.CertificateDiscovery,
+	lattice services.Lattice,
 ) *LatticeServiceModelBuilder {
 	return &LatticeServiceModelBuilder{
 		log:           log,
 		client:        client,
 		brTgBuilder:   brTgBuilder,
 		certDiscovery: certDiscovery,
+		lattice:       lattice,
 	}
 }
 
@@ -62,6 +65,7 @@ func (b *LatticeServiceModelBuilder) Build(
 		client:        b.client,
 		brTgBuilder:   b.brTgBuilder,
 		certDiscovery: b.certDiscovery,
+		lattice:       b.lattice,
 	}
 
 	if err := task.run(ctx); err != nil {
@@ -310,6 +314,7 @@ type latticeServiceModelBuildTask struct {
 	stack         core.Stack
 	brTgBuilder   BackendRefTargetGroupModelBuilder
 	certDiscovery services.CertificateDiscovery
+	lattice       services.Lattice
 }
 
 // isStandaloneMode determines if standalone mode should be enabled for the route.

--- a/pkg/gateway/model_build_listener_test.go
+++ b/pkg/gateway/model_build_listener_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -1385,6 +1387,284 @@ func Test_BuildListeners_AllowedRoutesFilterIndividualListeners(t *testing.T) {
 				}
 				assert.ElementsMatch(t, tt.expectedListenerPorts, actualPorts, tt.description)
 			}
+		})
+	}
+}
+
+func Test_ListenerModelBuild_TLSPassthrough_ExternalTargetGroup(t *testing.T) {
+	const (
+		validArn = "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06"
+		bareId   = "tg-0df85aff983932f06"
+	)
+	var sectionName gwv1.SectionName = "my-gw-listener"
+	var serviceKind gwv1.Kind = "Service"
+	var serviceImportKind gwv1.Kind = "ServiceImport"
+	const svcImportName = "external-import"
+	tlsModePassthrough := gwv1.TLSModePassthrough
+
+	vpcLatticeGatewayClass := gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gwClass"},
+		Spec:       gwv1.GatewayClassSpec{ControllerName: config.LatticeGatewayControllerName},
+	}
+	vpcLatticeGateway := gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway1", Namespace: "default"},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: gwv1.ObjectName(vpcLatticeGatewayClass.Name),
+			Listeners: []gwv1.Listener{
+				{
+					Port:     443,
+					Protocol: "TLS",
+					Name:     sectionName,
+					TLS:      &gwv1.ListenerTLSConfig{Mode: &tlsModePassthrough},
+				},
+			},
+		},
+	}
+
+	newTLSRoute := func(backendRefs []gwv1.BackendRef, deleting bool) core.Route {
+		om := metav1.ObjectMeta{Name: "service1", Namespace: "default"}
+		if deleting {
+			now := metav1.Now()
+			om.DeletionTimestamp = &now
+			om.Finalizers = []string{"test-finalizer"}
+		}
+		route := core.NewTLSRoute(gwv1.TLSRoute{
+			ObjectMeta: om,
+			Spec: gwv1.TLSRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{
+						{Name: gwv1.ObjectName(vpcLatticeGateway.Name), SectionName: &sectionName},
+					},
+				},
+				Rules: []gwv1.TLSRouteRule{{BackendRefs: backendRefs}},
+			},
+		})
+		route.Status().SetParents([]gwv1.RouteParentStatus{
+			{
+				ParentRef: gwv1.ParentReference{
+					Name:        gwv1.ObjectName(vpcLatticeGateway.Name),
+					SectionName: &sectionName,
+				},
+				Conditions: []metav1.Condition{
+					{Type: string(gwv1.RouteConditionAccepted), Status: metav1.ConditionTrue},
+				},
+			},
+		})
+		return route
+	}
+
+	externalImportRef := gwv1.BackendRef{
+		BackendObjectReference: gwv1.BackendObjectReference{
+			Name: gwv1.ObjectName(svcImportName),
+			Kind: &serviceImportKind,
+		},
+		Weight: aws.Int32(90),
+	}
+	eksServiceRef := gwv1.BackendRef{
+		BackendObjectReference: gwv1.BackendObjectReference{
+			Name: "k8s-service1",
+			Kind: &serviceKind,
+		},
+		Weight: aws.Int32(10),
+	}
+
+	tests := []struct {
+		name          string
+		backendRefs   []gwv1.BackendRef
+		annotations   map[string]string
+		mockLattice   func(m *services.MockLattice)
+		deleting      bool
+		eksStackTgIds []string
+		wantErr       bool
+		wantErrIs     func(error) bool
+		noListener    bool
+		expectedTGs   []*model.RuleTargetGroup
+	}{
+		{
+			name:        "single external-TG ServiceImport resolves to bare id in listener default action",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), &vpclattice.GetTargetGroupInput{
+					TargetGroupIdentifier: aws.String(validArn),
+				}).Return(&vpclattice.GetTargetGroupOutput{
+					Id: aws.String(bareId), Arn: aws.String(validArn),
+				}, nil)
+			},
+			expectedTGs: []*model.RuleTargetGroup{
+				{LatticeTgId: bareId, Weight: 90},
+			},
+		},
+		{
+			name:          "weighted mix: external-TG ServiceImport + EKS Service in the single passthrough rule",
+			backendRefs:   []gwv1.BackendRef{externalImportRef, eksServiceRef},
+			annotations:   map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			eksStackTgIds: []string{"k8s-service1"},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Return(&vpclattice.GetTargetGroupOutput{
+					Id: aws.String(bareId), Arn: aws.String(validArn),
+				}, nil)
+			},
+			expectedTGs: []*model.RuleTargetGroup{
+				{LatticeTgId: bareId, Weight: 90},
+				{StackTargetGroupId: "k8s-service1", Weight: 10},
+			},
+		},
+		{
+			name:        "malformed ARN fails the TLS build with InvalidExternalTargetGroupError",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsInvalidExternalTargetGroupError,
+		},
+		{
+			name:        "conflict: target-group-arn + export-name → ConflictingServiceImportAnnotationsError",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.ExportNameAnnotation:     "some-export",
+			},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsConflictingServiceImportAnnotationsError,
+		},
+		{
+			name:        "conflict: blank-but-set aws-vpc DOES trigger (key-presence semantics)",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.AwsVpcAnnotation:         "", // blank but set still counts as present
+			},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsConflictingServiceImportAnnotationsError,
+		},
+		{
+			name:        "nil client (GC path): skips existence check, LatticeTgId = bare id",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: nil,
+			expectedTGs: []*model.RuleTargetGroup{
+				{LatticeTgId: bareId, Weight: 90},
+			},
+		},
+		{
+			name:        "nil client (GC path): skips conflict check → no error, LatticeTgId = bare id",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.ExportNameAnnotation:     "some-export",
+			},
+			mockLattice: nil,
+			expectedTGs: []*model.RuleTargetGroup{
+				{LatticeTgId: bareId, Weight: 90},
+			},
+		},
+		{
+			name:        "nil client (GC path): malformed ARN tolerated → no error, id discarded",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+			mockLattice: nil,
+			expectedTGs: []*model.RuleTargetGroup{
+				{LatticeTgId: "", Weight: 90},
+			},
+		},
+		{
+			name:        "delete path: malformed ARN tolerated, no listener built, no error",
+			backendRefs: []gwv1.BackendRef{externalImportRef},
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+			mockLattice: nil,
+			deleting:    true,
+			noListener:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			gwv1.Install(k8sSchema)
+			gwv1alpha2.Install(k8sSchema)
+			anv1alpha1.Install(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+
+			assert.NoError(t, k8sClient.Create(ctx, vpcLatticeGatewayClass.DeepCopy()))
+			assert.NoError(t, k8sClient.Create(ctx, vpcLatticeGateway.DeepCopy()))
+			assert.NoError(t, k8sClient.Create(ctx, &anv1alpha1.ServiceImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        svcImportName,
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}))
+
+			route := newTLSRoute(tt.backendRefs, tt.deleting)
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(route.K8sObject())))
+
+			mockBrTgBuilder := NewMockBackendRefTargetGroupModelBuilder(c)
+			for _, id := range tt.eksStackTgIds {
+				id := id
+				mockBrTgBuilder.EXPECT().Build(ctx, route, gomock.Any(), gomock.Any()).
+					Return(nil, &model.TargetGroup{
+						ResourceMeta: core.NewResourceMeta(stack, "AWS:VPCServiceNetwork::TargetGroup", id),
+					}, nil)
+			}
+
+			var lattice services.Lattice
+			if tt.mockLattice != nil {
+				m := services.NewMockLattice(c)
+				tt.mockLattice(m)
+				lattice = m
+			}
+
+			task := &latticeServiceModelBuildTask{
+				log:         gwlog.FallbackLogger,
+				route:       route,
+				client:      k8sClient,
+				stack:       stack,
+				brTgBuilder: mockBrTgBuilder,
+				lattice:     lattice,
+			}
+
+			err := task.buildListeners(ctx, "svc-id")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.True(t, tt.wantErrIs(err), "error did not match expected predicate: %v", err)
+				}
+				return
+			}
+			assert.NoError(t, err)
+
+			var resListener []*model.Listener
+			stack.ListResources(&resListener)
+
+			if tt.noListener {
+				assert.Equal(t, 0, len(resListener), "a deleting route must build no listener")
+				return
+			}
+			assert.Equal(t, 1, len(resListener), "expected exactly one TLS_PASSTHROUGH listener")
+
+			spec := resListener[0].Spec
+			assert.Equal(t, string(types.ListenerProtocolTlsPassthrough), spec.Protocol)
+			assert.NotNil(t, spec.DefaultAction, "TLS passthrough listener must carry a default action")
+			assert.NotNil(t, spec.DefaultAction.Forward, "TLS passthrough default action must be a Forward")
+			assert.Nil(t, spec.DefaultAction.FixedResponseStatusCode,
+				"TLS passthrough default action must not be a fixed response")
+			assert.Equal(t, tt.expectedTGs, spec.DefaultAction.Forward.TargetGroups,
+				"external target group must resolve to its id in the listener default action")
 		})
 	}
 }

--- a/pkg/gateway/model_build_rule.go
+++ b/pkg/gateway/model_build_rule.go
@@ -5,15 +5,20 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apitypes "k8s.io/apimachinery/pkg/types"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
+	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -284,31 +289,68 @@ func (t *latticeServiceModelBuildTask) getTargetGroupsForRuleAction(ctx context.
 				if !apierrors.IsNotFound(err) {
 					return nil, err
 				}
+
+				if override, _ := k8s.GetServiceNameOverrideWithValidation(t.route.K8sObject()); override != "" {
+					return nil, fmt.Errorf("ServiceImport %s/%s referenced by route %s/%s with service-name-override=%q does not exist; refusing to claim the existing service",
+						namespace, string(backendRef.Name()),
+						t.route.Namespace(), t.route.Name(), override)
+				}
 			}
 
-			// Use annotation-based export name resolution
-			exportName := k8s.GetExportNameFromServiceImport(svcImport)
-			if exportName == "" {
-				exportName = string(backendRef.Name())
-			}
+			tgArn := strings.TrimSpace(svcImport.Annotations[k8s.TargetGroupArnAnnotation])
+			if tgArn != "" {
+				isUpsert := t.lattice != nil && t.route.DeletionTimestamp().IsZero()
+				if !isUpsert {
+					id, _ := k8s.TargetGroupIdFromArn(tgArn)
+					ruleTG.LatticeTgId = id
+				} else {
+					if k8s.ServiceImportHasTagDiscoveryAnnotation(svcImport.GetAnnotations()) {
+						return nil, k8s.NewConflictingServiceImportAnnotationsError(
+							fmt.Sprintf("ServiceImport %s/%s sets %s together with a tag-discovery annotation "+
+								"(%s / %s / %s); set exactly one",
+								svcImportName.Namespace, svcImportName.Name, k8s.TargetGroupArnAnnotation,
+								k8s.ExportNameAnnotation, k8s.AwsVpcAnnotation, k8s.AwsEksClusterNameAnnotation))
+					}
+					if _, err := k8s.TargetGroupIdFromArn(tgArn); err != nil {
+						return nil, k8s.NewInvalidExternalTargetGroupError(tgArn, err)
+					}
+					out, rerr := t.lattice.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+						TargetGroupIdentifier: aws.String(tgArn),
+					})
+					if rerr != nil {
+						var ade *types.AccessDeniedException
+						if services.IsNotFoundError(rerr) || errors.As(rerr, &ade) {
+							return nil, k8s.NewExternalTargetGroupNotFoundError(tgArn, config.Region, rerr)
+						}
+						return nil, rerr
+					}
+					ruleTG.LatticeTgId = aws.ToString(out.Id)
+				}
+			} else {
+				// Use annotation-based export name resolution
+				exportName := k8s.GetExportNameFromServiceImport(svcImport)
+				if exportName == "" {
+					exportName = string(backendRef.Name())
+				}
 
-			// there needs to be a pre-existing target group, we fetch all the fields
-			// needed to identify it
-			svcImportTg := model.SvcImportTargetGroup{
-				K8SServiceNamespace: namespace,
-				K8SServiceName:      exportName,
-			}
+				// there needs to be a pre-existing target group, we fetch all the fields
+				// needed to identify it
+				svcImportTg := model.SvcImportTargetGroup{
+					K8SServiceNamespace: namespace,
+					K8SServiceName:      exportName,
+				}
 
-			vpc, ok := svcImport.Annotations["application-networking.k8s.aws/aws-vpc"]
-			if ok {
-				svcImportTg.VpcId = vpc
-			}
+				vpc, ok := svcImport.Annotations[k8s.AwsVpcAnnotation]
+				if ok {
+					svcImportTg.VpcId = vpc
+				}
 
-			eksCluster, ok := svcImport.Annotations["application-networking.k8s.aws/aws-eks-cluster-name"]
-			if ok {
-				svcImportTg.K8SClusterName = eksCluster
+				eksCluster, ok := svcImport.Annotations[k8s.AwsEksClusterNameAnnotation]
+				if ok {
+					svcImportTg.K8SClusterName = eksCluster
+				}
+				ruleTG.SvcImportTG = &svcImportTg
 			}
-			ruleTG.SvcImportTG = &svcImportTg
 		}
 
 		if string(*backendRef.Kind()) == "Service" {

--- a/pkg/gateway/model_build_rule_test.go
+++ b/pkg/gateway/model_build_rule_test.go
@@ -2,16 +2,19 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -2044,6 +2047,354 @@ func Test_ServiceImportAnnotationMapping(t *testing.T) {
 				assert.Equal(t, tt.expectedVPC, targetGroup.SvcImportTG.VpcId,
 					"VPC ID should match expected value")
 			}
+		})
+	}
+}
+
+func Test_RuleModelBuild_ExternalTargetGroup(t *testing.T) {
+	const (
+		validArn = "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0df85aff983932f06"
+		bareId   = "tg-0df85aff983932f06"
+	)
+	var serviceImportKind gwv1.Kind = "ServiceImport"
+	var httpSectionName gwv1.SectionName = "http"
+	const svcImportName = "external-import"
+
+	newRoute := func(grpc, deleting bool) core.Route {
+		om := apimachineryv1.ObjectMeta{Name: "test-route", Namespace: "default"}
+		if deleting {
+			now := apimachineryv1.Now()
+			om.DeletionTimestamp = &now
+			om.Finalizers = []string{"test-finalizer"}
+		}
+		backendRef := gwv1.BackendRef{
+			BackendObjectReference: gwv1.BackendObjectReference{
+				Name: gwv1.ObjectName(svcImportName),
+				Kind: &serviceImportKind,
+			},
+		}
+		parentRefs := []gwv1.ParentReference{{Name: "gw1", SectionName: &httpSectionName}}
+		if grpc {
+			return core.NewGRPCRoute(gwv1.GRPCRoute{
+				ObjectMeta: om,
+				Spec: gwv1.GRPCRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: parentRefs},
+					Rules: []gwv1.GRPCRouteRule{{
+						BackendRefs: []gwv1.GRPCBackendRef{{BackendRef: backendRef}},
+					}},
+				},
+			})
+		}
+		return core.NewHTTPRoute(gwv1.HTTPRoute{
+			ObjectMeta: om,
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: parentRefs},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{{BackendRef: backendRef}},
+				}},
+			},
+		})
+	}
+
+	tests := []struct {
+		name            string
+		grpc            bool
+		deleting        bool
+		annotations     map[string]string
+		mockLattice     func(m *services.MockLattice)
+		wantErr         bool
+		wantErrIs       func(error) bool
+		wantLatticeTgId string
+	}{
+		{
+			name:        "HTTPRoute with valid external target group resolves to its id",
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), &vpclattice.GetTargetGroupInput{
+					TargetGroupIdentifier: aws.String(validArn),
+				}).Return(&vpclattice.GetTargetGroupOutput{
+					Id: aws.String(bareId), Arn: aws.String(validArn),
+				}, nil)
+			},
+			wantLatticeTgId: bareId,
+		},
+		{
+			name:        "GRPCRoute with valid external target group resolves to its id",
+			grpc:        true,
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Return(&vpclattice.GetTargetGroupOutput{
+					Id: aws.String(bareId), Arn: aws.String(validArn),
+				}, nil)
+			},
+			wantLatticeTgId: bareId,
+		},
+		{
+			name: "target-group-arn with export-name is a conflict",
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.ExportNameAnnotation:     "some-export",
+			},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsConflictingServiceImportAnnotationsError,
+		},
+		{
+			name: "target-group-arn with a blank but present aws-vpc is a conflict",
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.AwsVpcAnnotation:         "",
+			},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsConflictingServiceImportAnnotationsError,
+		},
+		{
+			name:        "malformed ARN returns InvalidExternalTargetGroupError",
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsInvalidExternalTargetGroupError,
+		},
+		{
+			name:        "target group not found returns ExternalTargetGroupNotFoundError",
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).
+					Return(nil, &types.ResourceNotFoundException{Message: aws.String("nope")})
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsExternalTargetGroupNotFoundError,
+		},
+		{
+			name:        "access denied returns ExternalTargetGroupNotFoundError",
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).
+					Return(nil, &types.AccessDeniedException{Message: aws.String("denied")})
+			},
+			wantErr:   true,
+			wantErrIs: k8s.IsExternalTargetGroupNotFoundError,
+		},
+		{
+			name:        "transient error is returned as-is, not classified as not found",
+			annotations: map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice: func(m *services.MockLattice) {
+				m.EXPECT().GetTargetGroup(gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("throttled"))
+			},
+			wantErr: true,
+			wantErrIs: func(err error) bool {
+				return err != nil && !k8s.IsExternalTargetGroupNotFoundError(err) &&
+					!k8s.IsInvalidExternalTargetGroupError(err)
+			},
+		},
+		{
+			name:            "nil client resolves the id without an existence check",
+			annotations:     map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice:     nil,
+			wantLatticeTgId: bareId,
+		},
+		{
+			name: "nil client skips the conflict check and resolves the id",
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.ExportNameAnnotation:     "some-export",
+			},
+			mockLattice:     nil,
+			wantLatticeTgId: bareId,
+		},
+		{
+			name:            "nil client skips the ARN-format check and leaves the id empty",
+			annotations:     map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+			mockLattice:     nil,
+			wantLatticeTgId: "",
+		},
+		{
+			name:            "delete path with valid ARN skips the existence check and resolves the id",
+			deleting:        true,
+			annotations:     map[string]string{k8s.TargetGroupArnAnnotation: validArn},
+			mockLattice:     nil,
+			wantLatticeTgId: bareId,
+		},
+		{
+			name:            "delete path tolerates a malformed ARN and leaves the id empty",
+			deleting:        true,
+			annotations:     map[string]string{k8s.TargetGroupArnAnnotation: "not-an-arn"},
+			mockLattice:     nil,
+			wantLatticeTgId: "",
+		},
+		{
+			name:     "delete path tolerates conflicting annotations",
+			deleting: true,
+			annotations: map[string]string{
+				k8s.TargetGroupArnAnnotation: validArn,
+				k8s.ExportNameAnnotation:     "some-export",
+			},
+			mockLattice:     nil,
+			wantLatticeTgId: bareId,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
+
+			k8sSchema := runtime.NewScheme()
+			k8sSchema.AddKnownTypes(anv1alpha1.SchemeGroupVersion, &anv1alpha1.ServiceImport{})
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+
+			serviceImport := &anv1alpha1.ServiceImport{
+				ObjectMeta: apimachineryv1.ObjectMeta{
+					Name:        svcImportName,
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+			assert.NoError(t, k8sClient.Create(ctx, serviceImport))
+
+			route := newRoute(tt.grpc, tt.deleting)
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(route.K8sObject())))
+
+			var lattice services.Lattice
+			if tt.mockLattice != nil {
+				m := services.NewMockLattice(c)
+				tt.mockLattice(m)
+				lattice = m
+			}
+
+			task := &latticeServiceModelBuildTask{
+				log:         gwlog.FallbackLogger,
+				route:       route,
+				stack:       stack,
+				client:      k8sClient,
+				brTgBuilder: &dummyTgBuilder{},
+				lattice:     lattice,
+			}
+
+			err := task.buildRules(ctx, "listener-id")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.True(t, tt.wantErrIs(err), "error did not match expected predicate: %v", err)
+				}
+				return
+			}
+			assert.NoError(t, err)
+
+			var rtg *model.RuleTargetGroup
+			if tt.deleting {
+				ruleTgList, gErr := task.getTargetGroupsForRuleAction(ctx, route.Spec().Rules()[0])
+				assert.NoError(t, gErr)
+				assert.Equal(t, 1, len(ruleTgList), "expected exactly one rule target group")
+				rtg = ruleTgList[0]
+			} else {
+				var resRules []*model.Rule
+				stack.ListResources(&resRules)
+				assert.Equal(t, 1, len(resRules), "expected exactly one rule on the stack")
+				assert.Equal(t, 1, len(resRules[0].Spec.Action.TargetGroups), "expected exactly one target group")
+				rtg = resRules[0].Spec.Action.TargetGroups[0]
+			}
+
+			assert.Equal(t, tt.wantLatticeTgId, rtg.LatticeTgId)
+			assert.Nil(t, rtg.SvcImportTG)
+			assert.Empty(t, rtg.StackTargetGroupId)
+		})
+	}
+}
+
+func Test_RuleModelBuild_MissingServiceImport_WithClaim(t *testing.T) {
+	const missingSvcImportName = "does-not-exist"
+	var serviceImportKind gwv1.Kind = "ServiceImport"
+	var httpSectionName gwv1.SectionName = "http"
+
+	newRoute := func(serviceNameOverride string) core.Route {
+		om := apimachineryv1.ObjectMeta{Name: "test-route", Namespace: "default"}
+		if serviceNameOverride != "" {
+			om.Annotations = map[string]string{
+				"application-networking.k8s.aws/service-name-override": serviceNameOverride,
+			}
+		}
+		return core.NewHTTPRoute(gwv1.HTTPRoute{
+			ObjectMeta: om,
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{Name: "gw1", SectionName: &httpSectionName}},
+				},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{{
+						BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(missingSvcImportName),
+								Kind: &serviceImportKind,
+							},
+						},
+					}},
+				}},
+			},
+		})
+	}
+
+	tests := []struct {
+		name                string
+		serviceNameOverride string
+		wantErr             bool
+		wantErrSubstr       string
+	}{
+		{
+			name:                "without service-name-override a missing ServiceImport is tolerated",
+			serviceNameOverride: "",
+			wantErr:             false,
+		},
+		{
+			name:                "with service-name-override a missing ServiceImport fails the build",
+			serviceNameOverride: "claim-target",
+			wantErr:             true,
+			wantErrSubstr:       "does not exist; refusing to claim the existing service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := gomock.NewController(t)
+			defer c.Finish()
+			ctx := context.TODO()
+
+			k8sSchema := runtime.NewScheme()
+			k8sSchema.AddKnownTypes(anv1alpha1.SchemeGroupVersion, &anv1alpha1.ServiceImport{})
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+
+			route := newRoute(tt.serviceNameOverride)
+			stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(route.K8sObject())))
+			task := &latticeServiceModelBuildTask{
+				log:         gwlog.FallbackLogger,
+				route:       route,
+				stack:       stack,
+				client:      k8sClient,
+				brTgBuilder: &dummyTgBuilder{},
+			}
+
+			err := task.buildRules(ctx, "listener-id")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrSubstr != "" {
+					assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				}
+				return
+			}
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,6 +47,12 @@ const (
 	// Export name annotation for ServiceImport to ServiceExport mapping
 	ExportNameAnnotation = AnnotationPrefix + "export-name"
 
+	// TargetGroupArnAnnotation references external target group by its full arn on a ServiceImport
+	TargetGroupArnAnnotation = AnnotationPrefix + "target-group-arn"
+
+	AwsVpcAnnotation            = AnnotationPrefix + "aws-vpc"
+	AwsEksClusterNameAnnotation = AnnotationPrefix + "aws-eks-cluster-name"
+
 	// AWS tag validation limits
 	maxTagKeyLength   = 128
 	maxTagValueLength = 256
@@ -52,7 +60,8 @@ const (
 )
 
 var (
-	tagPattern = regexp.MustCompile(`^([\p{L}\p{Z}\p{N}_.:\/=+\-@]*)$`)
+	tagPattern         = regexp.MustCompile(`^([\p{L}\p{Z}\p{N}_.:\/=+\-@]*)$`)
+	targetGroupIdRegex = regexp.MustCompile(`^targetgroup/tg-[0-9a-z]{17}$`)
 )
 
 type Tags = map[string]string
@@ -530,4 +539,81 @@ func GetExportNameFromServiceImport(serviceImport client.Object) string {
 		}
 	}
 	return ""
+}
+
+func TargetGroupIdFromArn(s string) (string, error) {
+	a, err := arn.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("not a valid ARN: %w", err)
+	}
+	if a.Service != "vpc-lattice" {
+		return "", fmt.Errorf("expected a vpc-lattice ARN, got service %q", a.Service)
+	}
+	if !targetGroupIdRegex.MatchString(a.Resource) {
+		return "", fmt.Errorf("expected a target group ARN (targetgroup/tg-...), got resource %q", a.Resource)
+	}
+	return strings.TrimPrefix(a.Resource, "targetgroup/"), nil
+}
+
+func ServiceImportHasTagDiscoveryAnnotation(annotations map[string]string) bool {
+	for _, key := range []string{ExportNameAnnotation, AwsVpcAnnotation, AwsEksClusterNameAnnotation} {
+		if _, ok := annotations[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+type InvalidExternalTargetGroupError struct {
+	Arn string
+	Err error
+}
+
+func (e *InvalidExternalTargetGroupError) Error() string {
+	return fmt.Sprintf("invalid external target group ARN %q: %v", e.Arn, e.Err)
+}
+
+func NewInvalidExternalTargetGroupError(arn string, err error) error {
+	return &InvalidExternalTargetGroupError{Arn: arn, Err: err}
+}
+
+func IsInvalidExternalTargetGroupError(err error) bool {
+	target := &InvalidExternalTargetGroupError{}
+	return errors.As(err, &target)
+}
+
+type ExternalTargetGroupNotFoundError struct {
+	Arn    string
+	Region string
+	Err    error
+}
+
+func (e *ExternalTargetGroupNotFoundError) Error() string {
+	return fmt.Sprintf("external target group %q could not be found in region %q: %v", e.Arn, e.Region, e.Err)
+}
+
+func NewExternalTargetGroupNotFoundError(arn, region string, err error) error {
+	return &ExternalTargetGroupNotFoundError{Arn: arn, Region: region, Err: err}
+}
+
+func IsExternalTargetGroupNotFoundError(err error) bool {
+	target := &ExternalTargetGroupNotFoundError{}
+	return errors.As(err, &target)
+}
+
+type ConflictingServiceImportAnnotationsError struct {
+	Detail string
+}
+
+func (e *ConflictingServiceImportAnnotationsError) Error() string {
+	return fmt.Sprintf("conflicting ServiceImport annotations: %s", e.Detail)
+}
+
+func NewConflictingServiceImportAnnotationsError(detail string) error {
+	return &ConflictingServiceImportAnnotationsError{Detail: detail}
+}
+
+func IsConflictingServiceImportAnnotationsError(err error) bool {
+	target := &ConflictingServiceImportAnnotationsError{}
+	return errors.As(err, &target)
 }

--- a/pkg/k8s/utils_test.go
+++ b/pkg/k8s/utils_test.go
@@ -1671,3 +1671,239 @@ func TestGetServiceNameOverrideWithValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestTargetGroupIdFromArn(t *testing.T) {
+	tests := []struct {
+		name    string
+		arn     string
+		wantID  string
+		wantErr bool
+	}{
+		{
+			name:    "valid lattice target group arn",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0",
+			wantID:  "tg-0123456789abcdef0",
+			wantErr: false,
+		},
+		{
+			name:    "valid arn in another partition",
+			arn:     "arn:aws-us-gov:vpc-lattice:us-gov-west-1:123456789012:targetgroup/tg-00112233445566778",
+			wantID:  "tg-00112233445566778",
+			wantErr: false,
+		},
+		{
+			name:    "not an arn",
+			arn:     "tg-0123456789abcdef0",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			arn:     "",
+			wantErr: true,
+		},
+		{
+			name:    "wrong service",
+			arn:     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tg/abc",
+			wantErr: true,
+		},
+		{
+			name:    "lattice arn but wrong resource type (service)",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:service/svc-0123456789abcdef0",
+			wantErr: true,
+		},
+		{
+			name:    "lattice targetgroup resource without tg- prefix",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/notatg",
+			wantErr: true,
+		},
+		{
+			name:    "missing resource section",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012",
+			wantErr: true,
+		},
+		{
+			name:    "degenerate empty target group id",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-",
+			wantErr: true,
+		},
+		{
+			name:    "id too short",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-abc123",
+			wantErr: true,
+		},
+		{
+			name:    "id too long",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef01",
+			wantErr: true,
+		},
+		{
+			name:    "uppercase in target group id",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-ABCDEF01234567890",
+			wantErr: true,
+		},
+		{
+			name:    "trailing path segment in resource",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0/extra",
+			wantErr: true,
+		},
+		{
+			name:    "colon-bearing resource",
+			arn:     "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0:foo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := TargetGroupIdFromArn(tt.arn)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, id, "id must be empty on error")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantID, id)
+			}
+		})
+	}
+}
+
+func TestHasTagDiscoveryAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		ann  map[string]string
+		want bool
+	}{
+		{
+			name: "nil annotations",
+			ann:  nil,
+			want: false,
+		},
+		{
+			name: "empty annotations",
+			ann:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "export-name set",
+			ann:  map[string]string{ExportNameAnnotation: "my-export"},
+			want: true,
+		},
+		{
+			name: "aws-vpc set",
+			ann:  map[string]string{AwsVpcAnnotation: "vpc-0123456789abcdef0"},
+			want: true,
+		},
+		{
+			name: "aws-eks-cluster-name set",
+			ann:  map[string]string{AwsEksClusterNameAnnotation: "my-cluster"},
+			want: true,
+		},
+		{
+			name: "all three tag-discovery annotations set",
+			ann: map[string]string{
+				ExportNameAnnotation:        "my-export",
+				AwsVpcAnnotation:            "vpc-0123456789abcdef0",
+				AwsEksClusterNameAnnotation: "my-cluster",
+			},
+			want: true,
+		},
+		{
+			name: "all three tag-discovery annotations plus target-group-arn",
+			ann: map[string]string{
+				ExportNameAnnotation:        "my-export",
+				AwsVpcAnnotation:            "vpc-0123456789abcdef0",
+				AwsEksClusterNameAnnotation: "my-cluster",
+				TargetGroupArnAnnotation:    "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0",
+			},
+			want: true,
+		},
+		{
+			name: "only unrelated annotation",
+			ann:  map[string]string{TargetGroupArnAnnotation: "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0"},
+			want: false,
+		},
+		{
+			name: "blank-but-set export-name still counts",
+			ann:  map[string]string{ExportNameAnnotation: ""},
+			want: true,
+		},
+		{
+			name: "blank-but-set aws-vpc still counts",
+			ann:  map[string]string{AwsVpcAnnotation: ""},
+			want: true,
+		},
+		{
+			name: "whitespace-only aws-vpc still counts",
+			ann:  map[string]string{AwsVpcAnnotation: "   "},
+			want: true,
+		},
+		{
+			name: "blank tag-discovery alongside a real target-group-arn counts",
+			ann: map[string]string{
+				AwsVpcAnnotation:         "",
+				TargetGroupArnAnnotation: "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0",
+			},
+			want: true,
+		},
+		{
+			name: "real aws-vpc alongside target-group-arn counts",
+			ann: map[string]string{
+				AwsVpcAnnotation:         "vpc-0123456789abcdef0",
+				TargetGroupArnAnnotation: "arn:aws:vpc-lattice:us-west-2:123456789012:targetgroup/tg-0123456789abcdef0",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ServiceImportHasTagDiscoveryAnnotation(tt.ann))
+		})
+	}
+}
+
+func TestExternalTargetGroupTypedErrors(t *testing.T) {
+	invalid := NewInvalidExternalTargetGroupError("tg-bad", errors.New("boom"))
+	notFound := NewExternalTargetGroupNotFoundError("arn:tg", "us-west-2", errors.New("404"))
+	conflict := NewConflictingServiceImportAnnotationsError("target-group-arn + export-name")
+
+	t.Run("each Is matches its own type", func(t *testing.T) {
+		assert.True(t, IsInvalidExternalTargetGroupError(invalid))
+		assert.True(t, IsExternalTargetGroupNotFoundError(notFound))
+		assert.True(t, IsConflictingServiceImportAnnotationsError(conflict))
+	})
+
+	t.Run("each Is matches through a %w wrap", func(t *testing.T) {
+		assert.True(t, IsInvalidExternalTargetGroupError(fmt.Errorf("wrap: %w", invalid)))
+		assert.True(t, IsExternalTargetGroupNotFoundError(fmt.Errorf("wrap: %w", notFound)))
+		assert.True(t, IsConflictingServiceImportAnnotationsError(fmt.Errorf("wrap: %w", conflict)))
+	})
+
+	t.Run("each Is does NOT match the other types", func(t *testing.T) {
+		assert.False(t, IsInvalidExternalTargetGroupError(notFound))
+		assert.False(t, IsInvalidExternalTargetGroupError(conflict))
+		assert.False(t, IsExternalTargetGroupNotFoundError(invalid))
+		assert.False(t, IsExternalTargetGroupNotFoundError(conflict))
+		assert.False(t, IsConflictingServiceImportAnnotationsError(invalid))
+		assert.False(t, IsConflictingServiceImportAnnotationsError(notFound))
+	})
+
+	t.Run("none match nil or a plain error", func(t *testing.T) {
+		plain := errors.New("plain")
+		for _, is := range []func(error) bool{
+			IsInvalidExternalTargetGroupError,
+			IsExternalTargetGroupNotFoundError,
+			IsConflictingServiceImportAnnotationsError,
+		} {
+			assert.False(t, is(nil))
+			assert.False(t, is(plain))
+		}
+	})
+
+	t.Run("messages carry context", func(t *testing.T) {
+		assert.Contains(t, invalid.Error(), "tg-bad")
+		assert.Contains(t, notFound.Error(), "arn:tg")
+		assert.Contains(t, notFound.Error(), "us-west-2")
+		assert.Contains(t, conflict.Error(), "export-name")
+	})
+}

--- a/test/suites/integration/serviceimport_external_target_group_test.go
+++ b/test/suites/integration/serviceimport_external_target_group_test.go
@@ -1,0 +1,3868 @@
+package integration
+
+import (
+	"errors"
+	"log"
+
+	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/test/pkg/test"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ = Describe("ServiceImport invalid external target group does not takeover or delete customer service", Ordered, Label("service-import-external-tg"), func() {
+	var (
+		preCreatedSnId *string
+		gateway        *gwv1.Gateway
+
+		preCreatedServiceArn     *string
+		preCreatedListenerArn    *string
+		preCreatedTargetGroupArn *string
+		preCreatedTargetGroupId  *string
+		preCreatedAssociationArn *string
+		preCreatedRuleId         *string
+
+		deployment    *appsv1.Deployment
+		service       *corev1.Service
+		currentRoute  *gwv1.HTTPRoute
+		currentImport *anv1alpha1.ServiceImport
+
+		customerServiceName          = "external-svc-1"
+		serviceNetworkAndGatewayName = "external-sn-1"
+	)
+
+	BeforeAll(func() {
+		snResp, err := testFramework.LatticeClient.CreateServiceNetwork(ctx, &vpclattice.CreateServiceNetworkInput{
+			Name: aws.String(serviceNetworkAndGatewayName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedSnId = snResp.Id
+
+		gateway = &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceNetworkAndGatewayName,
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http",
+						Protocol: gwv1.HTTPProtocolType,
+						Port:     80,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, gateway)
+
+		Eventually(func(g Gomega) {
+			gw := &gwv1.Gateway{}
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(gateway), gw)
+			g.Expect(err).To(BeNil())
+			programmed := false
+			for _, cond := range gw.Status.Conditions {
+				if cond.Type == string(gwv1.GatewayConditionProgrammed) &&
+					cond.Status == metav1.ConditionTrue {
+					programmed = true
+					break
+				}
+			}
+			g.Expect(programmed).To(BeTrue(), "gateway not Programmed")
+		}).Should(Succeed())
+
+		targetGroupResp, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-1"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolHttp,
+				Port:          aws.Int32(80),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArn = targetGroupResp.Arn
+		preCreatedTargetGroupId = targetGroupResp.Id
+
+		Eventually(func(g Gomega) {
+			getTargetGroupResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getTargetGroupResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		serviceResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+			Name: aws.String(customerServiceName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedServiceArn = serviceResp.Arn
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getServiceResp.Status)).To(Equal(string(types.ServiceStatusActive)))
+		}).Should(Succeed())
+
+		listenerResp, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-1"),
+			Protocol:          types.ListenerProtocolHttp,
+			Port:              aws.Int32(80),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn = listenerResp.Arn
+
+		ruleResp, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn,
+			Name:               aws.String("external-rule-1"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArn, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId = ruleResp.Id
+
+		associationResp, err := testFramework.LatticeClient.CreateServiceNetworkServiceAssociation(ctx, &vpclattice.CreateServiceNetworkServiceAssociationInput{
+			ServiceIdentifier:        preCreatedServiceArn,
+			ServiceNetworkIdentifier: preCreatedSnId,
+		})
+		Expect(err).To(BeNil())
+		preCreatedAssociationArn = associationResp.Arn
+
+		Eventually(func(g Gomega) {
+			getAssocResp, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getAssocResp.Status)).To(Equal(string(types.ServiceNetworkServiceAssociationStatusActive)))
+		}).Should(Succeed())
+
+		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:       "eks-1",
+			Namespace:  k8snamespace,
+			Port:       80,
+			TargetPort: 8080,
+		})
+		testFramework.ExpectCreated(ctx, deployment, service)
+	})
+
+	AfterEach(func() {
+		if currentRoute != nil {
+			_ = testFramework.Client.Delete(ctx, currentRoute)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentRoute = nil
+		}
+		if currentImport != nil {
+			_ = testFramework.Client.Delete(ctx, currentImport)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImport), currentImport)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImport = nil
+		}
+	})
+
+	It("Non existent ServiceImport", func() {
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-import-route",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName("missing-import"),
+								Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+							},
+							Weight: lo.ToPtr(int32(90)),
+						}},
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(service.Name),
+								Kind: lo.ToPtr(gwv1.Kind("Service")),
+								Port: lo.ToPtr(gwv1.PortNumber(80)),
+							},
+							Weight: lo.ToPtr(int32(10)),
+						}},
+					},
+				}},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			got := &gwv1.HTTPRoute{}
+			err := testFramework.Get(ctx, apitypes.NamespacedName{
+				Name:      currentRoute.Name,
+				Namespace: currentRoute.Namespace,
+			}, got)
+			g.Expect(err).To(BeNil())
+			g.Expect(got.Status.Parents).ToNot(BeEmpty())
+
+			parent := got.Status.Parents[0]
+			conds := map[string]metav1.Condition{}
+			for _, c := range parent.Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(resolved.Reason).To(Equal(string(gwv1.RouteReasonBackendNotFound)))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged")
+		}).Should(Succeed())
+
+		Expect(testFramework.Client.Delete(ctx, currentRoute)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "route finalized")
+		}).Should(Succeed())
+		currentRoute = nil
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*getServiceResp.Arn).To(Equal(*preCreatedServiceArn))
+
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged after delete")
+
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after delete")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+
+			ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleId,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*ruleResp.Id).To(Equal(*preCreatedRuleId), "rule ID preserved")
+			forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+			g.Expect(ok).To(BeTrue(), "rule action is Forward")
+			g.Expect(forward.Value.TargetGroups).To(HaveLen(1))
+			g.Expect(*forward.Value.TargetGroups[0].TargetGroupIdentifier).To(Equal(*preCreatedTargetGroupId))
+			g.Expect(*forward.Value.TargetGroups[0].Weight).To(BeEquivalentTo(100))
+		}).Should(Succeed())
+	})
+
+	It("Invalid target group arn on ServiceImport", func() {
+		currentImport = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "invalid-arn-import",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": "not-an-arn",
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImport)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "invalid-arn-route",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName("invalid-arn-import"),
+								Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+							},
+							Weight: lo.ToPtr(int32(90)),
+						}},
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(service.Name),
+								Kind: lo.ToPtr(gwv1.Kind("Service")),
+								Port: lo.ToPtr(gwv1.PortNumber(80)),
+							},
+							Weight: lo.ToPtr(int32(10)),
+						}},
+					},
+				}},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(resolved.Reason).To(Equal("InvalidExternalTargetGroup"))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged")
+		}).Should(Succeed())
+
+		Expect(testFramework.Client.Delete(ctx, currentRoute)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "route finalized")
+		}).Should(Succeed())
+		currentRoute = nil
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*getServiceResp.Arn).To(Equal(*preCreatedServiceArn))
+
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged after delete")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after delete")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+
+			ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleId,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*ruleResp.Id).To(Equal(*preCreatedRuleId), "rule ID preserved")
+			forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+			g.Expect(ok).To(BeTrue(), "rule action is Forward")
+			g.Expect(forward.Value.TargetGroups).To(HaveLen(1))
+			g.Expect(*forward.Value.TargetGroups[0].TargetGroupIdentifier).To(Equal(*preCreatedTargetGroupId))
+			g.Expect(*forward.Value.TargetGroups[0].Weight).To(BeEquivalentTo(100))
+		}).Should(Succeed())
+	})
+
+	It("Non existent target group with valid arn", func() {
+		currentImport = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-found-arn-import",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": "arn:aws:vpc-lattice:us-east-2:685175429445:targetgroup/tg-deadbeefdeadbeef0",
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImport)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-found-arn-route",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName("not-found-arn-import"),
+								Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+							},
+							Weight: lo.ToPtr(int32(90)),
+						}},
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(service.Name),
+								Kind: lo.ToPtr(gwv1.Kind("Service")),
+								Port: lo.ToPtr(gwv1.PortNumber(80)),
+							},
+							Weight: lo.ToPtr(int32(10)),
+						}},
+					},
+				}},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(resolved.Reason).To(Equal("ExternalTargetGroupNotFound"))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged")
+		}).Should(Succeed())
+
+		Expect(testFramework.Client.Delete(ctx, currentRoute)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "route finalized")
+		}).Should(Succeed())
+		currentRoute = nil
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*getServiceResp.Arn).To(Equal(*preCreatedServiceArn))
+
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged after delete")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after delete")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+			ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleId,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*ruleResp.Id).To(Equal(*preCreatedRuleId), "rule ID preserved")
+			forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+			g.Expect(ok).To(BeTrue(), "rule action is Forward")
+			g.Expect(forward.Value.TargetGroups).To(HaveLen(1))
+			g.Expect(*forward.Value.TargetGroups[0].TargetGroupIdentifier).To(Equal(*preCreatedTargetGroupId))
+			g.Expect(*forward.Value.TargetGroups[0].Weight).To(BeEquivalentTo(100))
+		}).Should(Succeed())
+	})
+
+	It("Conflicting annotations on ServiceImport", func() {
+		currentImport = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "conflicting-annotations-import",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": "arn:aws:vpc-lattice:us-east-2:685175429445:targetgroup/tg-deadbeefdeadbeef0",
+					"application-networking.k8s.aws/export-name":      "some-export-name",
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImport)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "conflicting-annotations-route",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName("conflicting-annotations-import"),
+								Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+							},
+							Weight: lo.ToPtr(int32(90)),
+						}},
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(service.Name),
+								Kind: lo.ToPtr(gwv1.Kind("Service")),
+								Port: lo.ToPtr(gwv1.PortNumber(80)),
+							},
+							Weight: lo.ToPtr(int32(10)),
+						}},
+					},
+				}},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(resolved.Reason).To(Equal("ConflictingServiceImportAnnotations"))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged")
+		}).Should(Succeed())
+
+		Expect(testFramework.Client.Delete(ctx, currentRoute)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "route finalized")
+		}).Should(Succeed())
+		currentRoute = nil
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*getServiceResp.Arn).To(Equal(*preCreatedServiceArn))
+
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "service untagged after delete")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after delete")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+
+			ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleId,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(*ruleResp.Id).To(Equal(*preCreatedRuleId), "rule ID preserved")
+			forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+			g.Expect(ok).To(BeTrue(), "rule action is Forward")
+			g.Expect(forward.Value.TargetGroups).To(HaveLen(1))
+			g.Expect(*forward.Value.TargetGroups[0].TargetGroupIdentifier).To(Equal(*preCreatedTargetGroupId))
+			g.Expect(*forward.Value.TargetGroups[0].Weight).To(BeEquivalentTo(100))
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		if preCreatedAssociationArn != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete association %s: %v", *preCreatedAssociationArn, err)
+				}
+			}
+			Eventually(func(g Gomega) {
+				_, getErr := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+					ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+				})
+				g.Expect(getErr).To(HaveOccurred())
+			}).Should(Succeed())
+		}
+
+		if preCreatedRuleId != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule %s: %v", *preCreatedRuleId, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener %s: %v", *preCreatedListenerArn, err)
+				}
+			}
+		}
+
+		if preCreatedServiceArn != nil {
+			_, err := testFramework.LatticeClient.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service %s: %v", *preCreatedServiceArn, err)
+				}
+			}
+		}
+
+		if preCreatedTargetGroupArn != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArn,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if deployment != nil && service != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deployment, service)
+		}
+
+		if gateway != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, gateway)
+		}
+
+		if preCreatedSnId != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+				ServiceNetworkIdentifier: preCreatedSnId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service network %s: %v", *preCreatedSnId, err)
+				}
+			}
+		}
+	})
+})
+
+var _ = Describe("External Service with single listener and single rule", Ordered, Label("service-import-external-tg"), func() {
+	var (
+		preCreatedSnId *string
+		gateway        *gwv1.Gateway
+
+		preCreatedServiceArn     *string
+		preCreatedListenerArn    *string
+		preCreatedTargetGroupArn *string
+		preCreatedTargetGroupId  *string
+		preCreatedAssociationArn *string
+		preCreatedRuleId         *string
+
+		deployment    *appsv1.Deployment
+		service       *corev1.Service
+		currentRoute  *gwv1.HTTPRoute
+		currentImport *anv1alpha1.ServiceImport
+
+		customerServiceName          = "external-svc-2"
+		serviceNetworkAndGatewayName = "external-sn-2"
+	)
+
+	BeforeAll(func() {
+		snResp, err := testFramework.LatticeClient.CreateServiceNetwork(ctx, &vpclattice.CreateServiceNetworkInput{
+			Name: aws.String(serviceNetworkAndGatewayName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedSnId = snResp.Id
+
+		gateway = &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceNetworkAndGatewayName,
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http",
+						Protocol: gwv1.HTTPProtocolType,
+						Port:     80,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, gateway)
+
+		Eventually(func(g Gomega) {
+			gw := &gwv1.Gateway{}
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(gateway), gw)
+			g.Expect(err).To(BeNil())
+			programmed := false
+			for _, cond := range gw.Status.Conditions {
+				if cond.Type == string(gwv1.GatewayConditionProgrammed) &&
+					cond.Status == metav1.ConditionTrue {
+					programmed = true
+					break
+				}
+			}
+			g.Expect(programmed).To(BeTrue(), "gateway not Programmed")
+		}).Should(Succeed())
+
+		targetGroupResp, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-2"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolHttp,
+				Port:          aws.Int32(80),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArn = targetGroupResp.Arn
+		preCreatedTargetGroupId = targetGroupResp.Id
+
+		Eventually(func(g Gomega) {
+			getTargetGroupResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getTargetGroupResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		serviceResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+			Name: aws.String(customerServiceName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedServiceArn = serviceResp.Arn
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getServiceResp.Status)).To(Equal(string(types.ServiceStatusActive)))
+		}).Should(Succeed())
+
+		listenerResp, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-2"),
+			Protocol:          types.ListenerProtocolHttp,
+			Port:              aws.Int32(80),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn = listenerResp.Arn
+
+		ruleResp, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn,
+			Name:               aws.String("external-rule-2"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArn, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId = ruleResp.Id
+
+		associationResp, err := testFramework.LatticeClient.CreateServiceNetworkServiceAssociation(ctx, &vpclattice.CreateServiceNetworkServiceAssociationInput{
+			ServiceIdentifier:        preCreatedServiceArn,
+			ServiceNetworkIdentifier: preCreatedSnId,
+		})
+		Expect(err).To(BeNil())
+		preCreatedAssociationArn = associationResp.Arn
+
+		Eventually(func(g Gomega) {
+			getAssocResp, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getAssocResp.Status)).To(Equal(string(types.ServiceNetworkServiceAssociationStatusActive)))
+		}).Should(Succeed())
+
+		deployment, service = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:       "eks-2",
+			Namespace:  k8snamespace,
+			Port:       80,
+			TargetPort: 8080,
+		})
+		testFramework.ExpectCreated(ctx, deployment, service)
+	})
+
+	AfterEach(func() {
+		if currentRoute != nil {
+			_ = testFramework.Client.Delete(ctx, currentRoute)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentRoute = nil
+		}
+		if currentImport != nil {
+			_ = testFramework.Client.Delete(ctx, currentImport)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImport), currentImport)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImport = nil
+		}
+	})
+
+	AfterAll(func() {
+		if preCreatedAssociationArn != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete association %s: %v", *preCreatedAssociationArn, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule %s: %v", *preCreatedRuleId, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener %s: %v", *preCreatedListenerArn, err)
+				}
+			}
+		}
+
+		if preCreatedServiceArn != nil {
+			_, err := testFramework.LatticeClient.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service %s: %v", *preCreatedServiceArn, err)
+				}
+			}
+		}
+
+		if preCreatedTargetGroupArn != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArn,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if deployment != nil && service != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deployment, service)
+		}
+
+		if gateway != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, gateway)
+		}
+
+		if preCreatedSnId != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+				ServiceNetworkIdentifier: preCreatedSnId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service network %s: %v", *preCreatedSnId, err)
+				}
+			}
+		}
+	})
+
+	It("HTTPRoute takes over customer service, shifts traffic to 90/10, then to 0/100", func() {
+		currentImport = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-2",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArn,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImport)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-2",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName("import-2"),
+								Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+							},
+							Weight: lo.ToPtr(int32(90)),
+						}},
+						{BackendRef: gwv1.BackendRef{
+							BackendObjectReference: gwv1.BackendObjectReference{
+								Name: gwv1.ObjectName(service.Name),
+								Kind: lo.ToPtr(gwv1.Kind("Service")),
+								Port: lo.ToPtr(gwv1.PortNumber(80)),
+							},
+							Weight: lo.ToPtr(int32(10)),
+						}},
+					},
+				}},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(resolved.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeTrue(), "service ManagedBy stamped")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after apply")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			rules, err := testFramework.LatticeClient.ListRulesAsList(ctx, &vpclattice.ListRulesInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil())
+
+			var routeRule *types.RuleSummary
+			for i := range rules {
+				if rules[i].IsDefault != nil && *rules[i].IsDefault {
+					continue
+				}
+				routeRule = &rules[i]
+				break
+			}
+			g.Expect(routeRule).NotTo(BeNil(), "non-default rule after claim")
+
+			ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     routeRule.Id,
+			})
+			g.Expect(err).To(BeNil())
+
+			forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(forward.Value.TargetGroups).To(HaveLen(2), "forward across external+EKS TG")
+
+			var externalWeight, eksWeight int32 = -1, -1
+			for _, wtg := range forward.Value.TargetGroups {
+				if *wtg.TargetGroupIdentifier == *preCreatedTargetGroupId {
+					externalWeight = *wtg.Weight
+				} else {
+					eksWeight = *wtg.Weight
+				}
+			}
+			g.Expect(externalWeight).To(BeEquivalentTo(90), "external TG weight 90")
+			g.Expect(eksWeight).To(BeEquivalentTo(10), "EKS TG weight 10")
+			g.Expect(externalWeight+eksWeight).To(BeEquivalentTo(100), "weights sum to 100")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "external TG untagged")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			latestRoute := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), latestRoute)).To(Succeed())
+			latestRoute.Spec.Rules[0].BackendRefs = []gwv1.HTTPBackendRef{
+				{BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Name: gwv1.ObjectName(service.Name),
+						Kind: lo.ToPtr(gwv1.Kind("Service")),
+						Port: lo.ToPtr(gwv1.PortNumber(80)),
+					},
+					Weight: lo.ToPtr(int32(100)),
+				}},
+			}
+			g.Expect(testFramework.Update(ctx, latestRoute)).To(Succeed())
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after apply")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			rules, err := testFramework.LatticeClient.ListRulesAsList(ctx, &vpclattice.ListRulesInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil())
+
+			nonDefault := lo.Filter(rules, func(r types.RuleSummary, _ int) bool {
+				return r.IsDefault == nil || !*r.IsDefault
+			})
+			g.Expect(nonDefault).To(HaveLen(1), "1 non-default rule after shift")
+
+			ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     nonDefault[0].Id,
+			})
+			g.Expect(err).To(BeNil())
+			forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+			g.Expect(ok).To(BeTrue(), "rule action is Forward")
+			g.Expect(forward.Value.TargetGroups).To(HaveLen(1), "forward has 1 TG after shift")
+			g.Expect(*forward.Value.TargetGroups[0].TargetGroupIdentifier).ToNot(Equal(*preCreatedTargetGroupId), "surviving TG is not external")
+			g.Expect(*forward.Value.TargetGroups[0].Weight).To(BeEquivalentTo(100), "EKS TG weight 100")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tgResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil(), "external TG exists")
+			g.Expect(string(tgResp.Status)).To(Equal(string(types.TargetGroupStatusActive)), "external TG Active")
+
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "external TG untagged")
+		}).Should(Succeed())
+	})
+})
+
+var _ = Describe("External Service with single listener and 2 rules", Ordered, Label("service-import-external-tg"), func() {
+	var (
+		preCreatedSnId *string
+		gateway        *gwv1.Gateway
+
+		preCreatedServiceArn      *string
+		preCreatedListenerArn     *string
+		preCreatedTargetGroupArnA *string
+		preCreatedTargetGroupIdA  *string
+		preCreatedTargetGroupArnB *string
+		preCreatedTargetGroupIdB  *string
+		preCreatedAssociationArn  *string
+		preCreatedRuleIdV1        *string
+		preCreatedRuleIdV2        *string
+
+		deploymentV1   *appsv1.Deployment
+		serviceV1      *corev1.Service
+		deploymentV2   *appsv1.Deployment
+		serviceV2      *corev1.Service
+		currentRoute   *gwv1.HTTPRoute
+		currentImportA *anv1alpha1.ServiceImport
+		currentImportB *anv1alpha1.ServiceImport
+
+		customerServiceName          = "external-svc-3"
+		serviceNetworkAndGatewayName = "external-sn-3"
+	)
+
+	BeforeAll(func() {
+		snResp, err := testFramework.LatticeClient.CreateServiceNetwork(ctx, &vpclattice.CreateServiceNetworkInput{
+			Name: aws.String(serviceNetworkAndGatewayName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedSnId = snResp.Id
+
+		gateway = &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceNetworkAndGatewayName,
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http",
+						Protocol: gwv1.HTTPProtocolType,
+						Port:     80,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, gateway)
+
+		Eventually(func(g Gomega) {
+			gw := &gwv1.Gateway{}
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(gateway), gw)
+			g.Expect(err).To(BeNil())
+			programmed := false
+			for _, cond := range gw.Status.Conditions {
+				if cond.Type == string(gwv1.GatewayConditionProgrammed) &&
+					cond.Status == metav1.ConditionTrue {
+					programmed = true
+					break
+				}
+			}
+			g.Expect(programmed).To(BeTrue(), "gateway not Programmed")
+		}).Should(Succeed())
+
+		tgRespA, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-v1-3"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolHttp,
+				Port:          aws.Int32(80),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArnA = tgRespA.Arn
+		preCreatedTargetGroupIdA = tgRespA.Id
+
+		Eventually(func(g Gomega) {
+			getResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArnA,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		tgRespB, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-v2-3"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolHttp,
+				Port:          aws.Int32(80),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArnB = tgRespB.Arn
+		preCreatedTargetGroupIdB = tgRespB.Id
+
+		Eventually(func(g Gomega) {
+			getResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArnB,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		serviceResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+			Name: aws.String(customerServiceName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedServiceArn = serviceResp.Arn
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getServiceResp.Status)).To(Equal(string(types.ServiceStatusActive)))
+		}).Should(Succeed())
+
+		listenerResp, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-3"),
+			Protocol:          types.ListenerProtocolHttp,
+			Port:              aws.Int32(80),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn = listenerResp.Arn
+
+		ruleRespV1, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn,
+			Name:               aws.String("external-rule-v1-3"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/v1"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnA, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleIdV1 = ruleRespV1.Id
+
+		ruleRespV2, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn,
+			Name:               aws.String("external-rule-v2-3"),
+			Priority:           aws.Int32(20),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/v2"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnB, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleIdV2 = ruleRespV2.Id
+
+		associationResp, err := testFramework.LatticeClient.CreateServiceNetworkServiceAssociation(ctx, &vpclattice.CreateServiceNetworkServiceAssociationInput{
+			ServiceIdentifier:        preCreatedServiceArn,
+			ServiceNetworkIdentifier: preCreatedSnId,
+		})
+		Expect(err).To(BeNil())
+		preCreatedAssociationArn = associationResp.Arn
+
+		Eventually(func(g Gomega) {
+			getAssocResp, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getAssocResp.Status)).To(Equal(string(types.ServiceNetworkServiceAssociationStatusActive)))
+		}).Should(Succeed())
+
+		deploymentV1, serviceV1 = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:       "eks-v1-3",
+			Namespace:  k8snamespace,
+			Port:       80,
+			TargetPort: 8080,
+		})
+		testFramework.ExpectCreated(ctx, deploymentV1, serviceV1)
+
+		deploymentV2, serviceV2 = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:       "eks-v2-3",
+			Namespace:  k8snamespace,
+			Port:       80,
+			TargetPort: 8080,
+		})
+		testFramework.ExpectCreated(ctx, deploymentV2, serviceV2)
+	})
+
+	AfterEach(func() {
+		if currentRoute != nil {
+			_ = testFramework.Client.Delete(ctx, currentRoute)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentRoute = nil
+		}
+		if currentImportA != nil {
+			_ = testFramework.Client.Delete(ctx, currentImportA)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImportA), currentImportA)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImportA = nil
+		}
+		if currentImportB != nil {
+			_ = testFramework.Client.Delete(ctx, currentImportB)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImportB), currentImportB)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImportB = nil
+		}
+	})
+
+	AfterAll(func() {
+		if preCreatedAssociationArn != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete association %s: %v", *preCreatedAssociationArn, err)
+				}
+			}
+		}
+
+		if preCreatedRuleIdV1 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleIdV1,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule v1 %s: %v", *preCreatedRuleIdV1, err)
+				}
+			}
+		}
+
+		if preCreatedRuleIdV2 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+				RuleIdentifier:     preCreatedRuleIdV2,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule v2 %s: %v", *preCreatedRuleIdV2, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener %s: %v", *preCreatedListenerArn, err)
+				}
+			}
+		}
+
+		if preCreatedServiceArn != nil {
+			_, err := testFramework.LatticeClient.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service %s: %v", *preCreatedServiceArn, err)
+				}
+			}
+		}
+
+		if preCreatedTargetGroupArnA != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArnA,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if preCreatedTargetGroupArnB != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArnB,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if deploymentV1 != nil && serviceV1 != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deploymentV1, serviceV1)
+		}
+		if deploymentV2 != nil && serviceV2 != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deploymentV2, serviceV2)
+		}
+
+		if gateway != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, gateway)
+		}
+
+		if preCreatedSnId != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+				ServiceNetworkIdentifier: preCreatedSnId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service network %s: %v", *preCreatedSnId, err)
+				}
+			}
+		}
+	})
+
+	It("HTTPRoute with path based rules takes over customer service and shifts traffic to 90/10 per path", func() {
+		currentImportA = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-v1-3",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArnA,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImportA)
+
+		currentImportB = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-v2-3",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArnB,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImportB)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-3",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{
+					{
+						Matches: []gwv1.HTTPRouteMatch{{
+							Path: &gwv1.HTTPPathMatch{
+								Type:  lo.ToPtr(gwv1.PathMatchPathPrefix),
+								Value: lo.ToPtr("/v1"),
+							},
+						}},
+						BackendRefs: []gwv1.HTTPBackendRef{
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-v1-3"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							}},
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(serviceV1.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(80)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							}},
+						},
+					},
+					{
+						Matches: []gwv1.HTTPRouteMatch{{
+							Path: &gwv1.HTTPPathMatch{
+								Type:  lo.ToPtr(gwv1.PathMatchPathPrefix),
+								Value: lo.ToPtr("/v2"),
+							},
+						}},
+						BackendRefs: []gwv1.HTTPBackendRef{
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-v2-3"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							}},
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(serviceV2.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(80)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							}},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(resolved.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeTrue(), "service ManagedBy stamped")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil(), "listener exists after apply")
+			g.Expect(*listenerResp.Arn).To(Equal(*preCreatedListenerArn), "listener ARN preserved")
+			g.Expect(*listenerResp.Port).To(BeEquivalentTo(80), "listener port unchanged")
+			g.Expect(string(listenerResp.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener protocol unchanged")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			rules, err := testFramework.LatticeClient.ListRulesAsList(ctx, &vpclattice.ListRulesInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn,
+			})
+			g.Expect(err).To(BeNil())
+
+			nonDefault := []types.RuleSummary{}
+			for _, r := range rules {
+				if r.IsDefault != nil && *r.IsDefault {
+					continue
+				}
+				nonDefault = append(nonDefault, r)
+			}
+			g.Expect(nonDefault).To(HaveLen(2), "2 non-default rules")
+
+			var foundA, foundB bool
+			for _, r := range nonDefault {
+				ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+					ServiceIdentifier:  preCreatedServiceArn,
+					ListenerIdentifier: preCreatedListenerArn,
+					RuleIdentifier:     r.Id,
+				})
+				g.Expect(err).To(BeNil())
+
+				forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+				g.Expect(ok).To(BeTrue(), "rule action is Forward")
+				g.Expect(forward.Value.TargetGroups).To(HaveLen(2), "forward across external+EKS TG")
+
+				var externalId string
+				var externalWeight, eksWeight int32 = -1, -1
+				for _, wtg := range forward.Value.TargetGroups {
+					if *wtg.TargetGroupIdentifier == *preCreatedTargetGroupIdA || *wtg.TargetGroupIdentifier == *preCreatedTargetGroupIdB {
+						externalId = *wtg.TargetGroupIdentifier
+						externalWeight = *wtg.Weight
+					} else {
+						eksWeight = *wtg.Weight
+					}
+				}
+				g.Expect(externalWeight).To(BeEquivalentTo(90), "external TG weight 90")
+				g.Expect(eksWeight).To(BeEquivalentTo(10), "EKS TG weight 10")
+
+				if externalId == *preCreatedTargetGroupIdA {
+					foundA = true
+				} else if externalId == *preCreatedTargetGroupIdB {
+					foundB = true
+				}
+			}
+			g.Expect(foundA).To(BeTrue(), "rule forwards to TG A")
+			g.Expect(foundB).To(BeTrue(), "rule forwards to TG B")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			for _, arn := range []*string{preCreatedTargetGroupArnA, preCreatedTargetGroupArnB} {
+				tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+					ResourceArn: arn,
+				})
+				g.Expect(err).To(BeNil())
+				_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+				g.Expect(hasManagedBy).To(BeFalse(), "external TG %s untagged", *arn)
+			}
+		}).Should(Succeed())
+	})
+})
+
+var _ = Describe("External Service with multiple listeners", Ordered, Label("service-import-external-tg"), func() {
+	var (
+		preCreatedSnId *string
+		gateway        *gwv1.Gateway
+
+		preCreatedServiceArn      *string
+		preCreatedListenerArn80   *string
+		preCreatedListenerArn8080 *string
+		preCreatedTargetGroupArnA *string
+		preCreatedTargetGroupIdA  *string
+		preCreatedTargetGroupArnB *string
+		preCreatedTargetGroupIdB  *string
+		preCreatedAssociationArn  *string
+		preCreatedRuleId80V1      *string
+		preCreatedRuleId80V2      *string
+		preCreatedRuleId8080V1    *string
+		preCreatedRuleId8080V2    *string
+
+		deploymentV1   *appsv1.Deployment
+		serviceV1      *corev1.Service
+		deploymentV2   *appsv1.Deployment
+		serviceV2      *corev1.Service
+		currentRoute   *gwv1.HTTPRoute
+		currentImportA *anv1alpha1.ServiceImport
+		currentImportB *anv1alpha1.ServiceImport
+
+		customerServiceName          = "external-svc-4"
+		serviceNetworkAndGatewayName = "external-sn-4"
+	)
+
+	BeforeAll(func() {
+		snResp, err := testFramework.LatticeClient.CreateServiceNetwork(ctx, &vpclattice.CreateServiceNetworkInput{
+			Name: aws.String(serviceNetworkAndGatewayName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedSnId = snResp.Id
+
+		gateway = &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceNetworkAndGatewayName,
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "http-80",
+						Protocol: gwv1.HTTPProtocolType,
+						Port:     80,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+					{
+						Name:     "http-8080",
+						Protocol: gwv1.HTTPProtocolType,
+						Port:     8080,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, gateway)
+
+		Eventually(func(g Gomega) {
+			gw := &gwv1.Gateway{}
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(gateway), gw)
+			g.Expect(err).To(BeNil())
+			programmed := false
+			for _, cond := range gw.Status.Conditions {
+				if cond.Type == string(gwv1.GatewayConditionProgrammed) &&
+					cond.Status == metav1.ConditionTrue {
+					programmed = true
+					break
+				}
+			}
+			g.Expect(programmed).To(BeTrue(), "gateway not Programmed")
+		}).Should(Succeed())
+
+		tgRespA, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-v1-4"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolHttp,
+				Port:          aws.Int32(80),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArnA = tgRespA.Arn
+		preCreatedTargetGroupIdA = tgRespA.Id
+
+		Eventually(func(g Gomega) {
+			getResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArnA,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		tgRespB, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-v2-4"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolHttp,
+				Port:          aws.Int32(80),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArnB = tgRespB.Arn
+		preCreatedTargetGroupIdB = tgRespB.Id
+
+		Eventually(func(g Gomega) {
+			getResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArnB,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		serviceResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+			Name: aws.String(customerServiceName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedServiceArn = serviceResp.Arn
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getServiceResp.Status)).To(Equal(string(types.ServiceStatusActive)))
+		}).Should(Succeed())
+
+		listenerResp80, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-80-4"),
+			Protocol:          types.ListenerProtocolHttp,
+			Port:              aws.Int32(80),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn80 = listenerResp80.Arn
+
+		listenerResp8080, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-8080-4"),
+			Protocol:          types.ListenerProtocolHttp,
+			Port:              aws.Int32(8080),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn8080 = listenerResp8080.Arn
+
+		ruleResp80V1, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn80,
+			Name:               aws.String("external-rule-80-v1-4"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/v1"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnA, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId80V1 = ruleResp80V1.Id
+
+		ruleResp80V2, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn80,
+			Name:               aws.String("external-rule-80-v2-4"),
+			Priority:           aws.Int32(20),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/v2"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnB, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId80V2 = ruleResp80V2.Id
+
+		ruleResp8080V1, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn8080,
+			Name:               aws.String("external-rule-8080-v1-4"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/v1"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnA, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId8080V1 = ruleResp8080V1.Id
+
+		ruleResp8080V2, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn8080,
+			Name:               aws.String("external-rule-8080-v2-4"),
+			Priority:           aws.Int32(20),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					PathMatch: &types.PathMatch{
+						Match:         &types.PathMatchTypeMemberPrefix{Value: "/v2"},
+						CaseSensitive: aws.Bool(false),
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnB, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId8080V2 = ruleResp8080V2.Id
+
+		associationResp, err := testFramework.LatticeClient.CreateServiceNetworkServiceAssociation(ctx, &vpclattice.CreateServiceNetworkServiceAssociationInput{
+			ServiceIdentifier:        preCreatedServiceArn,
+			ServiceNetworkIdentifier: preCreatedSnId,
+		})
+		Expect(err).To(BeNil())
+		preCreatedAssociationArn = associationResp.Arn
+
+		Eventually(func(g Gomega) {
+			getAssocResp, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getAssocResp.Status)).To(Equal(string(types.ServiceNetworkServiceAssociationStatusActive)))
+		}).Should(Succeed())
+
+		deploymentV1, serviceV1 = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:       "eks-v1-4",
+			Namespace:  k8snamespace,
+			Port:       80,
+			TargetPort: 8080,
+		})
+		testFramework.ExpectCreated(ctx, deploymentV1, serviceV1)
+
+		deploymentV2, serviceV2 = testFramework.NewHttpApp(test.HTTPAppOptions{
+			Name:       "eks-v2-4",
+			Namespace:  k8snamespace,
+			Port:       80,
+			TargetPort: 8080,
+		})
+		testFramework.ExpectCreated(ctx, deploymentV2, serviceV2)
+	})
+
+	AfterEach(func() {
+		if currentRoute != nil {
+			_ = testFramework.Client.Delete(ctx, currentRoute)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentRoute = nil
+		}
+		if currentImportA != nil {
+			_ = testFramework.Client.Delete(ctx, currentImportA)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImportA), currentImportA)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImportA = nil
+		}
+		if currentImportB != nil {
+			_ = testFramework.Client.Delete(ctx, currentImportB)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImportB), currentImportB)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImportB = nil
+		}
+	})
+
+	AfterAll(func() {
+		if preCreatedAssociationArn != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete association %s: %v", *preCreatedAssociationArn, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId80V1 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn80,
+				RuleIdentifier:     preCreatedRuleId80V1,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 80 v1 %s: %v", *preCreatedRuleId80V1, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId80V2 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn80,
+				RuleIdentifier:     preCreatedRuleId80V2,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 80 v2 %s: %v", *preCreatedRuleId80V2, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId8080V1 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8080,
+				RuleIdentifier:     preCreatedRuleId8080V1,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 8080 v1 %s: %v", *preCreatedRuleId8080V1, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId8080V2 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8080,
+				RuleIdentifier:     preCreatedRuleId8080V2,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 8080 v2 %s: %v", *preCreatedRuleId8080V2, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn80 != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn80,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener 80 %s: %v", *preCreatedListenerArn80, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn8080 != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8080,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener 8080 %s: %v", *preCreatedListenerArn8080, err)
+				}
+			}
+		}
+
+		if preCreatedServiceArn != nil {
+			_, err := testFramework.LatticeClient.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service %s: %v", *preCreatedServiceArn, err)
+				}
+			}
+		}
+
+		if preCreatedTargetGroupArnA != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArnA,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if preCreatedTargetGroupArnB != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArnB,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if deploymentV1 != nil && serviceV1 != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deploymentV1, serviceV1)
+		}
+		if deploymentV2 != nil && serviceV2 != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deploymentV2, serviceV2)
+		}
+
+		if gateway != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, gateway)
+		}
+
+		if preCreatedSnId != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+				ServiceNetworkIdentifier: preCreatedSnId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service network %s: %v", *preCreatedSnId, err)
+				}
+			}
+		}
+	})
+
+	It("HttpRoute with no sectionName replicates path segmented weighted rules across both listeners and shifts traffic to 90/10", func() {
+		currentImportA = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-v1-4",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArnA,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImportA)
+
+		currentImportB = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-v2-4",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArnB,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImportB)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-4",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.HTTPRouteRule{
+					{ // /v1
+						Matches: []gwv1.HTTPRouteMatch{{
+							Path: &gwv1.HTTPPathMatch{
+								Type:  lo.ToPtr(gwv1.PathMatchPathPrefix),
+								Value: lo.ToPtr("/v1"),
+							},
+						}},
+						BackendRefs: []gwv1.HTTPBackendRef{
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-v1-4"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							}},
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(serviceV1.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(80)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							}},
+						},
+					},
+					{ // /v2
+						Matches: []gwv1.HTTPRouteMatch{{
+							Path: &gwv1.HTTPPathMatch{
+								Type:  lo.ToPtr(gwv1.PathMatchPathPrefix),
+								Value: lo.ToPtr("/v2"),
+							},
+						}},
+						BackendRefs: []gwv1.HTTPBackendRef{
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-v2-4"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							}},
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(serviceV2.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(80)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							}},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.HTTPRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(resolved.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeTrue(), "service ManagedBy stamped")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listeners, err := testFramework.LatticeClient.ListListenersAsList(ctx, &vpclattice.ListListenersInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			var l80, l8080 *types.ListenerSummary
+			for i := range listeners {
+				switch *listeners[i].Name {
+				case "external-listener-80-4":
+					l80 = &listeners[i]
+				case "external-listener-8080-4":
+					l8080 = &listeners[i]
+				}
+			}
+			g.Expect(l80).ToNot(BeNil(), "listener on port %d must exist", 80)
+			g.Expect(l8080).ToNot(BeNil(), "listener on port %d must exist", 8080)
+
+			for _, l := range []*types.ListenerSummary{l80, l8080} {
+				var expectedListenerArn *string
+				var expectedPort int32
+				switch *l.Name {
+				case "external-listener-80-4":
+					expectedListenerArn = preCreatedListenerArn80
+					expectedPort = 80
+				case "external-listener-8080-4":
+					expectedListenerArn = preCreatedListenerArn8080
+					expectedPort = 8080
+				}
+				g.Expect(*l.Arn).To(Equal(*expectedListenerArn), "listener %s ARN preserved", *l.Name)
+				g.Expect(*l.Port).To(BeEquivalentTo(expectedPort), "listener %s port unchanged", *l.Name)
+				g.Expect(string(l.Protocol)).To(Equal(string(types.ListenerProtocolHttp)), "listener %s protocol unchanged", *l.Name)
+
+				rules, err := testFramework.LatticeClient.ListRulesAsList(ctx, &vpclattice.ListRulesInput{
+					ServiceIdentifier:  preCreatedServiceArn,
+					ListenerIdentifier: l.Arn,
+				})
+				g.Expect(err).To(BeNil())
+
+				nonDefault := []types.RuleSummary{}
+				for _, r := range rules {
+					if r.IsDefault != nil && *r.IsDefault {
+						continue
+					}
+					nonDefault = append(nonDefault, r)
+				}
+				g.Expect(nonDefault).To(HaveLen(2), "listener %s: 2 non-default rules", *l.Name)
+
+				var foundA, foundB bool
+				for _, r := range nonDefault {
+					ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+						ServiceIdentifier:  preCreatedServiceArn,
+						ListenerIdentifier: l.Arn,
+						RuleIdentifier:     r.Id,
+					})
+					g.Expect(err).To(BeNil())
+					forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+					g.Expect(ok).To(BeTrue(), "rule action is Forward")
+					g.Expect(forward.Value.TargetGroups).To(HaveLen(2), "forward across external+EKS TG")
+
+					var externalId string
+					var externalWeight, eksWeight int32 = -1, -1
+					for _, wtg := range forward.Value.TargetGroups {
+						id := *wtg.TargetGroupIdentifier
+						if id == *preCreatedTargetGroupIdA || id == *preCreatedTargetGroupIdB {
+							externalId = id
+							externalWeight = *wtg.Weight
+						} else {
+							eksWeight = *wtg.Weight
+						}
+					}
+					g.Expect(externalWeight).To(BeEquivalentTo(90), "external TG weight 90 on %s", *l.Name)
+					g.Expect(eksWeight).To(BeEquivalentTo(10), "EKS TG weight 10 on %s", *l.Name)
+
+					if externalId == *preCreatedTargetGroupIdA {
+						foundA = true
+					} else if externalId == *preCreatedTargetGroupIdB {
+						foundB = true
+					}
+				}
+				g.Expect(foundA).To(BeTrue(), "%s: rule forwards to TG A", *l.Name)
+				g.Expect(foundB).To(BeTrue(), "%s: rule forwards to TG B", *l.Name)
+			}
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			for _, arn := range []*string{preCreatedTargetGroupArnA, preCreatedTargetGroupArnB} {
+				tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+					ResourceArn: arn,
+				})
+				g.Expect(err).To(BeNil())
+				_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+				g.Expect(hasManagedBy).To(BeFalse(), "external TG %s untagged", *arn)
+			}
+		}).Should(Succeed())
+	})
+})
+
+var _ = Describe("External Grpc Service with multiple listeners", Ordered, Label("service-import-external-tg"), func() {
+	var (
+		preCreatedSnId *string
+		gateway        *gwv1.Gateway
+
+		preCreatedServiceArn      *string
+		preCreatedListenerArn80   *string
+		preCreatedListenerArn8080 *string
+		preCreatedTargetGroupArnA *string
+		preCreatedTargetGroupIdA  *string
+		preCreatedTargetGroupArnB *string
+		preCreatedTargetGroupIdB  *string
+		preCreatedAssociationArn  *string
+		preCreatedRuleId80V1      *string
+		preCreatedRuleId80V2      *string
+		preCreatedRuleId8080V1    *string
+		preCreatedRuleId8080V2    *string
+
+		deploymentV1   *appsv1.Deployment
+		serviceV1      *corev1.Service
+		deploymentV2   *appsv1.Deployment
+		serviceV2      *corev1.Service
+		currentRoute   *gwv1.GRPCRoute
+		currentImportA *anv1alpha1.ServiceImport
+		currentImportB *anv1alpha1.ServiceImport
+
+		customerServiceName          = "external-svc-5"
+		serviceNetworkAndGatewayName = "external-sn-5"
+	)
+
+	BeforeAll(func() {
+		snResp, err := testFramework.LatticeClient.CreateServiceNetwork(ctx, &vpclattice.CreateServiceNetworkInput{
+			Name: aws.String(serviceNetworkAndGatewayName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedSnId = snResp.Id
+
+		gateway = &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceNetworkAndGatewayName,
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "https-80",
+						Protocol: gwv1.HTTPSProtocolType,
+						Port:     80,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+					{
+						Name:     "https-8080",
+						Protocol: gwv1.HTTPSProtocolType,
+						Port:     8080,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, gateway)
+
+		Eventually(func(g Gomega) {
+			gw := &gwv1.Gateway{}
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(gateway), gw)
+			g.Expect(err).To(BeNil())
+			programmed := false
+			for _, cond := range gw.Status.Conditions {
+				if cond.Type == string(gwv1.GatewayConditionProgrammed) &&
+					cond.Status == metav1.ConditionTrue {
+					programmed = true
+					break
+				}
+			}
+			g.Expect(programmed).To(BeTrue(), "gateway not Programmed")
+		}).Should(Succeed())
+
+		tgRespA, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-v1-5"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:        types.TargetGroupProtocolHttps,
+				ProtocolVersion: types.TargetGroupProtocolVersionHttp2,
+				Port:            aws.Int32(80),
+				VpcIdentifier:   aws.String(testFramework.Cloud.Config().VpcId),
+				IpAddressType:   types.IpAddressTypeIpv4,
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArnA = tgRespA.Arn
+		preCreatedTargetGroupIdA = tgRespA.Id
+
+		Eventually(func(g Gomega) {
+			getResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArnA,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		tgRespB, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-v2-5"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:        types.TargetGroupProtocolHttps,
+				ProtocolVersion: types.TargetGroupProtocolVersionHttp2,
+				Port:            aws.Int32(80),
+				VpcIdentifier:   aws.String(testFramework.Cloud.Config().VpcId),
+				IpAddressType:   types.IpAddressTypeIpv4,
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArnB = tgRespB.Arn
+		preCreatedTargetGroupIdB = tgRespB.Id
+
+		Eventually(func(g Gomega) {
+			getResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArnB,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		serviceResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+			Name: aws.String(customerServiceName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedServiceArn = serviceResp.Arn
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getServiceResp.Status)).To(Equal(string(types.ServiceStatusActive)))
+		}).Should(Succeed())
+
+		listenerResp80, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-80-5"),
+			Protocol:          types.ListenerProtocolHttps,
+			Port:              aws.Int32(80),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn80 = listenerResp80.Arn
+
+		listenerResp8080, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-8080-5"),
+			Protocol:          types.ListenerProtocolHttps,
+			Port:              aws.Int32(8080),
+			DefaultAction: &types.RuleActionMemberFixedResponse{
+				Value: types.FixedResponseAction{
+					StatusCode: aws.Int32(404),
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn8080 = listenerResp8080.Arn
+
+		ruleResp80V1, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn80,
+			Name:               aws.String("external-rule-80-v1-5"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					Method: lo.ToPtr("POST"),
+					PathMatch: &types.PathMatch{
+						CaseSensitive: aws.Bool(true),
+						Match: &types.PathMatchTypeMemberExact{
+							Value: "/echo.EchoService/V1",
+						},
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnA, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId80V1 = ruleResp80V1.Id
+
+		ruleResp80V2, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn80,
+			Name:               aws.String("external-rule-80-v2-5"),
+			Priority:           aws.Int32(20),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					Method: lo.ToPtr("POST"),
+					PathMatch: &types.PathMatch{
+						CaseSensitive: aws.Bool(true),
+						Match: &types.PathMatchTypeMemberExact{
+							Value: "/echo.EchoService/V2",
+						},
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnB, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId80V2 = ruleResp80V2.Id
+
+		ruleResp8080V1, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn8080,
+			Name:               aws.String("external-rule-8080-v1-5"),
+			Priority:           aws.Int32(10),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					Method: lo.ToPtr("POST"),
+					PathMatch: &types.PathMatch{
+						CaseSensitive: aws.Bool(true),
+						Match: &types.PathMatchTypeMemberExact{
+							Value: "/echo.EchoService/V1",
+						},
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnA, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId8080V1 = ruleResp8080V1.Id
+
+		ruleResp8080V2, err := testFramework.LatticeClient.CreateRule(ctx, &vpclattice.CreateRuleInput{
+			ServiceIdentifier:  preCreatedServiceArn,
+			ListenerIdentifier: preCreatedListenerArn8080,
+			Name:               aws.String("external-rule-8080-v2-5"),
+			Priority:           aws.Int32(20),
+			Match: &types.RuleMatchMemberHttpMatch{
+				Value: types.HttpMatch{
+					Method: lo.ToPtr("POST"),
+					PathMatch: &types.PathMatch{
+						CaseSensitive: aws.Bool(true),
+						Match: &types.PathMatchTypeMemberExact{
+							Value: "/echo.EchoService/V2",
+						},
+					},
+				},
+			},
+			Action: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{
+						{TargetGroupIdentifier: preCreatedTargetGroupArnB, Weight: aws.Int32(100)},
+					},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedRuleId8080V2 = ruleResp8080V2.Id
+
+		associationResp, err := testFramework.LatticeClient.CreateServiceNetworkServiceAssociation(ctx, &vpclattice.CreateServiceNetworkServiceAssociationInput{
+			ServiceIdentifier:        preCreatedServiceArn,
+			ServiceNetworkIdentifier: preCreatedSnId,
+		})
+		Expect(err).To(BeNil())
+		preCreatedAssociationArn = associationResp.Arn
+
+		Eventually(func(g Gomega) {
+			getAssocResp, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getAssocResp.Status)).To(Equal(string(types.ServiceNetworkServiceAssociationStatusActive)))
+		}).Should(Succeed())
+
+		deploymentV1, serviceV1 = testFramework.NewGrpcBin(test.GrpcAppOptions{
+			AppName:   "eks-v1-5",
+			Namespace: k8snamespace,
+		})
+		testFramework.ExpectCreated(ctx, deploymentV1, serviceV1)
+
+		deploymentV2, serviceV2 = testFramework.NewGrpcHelloWorld(test.GrpcAppOptions{
+			AppName:   "eks-v2-5",
+			Namespace: k8snamespace,
+		})
+		testFramework.ExpectCreated(ctx, deploymentV2, serviceV2)
+	})
+
+	AfterEach(func() {
+		if currentRoute != nil {
+			_ = testFramework.Client.Delete(ctx, currentRoute)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentRoute = nil
+		}
+		if currentImportA != nil {
+			_ = testFramework.Client.Delete(ctx, currentImportA)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImportA), currentImportA)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImportA = nil
+		}
+		if currentImportB != nil {
+			_ = testFramework.Client.Delete(ctx, currentImportB)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImportB), currentImportB)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImportB = nil
+		}
+	})
+
+	AfterAll(func() {
+		if preCreatedAssociationArn != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete association %s: %v", *preCreatedAssociationArn, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId80V1 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn80,
+				RuleIdentifier:     preCreatedRuleId80V1,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 80 v1 %s: %v", *preCreatedRuleId80V1, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId80V2 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn80,
+				RuleIdentifier:     preCreatedRuleId80V2,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 80 v2 %s: %v", *preCreatedRuleId80V2, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId8080V1 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8080,
+				RuleIdentifier:     preCreatedRuleId8080V1,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 8080 v1 %s: %v", *preCreatedRuleId8080V1, err)
+				}
+			}
+		}
+
+		if preCreatedRuleId8080V2 != nil {
+			_, err := testFramework.LatticeClient.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8080,
+				RuleIdentifier:     preCreatedRuleId8080V2,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete rule 8080 v2 %s: %v", *preCreatedRuleId8080V2, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn80 != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn80,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener 80 %s: %v", *preCreatedListenerArn80, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn8080 != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8080,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener 8080 %s: %v", *preCreatedListenerArn8080, err)
+				}
+			}
+		}
+
+		if preCreatedServiceArn != nil {
+			_, err := testFramework.LatticeClient.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service %s: %v", *preCreatedServiceArn, err)
+				}
+			}
+		}
+
+		if preCreatedTargetGroupArnA != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArnA,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if preCreatedTargetGroupArnB != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArnB,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if deploymentV1 != nil && serviceV1 != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deploymentV1, serviceV1)
+		}
+		if deploymentV2 != nil && serviceV2 != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deploymentV2, serviceV2)
+		}
+
+		if gateway != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, gateway)
+		}
+
+		if preCreatedSnId != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+				ServiceNetworkIdentifier: preCreatedSnId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service network %s: %v", *preCreatedSnId, err)
+				}
+			}
+		}
+	})
+
+	It("GRPCRoute with no sectionName replicates method matched weighted rules across both listeners and shifts traffic to 90/10", func() {
+		currentImportA = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-v1-5",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArnA,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImportA)
+
+		currentImportB = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-v2-5",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArnB,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 80, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImportB)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-5",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.GRPCRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Rules: []gwv1.GRPCRouteRule{
+					{
+						Matches: []gwv1.GRPCRouteMatch{{
+							Method: &gwv1.GRPCMethodMatch{
+								Type:    lo.ToPtr(gwv1.GRPCMethodMatchExact),
+								Service: lo.ToPtr("echo.EchoService"),
+								Method:  lo.ToPtr("V1"),
+							},
+						}},
+						BackendRefs: []gwv1.GRPCBackendRef{
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-v1-5"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							}},
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(serviceV1.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(serviceV1.Spec.Ports[0].Port)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							}},
+						},
+					},
+					{
+						Matches: []gwv1.GRPCRouteMatch{{
+							Method: &gwv1.GRPCMethodMatch{
+								Type:    lo.ToPtr(gwv1.GRPCMethodMatchExact),
+								Service: lo.ToPtr("echo.EchoService"),
+								Method:  lo.ToPtr("V2"),
+							},
+						}},
+						BackendRefs: []gwv1.GRPCBackendRef{
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-v2-5"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							}},
+							{BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(serviceV2.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(serviceV2.Spec.Ports[0].Port)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							}},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.GRPCRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(resolved.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeTrue(), "service ManagedBy stamped")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listeners, err := testFramework.LatticeClient.ListListenersAsList(ctx, &vpclattice.ListListenersInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			var l80, l8080 *types.ListenerSummary
+			for i := range listeners {
+				switch *listeners[i].Name {
+				case "external-listener-80-5":
+					l80 = &listeners[i]
+				case "external-listener-8080-5":
+					l8080 = &listeners[i]
+				}
+			}
+			g.Expect(l80).ToNot(BeNil(), "listener on port %d must exist", 80)
+			g.Expect(l8080).ToNot(BeNil(), "listener on port %d must exist", 8080)
+
+			for _, l := range []*types.ListenerSummary{l80, l8080} {
+				var expectedListenerArn *string
+				var expectedPort int32
+				switch *l.Name {
+				case "external-listener-80-5":
+					expectedListenerArn = preCreatedListenerArn80
+					expectedPort = 80
+				case "external-listener-8080-5":
+					expectedListenerArn = preCreatedListenerArn8080
+					expectedPort = 8080
+				}
+				g.Expect(*l.Arn).To(Equal(*expectedListenerArn), "listener %s ARN preserved", *l.Name)
+				g.Expect(*l.Port).To(BeEquivalentTo(expectedPort), "listener %s port unchanged", *l.Name)
+				g.Expect(string(l.Protocol)).To(Equal(string(types.ListenerProtocolHttps)), "listener %s protocol unchanged", *l.Name)
+
+				rules, err := testFramework.LatticeClient.ListRulesAsList(ctx, &vpclattice.ListRulesInput{
+					ServiceIdentifier:  preCreatedServiceArn,
+					ListenerIdentifier: l.Arn,
+				})
+				g.Expect(err).To(BeNil())
+
+				nonDefault := []types.RuleSummary{}
+				for _, r := range rules {
+					if r.IsDefault != nil && *r.IsDefault {
+						continue
+					}
+					nonDefault = append(nonDefault, r)
+				}
+				g.Expect(nonDefault).To(HaveLen(2), "listener %s: 2 non-default rules", *l.Name)
+
+				var foundA, foundB bool
+				for _, r := range nonDefault {
+					ruleResp, err := testFramework.LatticeClient.GetRule(ctx, &vpclattice.GetRuleInput{
+						ServiceIdentifier:  preCreatedServiceArn,
+						ListenerIdentifier: l.Arn,
+						RuleIdentifier:     r.Id,
+					})
+					g.Expect(err).To(BeNil())
+
+					httpMatch, ok := ruleResp.Match.(*types.RuleMatchMemberHttpMatch)
+					g.Expect(ok).To(BeTrue(), "rule match is HttpMatch")
+					g.Expect(httpMatch.Value.Method).ToNot(BeNil(), "httpMatch.Method set on %s", *l.Name)
+					g.Expect(*httpMatch.Value.Method).To(Equal("POST"), "httpMatch.Method=POST on %s", *l.Name)
+					g.Expect(httpMatch.Value.PathMatch).ToNot(BeNil(), "httpMatch.PathMatch set on %s", *l.Name)
+					exactMatch, ok := httpMatch.Value.PathMatch.Match.(*types.PathMatchTypeMemberExact)
+					g.Expect(ok).To(BeTrue(), "PathMatch is Exact on %s", *l.Name)
+
+					forward, ok := ruleResp.Action.(*types.RuleActionMemberForward)
+					g.Expect(ok).To(BeTrue(), "rule action is Forward")
+					g.Expect(forward.Value.TargetGroups).To(HaveLen(2), "forward across external+EKS TG")
+
+					var externalId string
+					var externalWeight, eksWeight int32 = -1, -1
+					for _, wtg := range forward.Value.TargetGroups {
+						id := *wtg.TargetGroupIdentifier
+						if id == *preCreatedTargetGroupIdA || id == *preCreatedTargetGroupIdB {
+							externalId = id
+							externalWeight = *wtg.Weight
+						} else {
+							eksWeight = *wtg.Weight
+						}
+					}
+					g.Expect(externalWeight).To(BeEquivalentTo(90), "external TG weight 90 on %s", *l.Name)
+					g.Expect(eksWeight).To(BeEquivalentTo(10), "EKS TG weight 10 on %s", *l.Name)
+
+					if externalId == *preCreatedTargetGroupIdA {
+						foundA = true
+						g.Expect(exactMatch.Value).To(Equal("/echo.EchoService/V1"), "TG-A rule matches V1 path on %s", *l.Name)
+					} else if externalId == *preCreatedTargetGroupIdB {
+						foundB = true
+						g.Expect(exactMatch.Value).To(Equal("/echo.EchoService/V2"), "TG-B rule matches V2 path on %s", *l.Name)
+					}
+				}
+				g.Expect(foundA).To(BeTrue(), "%s: rule forwards to TG A (V1)", *l.Name)
+				g.Expect(foundB).To(BeTrue(), "%s: rule forwards to TG B (V2)", *l.Name)
+			}
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			for _, arn := range []*string{preCreatedTargetGroupArnA, preCreatedTargetGroupArnB} {
+				tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+					ResourceArn: arn,
+				})
+				g.Expect(err).To(BeNil())
+				_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+				g.Expect(hasManagedBy).To(BeFalse(), "external TG %s untagged", *arn)
+			}
+		}).Should(Succeed())
+	})
+})
+
+var _ = Describe("External service with TLS listeners", Ordered, Label("service-import-external-tg"), func() {
+	var (
+		preCreatedSnId *string
+		gateway        *gwv1.Gateway
+
+		preCreatedServiceArn      *string
+		preCreatedListenerArn443  *string
+		preCreatedListenerArn8443 *string
+		preCreatedTargetGroupArn  *string
+		preCreatedTargetGroupId   *string
+		preCreatedAssociationArn  *string
+
+		deployment    *appsv1.Deployment
+		tlsEksService *corev1.Service
+		currentRoute  *gwv1.TLSRoute
+		currentImport *anv1alpha1.ServiceImport
+
+		customerServiceName          = "external-svc-6"
+		customerServiceCustomDomain  = "tls-service.test.local"
+		serviceNetworkAndGatewayName = "external-sn-6"
+	)
+
+	BeforeAll(func() {
+		snResp, err := testFramework.LatticeClient.CreateServiceNetwork(ctx, &vpclattice.CreateServiceNetworkInput{
+			Name: aws.String(serviceNetworkAndGatewayName),
+		})
+		Expect(err).To(BeNil())
+		preCreatedSnId = snResp.Id
+
+		gateway = &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceNetworkAndGatewayName,
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: "amazon-vpc-lattice",
+				Listeners: []gwv1.Listener{
+					{
+						Name:     "tls-443",
+						Protocol: gwv1.TLSProtocolType,
+						Port:     443,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+						TLS: &gwv1.ListenerTLSConfig{
+							Mode: lo.ToPtr(gwv1.TLSModePassthrough),
+						},
+					},
+					{
+						Name:     "tls-8443",
+						Protocol: gwv1.TLSProtocolType,
+						Port:     8443,
+						AllowedRoutes: &gwv1.AllowedRoutes{
+							Namespaces: &gwv1.RouteNamespaces{
+								From: lo.ToPtr(gwv1.NamespacesFromSame),
+							},
+						},
+						TLS: &gwv1.ListenerTLSConfig{
+							Mode: lo.ToPtr(gwv1.TLSModePassthrough),
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, gateway)
+
+		Eventually(func(g Gomega) {
+			gw := &gwv1.Gateway{}
+			err := testFramework.Get(ctx, client.ObjectKeyFromObject(gateway), gw)
+			g.Expect(err).To(BeNil())
+			programmed := false
+			for _, cond := range gw.Status.Conditions {
+				if cond.Type == string(gwv1.GatewayConditionProgrammed) &&
+					cond.Status == metav1.ConditionTrue {
+					programmed = true
+					break
+				}
+			}
+			g.Expect(programmed).To(BeTrue(), "gateway not Programmed")
+		}).Should(Succeed())
+
+		targetGroupResp, err := testFramework.LatticeClient.CreateTargetGroup(ctx, &vpclattice.CreateTargetGroupInput{
+			Name: aws.String("external-tg-6"),
+			Type: types.TargetGroupTypeIp,
+			Config: &types.TargetGroupConfig{
+				Protocol:      types.TargetGroupProtocolTcp,
+				Port:          aws.Int32(443),
+				VpcIdentifier: aws.String(testFramework.Cloud.Config().VpcId),
+				IpAddressType: types.IpAddressTypeIpv4,
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedTargetGroupArn = targetGroupResp.Arn
+		preCreatedTargetGroupId = targetGroupResp.Id
+
+		Eventually(func(g Gomega) {
+			getTargetGroupResp, err := testFramework.LatticeClient.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+				TargetGroupIdentifier: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getTargetGroupResp.Status)).To(Equal(string(types.TargetGroupStatusActive)))
+		}).Should(Succeed())
+
+		serviceResp, err := testFramework.LatticeClient.CreateService(ctx, &vpclattice.CreateServiceInput{
+			Name:             aws.String(customerServiceName),
+			CustomDomainName: aws.String(customerServiceCustomDomain),
+		})
+		Expect(err).To(BeNil())
+		preCreatedServiceArn = serviceResp.Arn
+
+		Eventually(func(g Gomega) {
+			getServiceResp, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getServiceResp.Status)).To(Equal(string(types.ServiceStatusActive)))
+		}).Should(Succeed())
+
+		listenerResp443, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-443-6"),
+			Protocol:          types.ListenerProtocolTlsPassthrough,
+			Port:              aws.Int32(443),
+			DefaultAction: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{{
+						TargetGroupIdentifier: preCreatedTargetGroupArn,
+						Weight:                lo.ToPtr(int32(100)),
+					}},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn443 = listenerResp443.Arn
+
+		listenerResp8443, err := testFramework.LatticeClient.CreateListener(ctx, &vpclattice.CreateListenerInput{
+			ServiceIdentifier: preCreatedServiceArn,
+			Name:              aws.String("external-listener-8443-6"),
+			Protocol:          types.ListenerProtocolTlsPassthrough,
+			Port:              aws.Int32(8443),
+			DefaultAction: &types.RuleActionMemberForward{
+				Value: types.ForwardAction{
+					TargetGroups: []types.WeightedTargetGroup{{
+						TargetGroupIdentifier: preCreatedTargetGroupArn,
+						Weight:                lo.ToPtr(int32(100)),
+					}},
+				},
+			},
+		})
+		Expect(err).To(BeNil())
+		preCreatedListenerArn8443 = listenerResp8443.Arn
+
+		associationResp, err := testFramework.LatticeClient.CreateServiceNetworkServiceAssociation(ctx, &vpclattice.CreateServiceNetworkServiceAssociationInput{
+			ServiceIdentifier:        preCreatedServiceArn,
+			ServiceNetworkIdentifier: preCreatedSnId,
+		})
+		Expect(err).To(BeNil())
+		preCreatedAssociationArn = associationResp.Arn
+
+		Eventually(func(g Gomega) {
+			getAssocResp, err := testFramework.LatticeClient.GetServiceNetworkServiceAssociation(ctx, &vpclattice.GetServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(string(getAssocResp.Status)).To(Equal(string(types.ServiceNetworkServiceAssociationStatusActive)))
+		}).Should(Succeed())
+
+		deployment, tlsEksService = testFramework.NewHttpsApp(test.HTTPsAppOptions{
+			Name:       "eks-6",
+			Namespace:  k8snamespace,
+			Port:       443,
+			TargetPort: 443,
+		})
+		testFramework.ExpectCreated(ctx, deployment, tlsEksService)
+	})
+
+	AfterEach(func() {
+		if currentRoute != nil {
+			_ = testFramework.Client.Delete(ctx, currentRoute)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), currentRoute)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentRoute = nil
+		}
+		if currentImport != nil {
+			_ = testFramework.Client.Delete(ctx, currentImport)
+			Eventually(func(g Gomega) {
+				err := testFramework.Get(ctx, client.ObjectKeyFromObject(currentImport), currentImport)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+			currentImport = nil
+		}
+	})
+
+	AfterAll(func() {
+		if preCreatedAssociationArn != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+				ServiceNetworkServiceAssociationIdentifier: preCreatedAssociationArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete association %s: %v", *preCreatedAssociationArn, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn443 != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn443,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener 443 %s: %v", *preCreatedListenerArn443, err)
+				}
+			}
+		}
+
+		if preCreatedListenerArn8443 != nil {
+			_, err := testFramework.LatticeClient.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+				ServiceIdentifier:  preCreatedServiceArn,
+				ListenerIdentifier: preCreatedListenerArn8443,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete listener 8443 %s: %v", *preCreatedListenerArn8443, err)
+				}
+			}
+		}
+
+		if preCreatedServiceArn != nil {
+			_, err := testFramework.LatticeClient.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service %s: %v", *preCreatedServiceArn, err)
+				}
+			}
+		}
+
+		if preCreatedTargetGroupArn != nil {
+			Eventually(func(g Gomega) {
+				_, err := testFramework.LatticeClient.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+					TargetGroupIdentifier: preCreatedTargetGroupArn,
+				})
+				if err != nil {
+					var respErr *smithyhttp.ResponseError
+					if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+						return
+					}
+				}
+				g.Expect(err).To(BeNil())
+			}).Should(Succeed())
+		}
+
+		if deployment != nil && tlsEksService != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, deployment, tlsEksService)
+		}
+
+		if gateway != nil {
+			testFramework.ExpectDeletedThenNotFound(ctx, gateway)
+		}
+
+		if preCreatedSnId != nil {
+			_, err := testFramework.LatticeClient.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+				ServiceNetworkIdentifier: preCreatedSnId,
+			})
+			if err != nil {
+				var respErr *smithyhttp.ResponseError
+				if !errors.As(err, &respErr) || respErr.HTTPStatusCode() != 404 {
+					log.Printf("Failed to delete service network %s: %v", *preCreatedSnId, err)
+				}
+			}
+		}
+	})
+
+	It("TLSRoute with no sectionName replicates weighted forward across both listeners default action", func() {
+		currentImport = &anv1alpha1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "import-6",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/target-group-arn": *preCreatedTargetGroupArn,
+				},
+			},
+			Spec: anv1alpha1.ServiceImportSpec{
+				Type: anv1alpha1.ClusterSetIP,
+				Ports: []anv1alpha1.ServicePort{
+					{Port: 443, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentImport)
+
+		parentNS := gwv1.Namespace(gateway.Namespace)
+		currentRoute = &gwv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-6",
+				Namespace: k8snamespace,
+				Labels: map[string]string{
+					test.DiscoveryLabel: "true",
+				},
+				Annotations: map[string]string{
+					"application-networking.k8s.aws/service-name-override": customerServiceName,
+				},
+			},
+			Spec: gwv1.TLSRouteSpec{
+				CommonRouteSpec: gwv1.CommonRouteSpec{
+					ParentRefs: []gwv1.ParentReference{{
+						Name:      gwv1.ObjectName(gateway.Name),
+						Namespace: &parentNS,
+					}},
+				},
+				Hostnames: []gwv1.Hostname{gwv1.Hostname(customerServiceCustomDomain)},
+				Rules: []gwv1.TLSRouteRule{
+					{
+						BackendRefs: []gwv1.BackendRef{
+							{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName("import-6"),
+									Kind: lo.ToPtr(gwv1.Kind("ServiceImport")),
+								},
+								Weight: lo.ToPtr(int32(90)),
+							},
+							{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: gwv1.ObjectName(tlsEksService.Name),
+									Kind: lo.ToPtr(gwv1.Kind("Service")),
+									Port: lo.ToPtr(gwv1.PortNumber(443)),
+								},
+								Weight: lo.ToPtr(int32(10)),
+							},
+						},
+					},
+				},
+			},
+		}
+		testFramework.ExpectCreated(ctx, currentRoute)
+
+		Eventually(func(g Gomega) {
+			rt := &gwv1.TLSRoute{}
+			g.Expect(testFramework.Get(ctx, client.ObjectKeyFromObject(currentRoute), rt)).To(Succeed())
+			g.Expect(rt.Status.Parents).ToNot(BeEmpty())
+			conds := map[string]metav1.Condition{}
+			for _, c := range rt.Status.Parents[0].Conditions {
+				conds[c.Type] = c
+			}
+			accepted, ok := conds[string(gwv1.RouteConditionAccepted)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(accepted.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(accepted.Reason).To(Equal(string(gwv1.RouteReasonAccepted)))
+
+			resolved, ok := conds[string(gwv1.RouteConditionResolvedRefs)]
+			g.Expect(ok).To(BeTrue())
+			g.Expect(resolved.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(resolved.Reason).To(Equal(string(gwv1.RouteReasonResolvedRefs)))
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeTrue(), "service ManagedBy stamped")
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			listeners, err := testFramework.LatticeClient.ListListenersAsList(ctx, &vpclattice.ListListenersInput{
+				ServiceIdentifier: preCreatedServiceArn,
+			})
+			g.Expect(err).To(BeNil())
+			var l443, l8443 *types.ListenerSummary
+			for i := range listeners {
+				switch *listeners[i].Name {
+				case "external-listener-443-6":
+					l443 = &listeners[i]
+				case "external-listener-8443-6":
+					l8443 = &listeners[i]
+				}
+			}
+			g.Expect(l443).ToNot(BeNil(), "listener on port %d must survive claim", 443)
+			g.Expect(l8443).ToNot(BeNil(), "listener on port %d must survive claim", 8443)
+
+			for _, l := range []*types.ListenerSummary{l443, l8443} {
+				var expectedListenerArn *string
+				var expectedPort int32
+				switch *l.Name {
+				case "external-listener-443-6":
+					expectedListenerArn = preCreatedListenerArn443
+					expectedPort = 443
+				case "external-listener-8443-6":
+					expectedListenerArn = preCreatedListenerArn8443
+					expectedPort = 8443
+				}
+				g.Expect(*l.Arn).To(Equal(*expectedListenerArn), "listener %s ARN preserved", *l.Name)
+				g.Expect(*l.Port).To(BeEquivalentTo(expectedPort), "listener %s port unchanged", *l.Name)
+				g.Expect(string(l.Protocol)).To(Equal(string(types.ListenerProtocolTlsPassthrough)), "listener %s protocol unchanged", *l.Name)
+
+				rules, err := testFramework.LatticeClient.ListRulesAsList(ctx, &vpclattice.ListRulesInput{
+					ServiceIdentifier:  preCreatedServiceArn,
+					ListenerIdentifier: l.Arn,
+				})
+				g.Expect(err).To(BeNil())
+				nonDefault := []types.RuleSummary{}
+				for _, r := range rules {
+					if r.IsDefault != nil && *r.IsDefault {
+						continue
+					}
+					nonDefault = append(nonDefault, r)
+				}
+				g.Expect(nonDefault).To(HaveLen(0), "listener %s: 0 non-default rules", *l.Name)
+
+				listenerResp, err := testFramework.LatticeClient.GetListener(ctx, &vpclattice.GetListenerInput{
+					ServiceIdentifier:  preCreatedServiceArn,
+					ListenerIdentifier: l.Id,
+				})
+				g.Expect(err).To(BeNil())
+				forward, ok := listenerResp.DefaultAction.(*types.RuleActionMemberForward)
+				g.Expect(ok).To(BeTrue(), "listener %s default action is Forward", *l.Name)
+				g.Expect(forward.Value.TargetGroups).To(HaveLen(2), "forward across external+EKS TG on %s", *l.Name)
+
+				var externalWeight, eksWeight int32 = -1, -1
+				for _, wtg := range forward.Value.TargetGroups {
+					if *wtg.TargetGroupIdentifier == *preCreatedTargetGroupId {
+						externalWeight = *wtg.Weight
+					} else {
+						eksWeight = *wtg.Weight
+					}
+				}
+				g.Expect(externalWeight).To(BeEquivalentTo(90), "external TG weight 90 on %s", *l.Name)
+				g.Expect(eksWeight).To(BeEquivalentTo(10), "EKS TG weight 10 on %s", *l.Name)
+			}
+		}).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			tagsResp, err := testFramework.LatticeClient.ListTagsForResource(ctx, &vpclattice.ListTagsForResourceInput{
+				ResourceArn: preCreatedTargetGroupArn,
+			})
+			g.Expect(err).To(BeNil())
+			_, hasManagedBy := tagsResp.Tags["application-networking.k8s.aws/ManagedBy"]
+			g.Expect(hasManagedBy).To(BeFalse(), "external TG %s untagged", *preCreatedTargetGroupArn)
+		}).Should(Succeed())
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**
feature

**What does this PR do / Why do we need it**:
Adds a new `application-networking.k8s.aws/target-group-arn` annotation on`ServiceImport` that references an existing, customer-managed VPC Lattice target group by ARN. Combined with the existing`application-networking.k8s.aws/service-name-override` annotation, a route can weight-split traffic between EKS pods and the external target group, enabling gradual ECS / Lambda / EC2 / ALB to EKS migration using Lattice native weighted routing.

Key behaviors:
  - The external target group is reference-only: the controller never tags, mutates, registers targets on, or deletes it.
  - Malformed-ARN, target-group-not-found, and annotation-conflict failures surface as `ResolvedRefs=False` conditions at build time, before any claimed service is mutated.
  - The claim teardown path is hardened: `TryOwn` / `TryOwnFromTags` take an `isDeleting` flag so an untagged customer service is not auto-adopted and deleted on a route delete.


**Testing done on this change**:
Added integration tests

**Will this PR introduce any new dependencies?**:
No

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
No

**Does this PR introduce any user-facing change?**:
Yes
```release-note 
Add the `application-networking.k8s.aws/target-group-arn` annotation on ServiceImport to reference an existing VPC Lattice target group by ARN. Combined with `service-name-override`, this enables weighted ECS/Lambda/EC2/ALB to EKS migration.
```

**Do all end-to-end tests successfully pass when running make e2e-test?**
Yes

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.