### PR TITLE
fix(helm): expose service network override value

### DIFF
--- a/docs/guides/environment.md
+++ b/docs/guides/environment.md
@@ -75,6 +75,8 @@ The created service network will be also associated with cluster VPC.
 
 When set as "true", the controller will run in "single service network" mode that will override all gateways to point to default service network, instead of searching for service network with the same name. Can be used for small setups and conformance tests.
 
+The Helm chart exposes this setting as `enableServiceNetworkOverride`.
+
 ---
 
 #### `WEBHOOK_ENABLED`

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -166,6 +166,9 @@
       "type": "string",
       "enum": ["cluster", "namespace"]
     },
+    "enableServiceNetworkOverride": {
+      "type": "boolean"
+    },
     "serviceAccount": {
       "description": "ServiceAccount settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,6 +98,7 @@ awsAccountId:
 clusterVpcId:
 clusterName:
 defaultServiceNetwork:
+enableServiceNetworkOverride: false
 latticeEndpoint:
 webhookEnabled: true
 disableTaggingServiceApi: false


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fixes #625

**What does this PR do / Why do we need it**:

The Helm deployment template already maps `ENABLE_SERVICE_NETWORK_OVERRIDE` from `.Values.enableServiceNetworkOverride`, but the value is not exposed in `values.yaml` or the chart schema.

This adds the chart value with a default of `false`, adds it to `values.schema.json`, and documents the Helm value name in the environment guide.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

N/A

**Testing done on this change**:

```bash
git diff --check
jq empty helm/values.schema.json
```

**Automation added to e2e**:

No. This is a Helm values/schema/docs change only.

**Will this PR introduce any new dependencies?**:

No.

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

No breaking change expected. The new Helm value defaults to `false`, preserving the existing rendered environment value unless users opt in.

Updating a running cluster was not tested locally.

**Does this PR introduce any user-facing change?**:

Yes. Users can now discover and set the service network override option through the Helm chart values.

```release-note
Expose the `enableServiceNetworkOverride` Helm value for configuring `ENABLE_SERVICE_NETWORK_OVERRIDE`.
```

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:

```bash
Not run locally. This change only updates Helm chart values, schema, and documentation.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
