### PR TITLE
fix certificate resolution for routes with omitted sectionName

### DIFF
--- a/pkg/gateway/model_build_lattice_service.go
+++ b/pkg/gateway/model_build_lattice_service.go
@@ -265,21 +265,19 @@ func (t *latticeServiceModelBuildTask) getACMCertArn(ctx context.Context) (strin
 			continue
 		}
 
-		if parentRef.SectionName == nil {
-			continue
+		matched, err := t.matchedListeners(ctx, gw, parentRef)
+		if err != nil {
+			return "", err
 		}
 
-		for _, section := range gw.Spec.Listeners {
-			if section.Name == *parentRef.SectionName && section.TLS != nil {
-				if section.TLS.Mode != nil && *section.TLS.Mode == gwv1.TLSModeTerminate {
-					hasTLSTerminateListener = true
-					curCertARN, ok := section.TLS.Options[awsCustomCertARN]
-					if ok {
-						t.log.Debugf(ctx, "Found certification %s under section %s", curCertARN, section.Name)
-						return string(curCertARN), nil
-					}
+		for _, section := range matched {
+			if section.TLS != nil && section.TLS.Mode != nil && *section.TLS.Mode == gwv1.TLSModeTerminate {
+				hasTLSTerminateListener = true
+				curCertARN, ok := section.TLS.Options[awsCustomCertARN]
+				if ok {
+					t.log.Debugf(ctx, "Found certification %s under section %s", curCertARN, section.Name)
+					return string(curCertARN), nil
 				}
-				break
 			}
 		}
 	}

--- a/pkg/gateway/model_build_lattice_service_test.go
+++ b/pkg/gateway/model_build_lattice_service_test.go
@@ -2098,6 +2098,8 @@ func (s *stubCertDiscovery) Discover(_ context.Context, _ string) (string, error
 func Test_getACMCertArn(t *testing.T) {
 	tlsSectionName := gwv1.SectionName("tls")
 	tlsModeTerminate := gwv1.TLSModeTerminate
+	exampleHostname := gwv1.Hostname("*.example.com")
+	otherHostname := gwv1.Hostname("*.other.com")
 
 	gwClass := gwv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "gwClass"},
@@ -2109,44 +2111,61 @@ func Test_getACMCertArn(t *testing.T) {
 		return &p
 	}
 
-	httpsGateway := gwv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
-		Spec: gwv1.GatewaySpec{
-			GatewayClassName: gwv1.ObjectName(gwClass.Name),
-			Listeners: []gwv1.Listener{
-				{
-					Name:     "tls",
-					Port:     443,
-					Protocol: "HTTPS",
-					TLS: &gwv1.ListenerTLSConfig{
-						Mode: &tlsModeTerminate,
-					},
-				},
+	makeGateway := func(listeners ...gwv1.Listener) gwv1.Gateway {
+		return gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: gwv1.ObjectName(gwClass.Name),
+				Listeners:        listeners,
+			},
+		}
+	}
+
+	httpsListener := gwv1.Listener{
+		Name:     "tls",
+		Port:     443,
+		Protocol: "HTTPS",
+		TLS: &gwv1.ListenerTLSConfig{
+			Mode: &tlsModeTerminate,
+		},
+	}
+
+	httpsListenerWithCert := gwv1.Listener{
+		Name:     "tls",
+		Port:     443,
+		Protocol: "HTTPS",
+		TLS: &gwv1.ListenerTLSConfig{
+			Mode: &tlsModeTerminate,
+			Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				"application-networking.k8s.aws/certificate-arn": "arn:aws:acm:us-west-2:123456789012:certificate/manual-cert",
 			},
 		},
 	}
 
-	httpsGatewayWithCert := gwv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
-		Spec: gwv1.GatewaySpec{
-			GatewayClassName: gwv1.ObjectName(gwClass.Name),
-			Listeners: []gwv1.Listener{
-				{
-					Name:     "tls",
-					Port:     443,
-					Protocol: "HTTPS",
-					TLS: &gwv1.ListenerTLSConfig{
-						Mode: &tlsModeTerminate,
-						Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
-							"application-networking.k8s.aws/certificate-arn": "arn:aws:acm:us-west-2:123456789012:certificate/manual-cert",
-						},
-					},
-				},
+	httpsListenerWithCertAndHostname := gwv1.Listener{
+		Name:     "tls",
+		Port:     443,
+		Protocol: "HTTPS",
+		Hostname: &exampleHostname,
+		TLS: &gwv1.ListenerTLSConfig{
+			Mode: &tlsModeTerminate,
+			Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+				"application-networking.k8s.aws/certificate-arn": "arn:aws:acm:us-west-2:123456789012:certificate/manual-cert",
 			},
 		},
 	}
 
-	makeRoute := func(hostnames []gwv1.Hostname, deletionTimestamp *metav1.Time) core.Route {
+	httpsListenerWithHostname := gwv1.Listener{
+		Name:     "tls",
+		Port:     443,
+		Protocol: "HTTPS",
+		Hostname: &exampleHostname,
+		TLS: &gwv1.ListenerTLSConfig{
+			Mode: &tlsModeTerminate,
+		},
+	}
+
+	makeRoute := func(hostnames []gwv1.Hostname, deletionTimestamp *metav1.Time, sectionName *gwv1.SectionName) core.Route {
 		route := core.NewHTTPRoute(gwv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "route1",
@@ -2165,7 +2184,7 @@ func Test_getACMCertArn(t *testing.T) {
 						{
 							Name:        "gw",
 							Namespace:   namespacePtr("default"),
-							SectionName: &tlsSectionName,
+							SectionName: sectionName,
 						},
 					},
 				},
@@ -2177,7 +2196,7 @@ func Test_getACMCertArn(t *testing.T) {
 				ParentRef: gwv1.ParentReference{
 					Name:        "gw",
 					Namespace:   namespacePtr("default"),
-					SectionName: &tlsSectionName,
+					SectionName: sectionName,
 				},
 				Conditions: []metav1.Condition{
 					{Type: string(gwv1.RouteConditionAccepted), Status: metav1.ConditionTrue},
@@ -2199,34 +2218,34 @@ func Test_getACMCertArn(t *testing.T) {
 	}{
 		{
 			name:                "manual cert annotation present returns manual ARN and skips discovery",
-			gw:                  httpsGatewayWithCert,
-			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil),
+			gw:                  makeGateway(httpsListenerWithCert),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, &tlsSectionName),
 			certDiscovery:       &stubCertDiscovery{arn: "should-not-be-used"},
 			wantArn:             "arn:aws:acm:us-west-2:123456789012:certificate/manual-cert",
 			wantDiscoveryCalled: false,
 		},
 		{
 			name:                "no annotation with hostname triggers discovery",
-			gw:                  httpsGateway,
-			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil),
+			gw:                  makeGateway(httpsListener),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, &tlsSectionName),
 			certDiscovery:       &stubCertDiscovery{arn: "arn:aws:acm:us-west-2:123456789012:certificate/discovered"},
 			wantArn:             "arn:aws:acm:us-west-2:123456789012:certificate/discovered",
 			wantDiscoveryCalled: true,
 		},
 		{
 			name:                "no hostnames skips discovery",
-			gw:                  httpsGateway,
-			route:               makeRoute(nil, nil),
+			gw:                  makeGateway(httpsListener),
+			route:               makeRoute(nil, nil, &tlsSectionName),
 			certDiscovery:       &stubCertDiscovery{arn: "should-not-be-used"},
 			wantArn:             "",
 			wantDiscoveryCalled: false,
 		},
 		{
 			name: "route being deleted skips discovery",
-			gw:   httpsGateway,
+			gw:   makeGateway(httpsListener),
 			route: func() core.Route {
 				now := metav1.Now()
-				return makeRoute([]gwv1.Hostname{"app.example.com"}, &now)
+				return makeRoute([]gwv1.Hostname{"app.example.com"}, &now, &tlsSectionName)
 			}(),
 			certDiscovery:       &stubCertDiscovery{arn: "should-not-be-used"},
 			wantArn:             "",
@@ -2234,8 +2253,8 @@ func Test_getACMCertArn(t *testing.T) {
 		},
 		{
 			name:                "discovery transient error propagates",
-			gw:                  httpsGateway,
-			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil),
+			gw:                  makeGateway(httpsListener),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, &tlsSectionName),
 			certDiscovery:       &stubCertDiscovery{err: fmt.Errorf("acm error")},
 			wantArn:             "",
 			wantErr:             true,
@@ -2243,8 +2262,8 @@ func Test_getACMCertArn(t *testing.T) {
 		},
 		{
 			name:                "discovery access denied returns error with permission message",
-			gw:                  httpsGateway,
-			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil),
+			gw:                  makeGateway(httpsListener),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, &tlsSectionName),
 			certDiscovery:       &stubCertDiscovery{err: services.ErrACMAccessDenied},
 			wantArn:             "",
 			wantErr:             true,
@@ -2253,13 +2272,109 @@ func Test_getACMCertArn(t *testing.T) {
 		},
 		{
 			name:                "no matching cert returns error",
-			gw:                  httpsGateway,
-			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil),
+			gw:                  makeGateway(httpsListener),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, &tlsSectionName),
 			certDiscovery:       &stubCertDiscovery{arn: ""},
 			wantArn:             "",
 			wantErr:             true,
 			wantErrIs:           ErrCertificateNotFound,
 			wantDiscoveryCalled: true,
+		},
+		{
+			name:                "nil sectionName with matching hostname resolves cert from listener annotation",
+			gw:                  makeGateway(httpsListenerWithCertAndHostname),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, nil),
+			certDiscovery:       &stubCertDiscovery{arn: "should-not-be-used"},
+			wantArn:             "arn:aws:acm:us-west-2:123456789012:certificate/manual-cert",
+			wantDiscoveryCalled: false,
+		},
+		{
+			name:                "nil sectionName with matching hostname triggers discovery when no cert annotation",
+			gw:                  makeGateway(httpsListenerWithHostname),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, nil),
+			certDiscovery:       &stubCertDiscovery{arn: "arn:aws:acm:us-west-2:123456789012:certificate/discovered"},
+			wantArn:             "arn:aws:acm:us-west-2:123456789012:certificate/discovered",
+			wantDiscoveryCalled: true,
+		},
+		{
+			name: "nil sectionName with non-intersecting hostname skips listener",
+			gw: makeGateway(gwv1.Listener{
+				Name:     "https",
+				Port:     443,
+				Protocol: "HTTPS",
+				Hostname: &otherHostname,
+				TLS: &gwv1.ListenerTLSConfig{
+					Mode: &tlsModeTerminate,
+					Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+						"application-networking.k8s.aws/certificate-arn": "arn:aws:acm:us-west-2:123456789012:certificate/wrong-cert",
+					},
+				},
+			}),
+			route:               makeRoute([]gwv1.Hostname{"app.example.com"}, nil, nil),
+			certDiscovery:       &stubCertDiscovery{arn: "should-not-be-used"},
+			wantArn:             "",
+			wantDiscoveryCalled: false,
+		},
+		{
+			name: "nil sectionName with port filter only matches listener on correct port",
+			gw: makeGateway(
+				gwv1.Listener{
+					Name:     "https-8443",
+					Port:     8443,
+					Protocol: "HTTPS",
+					TLS: &gwv1.ListenerTLSConfig{
+						Mode: &tlsModeTerminate,
+						Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+							"application-networking.k8s.aws/certificate-arn": "arn:aws:acm:us-west-2:123456789012:certificate/wrong-port-cert",
+						},
+					},
+				},
+				gwv1.Listener{
+					Name:     "https-443",
+					Port:     443,
+					Protocol: "HTTPS",
+					TLS: &gwv1.ListenerTLSConfig{
+						Mode: &tlsModeTerminate,
+						Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+							"application-networking.k8s.aws/certificate-arn": "arn:aws:acm:us-west-2:123456789012:certificate/correct-port-cert",
+						},
+					},
+				},
+			),
+			route: func() core.Route {
+				port := gwv1.PortNumber(443)
+				route := core.NewHTTPRoute(gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default"},
+					Spec: gwv1.HTTPRouteSpec{
+						CommonRouteSpec: gwv1.CommonRouteSpec{
+							ParentRefs: []gwv1.ParentReference{
+								{
+									Name:      "gw",
+									Namespace: namespacePtr("default"),
+									Port:      &port,
+								},
+							},
+						},
+						Hostnames: []gwv1.Hostname{"app.example.com"},
+					},
+				})
+				route.Status().SetParents([]gwv1.RouteParentStatus{
+					{
+						ParentRef: gwv1.ParentReference{
+							Name:      "gw",
+							Namespace: namespacePtr("default"),
+							Port:      &port,
+						},
+						Conditions: []metav1.Condition{
+							{Type: string(gwv1.RouteConditionAccepted), Status: metav1.ConditionTrue},
+						},
+					},
+				})
+				return route
+			}(),
+			certDiscovery:       &stubCertDiscovery{arn: "should-not-be-used"},
+			wantArn:             "arn:aws:acm:us-west-2:123456789012:certificate/correct-port-cert",
+			wantDiscoveryCalled: false,
 		},
 	}
 

