### PR TITLE
fix: increase integration test timeouts

### DIFF
--- a/test/suites/integration/additional_tags_test.go
+++ b/test/suites/integration/additional_tags_test.go
@@ -2,10 +2,9 @@ package integration
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	vpclattice "github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -126,7 +125,7 @@ var _ = Describe("Additional Tags test", Ordered, func() {
 				g.Expect(associationTagsMap).To(HaveKeyWithValue("Team", "Platform"))
 				g.Expect(associationTagsMap).To(HaveKeyWithValue("CostCenter", "12345"))
 			}
-		}).Within(1 * time.Minute).Should(Succeed())
+		}).Should(Succeed())
 	})
 
 	It("Update HTTPRoute additional tags and verify AWS managed tags cannot be overridden", func() {
@@ -237,7 +236,7 @@ var _ = Describe("Additional Tags test", Ordered, func() {
 				g.Expect(associationTagsMap).ToNot(HaveKeyWithValue(pkg_aws.TagManagedBy, "test-override"))
 				g.Expect(associationTagsMap).To(HaveKeyWithValue(pkg_aws.TagManagedBy, fmt.Sprintf("%s/%s/%s", testFramework.Cloud.Config().AccountId, testFramework.Cloud.Config().ClusterName, testFramework.Cloud.Config().VpcId)))
 			}
-		}).Within(1 * time.Minute).Should(Succeed())
+		}).Should(Succeed())
 	})
 
 	It("Cleanup HTTPRoute resources", func() {
@@ -307,7 +306,7 @@ var _ = Describe("Additional Tags test", Ordered, func() {
 			g.Expect(tgTagsMap).To(HaveKeyWithValue("CostCenter", "12345"))
 
 			g.Expect(tgTagsMap).To(HaveKeyWithValue(pkg_aws.TagManagedBy, fmt.Sprintf("%s/%s/%s", testFramework.Cloud.Config().AccountId, testFramework.Cloud.Config().ClusterName, testFramework.Cloud.Config().VpcId)))
-		}).Within(1 * time.Minute).Should(Succeed())
+		}).Should(Succeed())
 	})
 
 	It("Update ServiceExport additional tags and verify AWS managed tags cannot be overridden", func() {
@@ -338,7 +337,7 @@ var _ = Describe("Additional Tags test", Ordered, func() {
 
 			g.Expect(tgTagsMap).ToNot(HaveKeyWithValue(pkg_aws.TagManagedBy, "test-override"))
 			g.Expect(tgTagsMap).To(HaveKeyWithValue(pkg_aws.TagManagedBy, fmt.Sprintf("%s/%s/%s", testFramework.Cloud.Config().AccountId, testFramework.Cloud.Config().ClusterName, testFramework.Cloud.Config().VpcId)))
-		}).Within(1 * time.Minute).Should(Succeed())
+		}).Should(Succeed())
 	})
 
 	It("Cleanup ServiceExport resources", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix**:
n/a

**What does this PR do / Why do we need it**:
flaky test fails due to insufficient timeout waiting for target groups and listeners to be created. Removed the timeout override so now it uses default of 5 min

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

```
------------------------------
• [FAILED] [60.001 seconds]
Additional Tags test [It] Verify additional tags on HTTPRoute VPC Lattice resources
/home/runner/work/aws-application-networking-k8s/aws-application-networking-k8s/test/suites/integration/additional_tags_test.go:44

  Captured StdOut/StdErr Output >>
  {"level":"info","ts":"2026-06-17T01:53:36.690Z","caller":"test/framework.go:379","msg":"Error getting target group additional-tags-http, e2e-test due to operation error VPC Lattice: ListTagsForResource, https response error StatusCode: 400, RequestID: 4a9f47fc-b633-4b77-8b5a-5b1b2be8ea92, api error BadRequestException: Invalid input resource arn"}
  {"level":"info","ts":"2026-06-17T01:53:41.888Z","caller":"test/framework.go:379","msg":"Error getting target group additional-tags-http, e2e-test due to operation error VPC Lattice: ListTagsForResource, https response error StatusCode: 400, RequestID: 67325291-47ff-47ba-82c4-3795f1f62baf, api error BadRequestException: Invalid input resource arn"}
  {"level":"info","ts":"2026-06-17T01:54:07.370Z","caller":"test/framework.go:389","msg":"Found target group k8s-e2e-test-additional-tags-http-uggpbnjhmh, tg-022985cea2ac57a23"}
  << Captured StdOut/StdErr Output

  [FAILED] Timed out after 60.000s.
  The function passed to Eventually failed at /home/runner/work/aws-application-networking-k8s/aws-application-networking-k8s/test/suites/integration/additional_tags_test.go:77 with:
  Expected
      <int>: 0
  to be >
      <int>: 0
  In [It] at: /home/runner/work/aws-application-networking-k8s/aws-application-networking-k8s/test/suites/integration/additional_tags_test.go:129 @ 06/17/26 01:54:10.616
------------------------------
```


**Testing done on this change**:
ran tests locally

**Automation added to e2e**:
n/a

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this PR introduce any user-facing change?**:
no

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.