--- a/pkg/gateway/model_build_listener.go
+++ b/pkg/gateway/model_build_listener.go
@@ -84,23 +84,12 @@ func (t *latticeServiceModelBuildTask) buildListeners(ctx context.Context, stack
 		}
 
 		// Find all gateway listeners that match this parentRef
-		for _, gwListener := range gw.Spec.Listeners {
-			if parentRef.Port != nil && *parentRef.Port != gwListener.Port {
-				continue
-			}
-			if parentRef.SectionName != nil && *parentRef.SectionName != gwListener.Name {
-				continue
-			}
+		matched, err := t.matchedListeners(ctx, gw, parentRef)
+		if err != nil {
+			return err
+		}
 
-			allowed, err := core.IsRouteAllowedByListener(ctx, t.client, t.route, gw, gwListener)
-			if err != nil {
-				return fmt.Errorf("error checking allowedRoutes policy for listener %s: %w", gwListener.Name, err)
-			}
-			if !allowed {
-				t.log.Debugf(ctx, "Skipping listener %s due to allowedRoutes policy", gwListener.Name)
-				continue
-			}
-
+		for _, gwListener := range matched {
 			protocol := string(gwListener.Protocol)
 			if isTLSPassthroughGatewayListener(&gwListener) {
 				t.log.Debugf(ctx, "Found TLS passthrough listener %s", gwListener.Name)
@@ -168,4 +157,33 @@ func (t *latticeServiceModelBuildTask) getListenerDefaultAction(ctx context.Cont
 			TargetGroups: ruleTgList,
 		},
 	}, nil
+}
+
+// matchedListeners returns the Gateway listeners that a parentRef matches,
+// using the standard Gateway API matching logic: port filter, sectionName filter,
+// and IsRouteAllowedByListener (route kind, hostname intersection, allowedRoutes policy).
+func (t *latticeServiceModelBuildTask) matchedListeners(
+	ctx context.Context, gw *gwv1.Gateway, parentRef gwv1.ParentReference,
+) ([]gwv1.Listener, error) {
+	var matched []gwv1.Listener
+	for _, gwListener := range gw.Spec.Listeners {
+		if parentRef.Port != nil && *parentRef.Port != gwListener.Port {
+			continue
+		}
+		if parentRef.SectionName != nil && *parentRef.SectionName != gwListener.Name {
+			continue
+		}
+
+		allowed, err := core.IsRouteAllowedByListener(ctx, t.client, t.route, gw, gwListener)
+		if err != nil {
+			return nil, fmt.Errorf("error checking allowedRoutes policy for listener %s: %w", gwListener.Name, err)
+		}
+		if !allowed {
+			t.log.Debugf(ctx, "Skipping listener %s due to allowedRoutes policy", gwListener.Name)
+			continue
+		}
+
+		matched = append(matched, gwListener)
+	}
+	return matched, nil
 }

--- a/test/suites/integration/byoc_test.go
+++ b/test/suites/integration/byoc_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Bring your own certificate (BYOC)", Serial, Ordered, func() {
 
 	var (
 		log       = testFramework.Log.Named("byoc")
-		awsCfg = lo.Must(awsconfig.LoadDefaultConfig(context.TODO(), awsconfig.WithRegion(config.Region)))
+		awsCfg    = lo.Must(awsconfig.LoadDefaultConfig(context.TODO(), awsconfig.WithRegion(config.Region)))
 		acmClient = acm.NewFromConfig(awsCfg)
 		r53Client = route53.NewFromConfig(awsCfg)
 
@@ -106,6 +106,34 @@ var _ = Describe("Bring your own certificate (BYOC)", Serial, Ordered, func() {
 			g.Expect(stdout).To(ContainSubstring("byoc-app handler pod"))
 			g.Expect(stderr).To(ContainSubstring("issuer: O=byoc-e2e-test"))
 		}).Should(Succeed())
+	})
+
+	It("resolves cert when parentRef omits sectionName", func() {
+		log := log.Named("nil-sectionname")
+
+		// create a route WITHOUT sectionName
+		httpRoute2 := testFramework.NewHttpRoute(testGateway, service, "Service")
+		httpRoute2.Name = "byoc-no-section"
+		httpRoute2.Spec.Hostnames = []gwv1.Hostname{cname}
+		testFramework.ExpectCreated(context.TODO(), httpRoute2)
+
+		// verify the Lattice service is created with the correct cert
+		svc := testFramework.GetVpcLatticeService(context.TODO(), core.NewHTTPRoute(gwv1.HTTPRoute(*httpRoute2)))
+		log.Infof(ctx, "nil-sectionName route created lattice service: %s", *svc.Id)
+
+		// verify HTTPS traffic works with the discovered cert
+		pods := testFramework.GetPodsByDeploymentName(deployment.Name, deployment.Namespace)
+		pod := pods[0]
+		Eventually(func(g Gomega) {
+			cmd := fmt.Sprintf("curl -v -k https://%s/", cname)
+			log.Infof(ctx, "calling lattice service, cmd=%s, pod=%s/%s", cmd, pod.Namespace, pod.Name)
+			stdout, stderr, err := testFramework.PodExec(pod, cmd)
+			g.Expect(err).To(BeNil())
+			g.Expect(stdout).To(ContainSubstring("byoc-app handler pod"))
+			g.Expect(stderr).To(ContainSubstring("issuer: O=byoc-e2e-test"))
+		}).Should(Succeed())
+
+		testFramework.ExpectDeletedThenNotFound(context.TODO(), httpRoute2)
 	})
 
 	AfterAll(func() {

--- a/test/suites/integration/cert_discovery_test.go
+++ b/test/suites/integration/cert_discovery_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ACM certificate discovery", Serial, Ordered, func() {
 
 	var (
 		log       = testFramework.Log.Named("cert-discovery")
-		awsCfg = lo.Must(awsconfig.LoadDefaultConfig(context.TODO(), awsconfig.WithRegion(config.Region)))
+		awsCfg    = lo.Must(awsconfig.LoadDefaultConfig(context.TODO(), awsconfig.WithRegion(config.Region)))
 		acmClient = acm.NewFromConfig(awsCfg)
 		r53Client = route53.NewFromConfig(awsCfg)
 
@@ -130,6 +130,30 @@ var _ = Describe("ACM certificate discovery", Serial, Ordered, func() {
 			g.Expect(err).To(BeNil())
 			g.Expect(stdout).To(ContainSubstring("cert-discovery-app handler pod"))
 		}).Should(Succeed())
+	})
+
+	It("auto-discovers cert when parentRef omits sectionName", func() {
+		log := log.Named("nil-sectionname")
+
+		// create a route WITHOUT sectionName
+		httpRoute2 := testFramework.NewHttpRoute(testGateway, service, "Service")
+		httpRoute2.Name = "cert-disc-no-section"
+		httpRoute2.Spec.Hostnames = []gwv1.Hostname{cname}
+		testFramework.ExpectCreated(context.TODO(), httpRoute2)
+
+		// verify the Lattice service gets the auto-discovered cert
+		svc := testFramework.GetVpcLatticeService(context.TODO(), core.NewHTTPRoute(gwv1.HTTPRoute(*httpRoute2)))
+		Eventually(func(g Gomega) {
+			out, err := testFramework.LatticeClient.GetService(ctx, &vpclattice.GetServiceInput{
+				ServiceIdentifier: svc.Id,
+			})
+			g.Expect(err).To(BeNil())
+			g.Expect(out.CertificateArn).ToNot(BeNil())
+			g.Expect(*out.CertificateArn).To(Equal(certArn))
+			log.Infof(ctx, "nil-sectionName route discovered cert: %s", *out.CertificateArn)
+		}).WithTimeout(3 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
+
+		testFramework.ExpectDeletedThenNotFound(context.TODO(), httpRoute2)
 	})
 
 	AfterAll(func() {


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:
fixes #979

**What does this PR do / Why do we need it**:
This PR fixes a bug where VPC Lattice Services are created without a TLS certificate when an HTTPRoute/GRPCRoute/TLSRoute attaches to a Gateway without specifying sectionName in its parentRef.
 
Certificate resolution now iterates all Gateway listeners and applies the same matching logic as listener attachment when sectionName is nil. If a matched listener has TLS mode Terminate, its cert annotation is read. If no annotation is present, the auto-discovery fallback is enabled — same behaviour as when sectionName is explicitly specified.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
added unit tests and integ tests covering the exact issue

**Automation added to e2e**:
yes, new integ tests

**Will this PR introduce any new dependencies?**:
no

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this PR introduce any user-facing change?**:

```release-note
Fixed TLS certificates not being applied to VPC Lattice Services when a route's parentRef omits sectionName.
```

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
```
Ran 162 of 170 Specs in 3031.611 seconds
SUCCESS! -- 162 Passed | 0 Failed | 0 Pending | 8 Skipped
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.