### PR TITLE
fix: Surface ConflictException as terminal status condition

### DIFF
--- a/pkg/controllers/vpcassociationpolicy_controller.go
+++ b/pkg/controllers/vpcassociationpolicy_controller.go
@@ -128,6 +128,14 @@ func (c *vpcAssociationPolicyReconciler) upsert(ctx context.Context, k8sPolicy *
 
 	snva, err := c.manager.UpsertVpcAssociation(ctx, snName, sgIds, additionalTags)
 	if err != nil {
+		if services.IsConflictError(err) {
+			c.log.Infow(ctx, "permanent conflict, setting Accepted=False",
+				"name", k8sPolicy.Name, "message", err.Error())
+			if updateErr := c.ph.UpdateAcceptedCondition(ctx, k8sPolicy, policy.ReasonConflicted, err.Error()); updateErr != nil {
+				return updateErr
+			}
+			return nil
+		}
 		return err
 	}
 	err = c.updateLatticeAnnotation(ctx, k8sPolicy, snva)

--- a/pkg/controllers/vpcassociationpolicy_controller_test.go
+++ b/pkg/controllers/vpcassociationpolicy_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	deploy "github.com/aws/aws-application-networking-k8s/pkg/deploy/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/k8s"
@@ -100,4 +101,92 @@ func Test_VpcAssociationPolicy_PeriodicRequeue(t *testing.T) {
 	// matching pkg/runtime/reconcile_test.go::Test_NilError_WithReconcileInterval.
 	assert.GreaterOrEqual(t, result.RequeueAfter, interval)
 	assert.LessOrEqual(t, result.RequeueAfter, time.Duration(float64(interval)*1.2))
+}
+
+// Test_VpcAssociationPolicy_ConflictError_SetsAcceptedFalse verifies that when
+// UpsertVpcAssociation returns a ConflictError, the reconciler sets the Accepted
+// condition to False with reason Conflicted and does NOT retry (returns no error).
+func Test_VpcAssociationPolicy_ConflictError_SetsAcceptedFalse(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+
+	k8sScheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(k8sScheme)
+	gwv1.Install(k8sScheme)
+	anv1alpha1.Install(k8sScheme)
+
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "amazon-vpc-lattice",
+		},
+	}
+
+	vap := &anv1alpha1.VpcAssociationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "test-namespace",
+		},
+		Spec: anv1alpha1.VpcAssociationPolicySpec{
+			TargetRef: &gwv1alpha2.NamespacedPolicyTargetReference{
+				Group: gwv1.GroupName,
+				Kind:  "Gateway",
+				Name:  "test-gateway",
+			},
+		},
+	}
+
+	k8sClient := testclient.NewClientBuilder().
+		WithScheme(k8sScheme).
+		WithObjects(vap, gw).
+		WithStatusSubresource(&anv1alpha1.VpcAssociationPolicy{}).
+		Build()
+
+	// UpsertVpcAssociation returns a ConflictError (VPC already associated to another SN)
+	mockSNManager := deploy.NewMockServiceNetworkManager(c)
+	mockSNManager.EXPECT().UpsertVpcAssociation(gomock.Any(), "test-gateway", gomock.Any(), gomock.Any()).Return(
+		"", &services.ConflictError{
+			ResourceType: "ServiceNetworkVpcAssociation",
+			Name:         "test-gateway",
+			Message:      "VPC has already been associated to a service network.",
+		})
+
+	mockFinalizer := k8s.NewMockFinalizerManager(c)
+	mockFinalizer.EXPECT().AddFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	r := &vpcAssociationPolicyReconciler{
+		log:              gwlog.FallbackLogger,
+		client:           k8sClient,
+		finalizerManager: mockFinalizer,
+		manager:          mockSNManager,
+		ph:               policy.NewVpcAssociationPolicyHandler(gwlog.FallbackLogger, k8sClient),
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-policy", Namespace: "test-namespace"},
+	})
+	// Should NOT return an error — stops retrying
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), result.RequeueAfter)
+
+	// Verify the status condition was set to Accepted=False, Reason=Conflicted
+	updatedVap := &anv1alpha1.VpcAssociationPolicy{}
+	err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-policy", Namespace: "test-namespace"}, updatedVap)
+	assert.NoError(t, err)
+
+	var acceptedCond *metav1.Condition
+	for i := range updatedVap.Status.Conditions {
+		if updatedVap.Status.Conditions[i].Type == string(gwv1.PolicyConditionAccepted) {
+			acceptedCond = &updatedVap.Status.Conditions[i]
+			break
+		}
+	}
+	assert.NotNil(t, acceptedCond, "Accepted condition should be set")
+	assert.Equal(t, metav1.ConditionFalse, acceptedCond.Status)
+	assert.Equal(t, string(gwv1.PolicyReasonConflicted), acceptedCond.Reason)
+	assert.Contains(t, acceptedCond.Message, "VPC has already been associated")
 }

--- a/pkg/deploy/lattice/service_network_manager.go
+++ b/pkg/deploy/lattice/service_network_manager.go
@@ -2,7 +2,9 @@ package lattice
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"slices"
 
@@ -101,6 +103,16 @@ func (m *defaultServiceNetworkManager) UpsertVpcAssociation(ctx context.Context,
 		}
 		resp, err := m.cloud.Lattice().CreateServiceNetworkVpcAssociation(ctx, &req)
 		if err != nil {
+			var ce *types.ConflictException
+			if errors.As(err, &ce) {
+				msg := aws.ToString(ce.Message)
+				if strings.Contains(msg, string(types.ServiceNetworkVpcAssociationStatusCreateInProgress)) {
+					// Transient conflict — the association is being created, retry later
+					return "", fmt.Errorf("%w: %s", lattice_runtime.NewRetryError(), msg)
+				}
+				// Permanent conflict — VPC already associated with another service network
+				return "", services.NewConflictError("ServiceNetworkVpcAssociation", snName, msg)
+			}
 			return "", err
 		}
 		switch status := string(resp.Status); status {

--- a/pkg/deploy/lattice/service_network_manager_test.go
+++ b/pkg/deploy/lattice/service_network_manager_test.go
@@ -1057,3 +1057,83 @@ func Test_Delete_ConflictException(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "ConflictException")
 }
+
+// Test that a permanent ConflictException (VPC already associated) returns a services.ConflictError.
+func Test_UpsertVpcAssociation_ConflictException_PermanentConflict(t *testing.T) {
+	snId := "sn-12345678912345678"
+	snArn := "arn:aws:vpc-lattice:us-west-2:123456789012:servicenetwork/sn-12345678912345678"
+	name := "test-sn"
+	item := types.ServiceNetworkSummary{
+		Arn:  &snArn,
+		Id:   &snId,
+		Name: &name,
+	}
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+	mockLattice := mocks.NewMockLattice(c)
+	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any()).Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: item,
+			Tags:       nil,
+		}, nil)
+	// No existing association for this SN+VPC pair
+	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(
+		[]types.ServiceNetworkVpcAssociationSummary{}, nil)
+	// CreateServiceNetworkVpcAssociation returns a permanent ConflictException
+	mockLattice.EXPECT().CreateServiceNetworkVpcAssociation(ctx, gomock.Any()).Return(
+		nil, &types.ConflictException{
+			Message: aws.String("VPC has already been associated to a service network."),
+		})
+
+	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
+	_, err := snMgr.UpsertVpcAssociation(ctx, name, []string{}, nil)
+
+	assert.NotNil(t, err)
+	assert.True(t, mocks.IsConflictError(err))
+	assert.Contains(t, err.Error(), "VPC has already been associated")
+}
+
+// Test that a transient ConflictException (CREATE_IN_PROGRESS) returns a RetryError.
+func Test_UpsertVpcAssociation_ConflictException_TransientCreateInProgress(t *testing.T) {
+	snId := "sn-12345678912345678"
+	snArn := "arn:aws:vpc-lattice:us-west-2:123456789012:servicenetwork/sn-12345678912345678"
+	name := "test-sn"
+	item := types.ServiceNetworkSummary{
+		Arn:  &snArn,
+		Id:   &snId,
+		Name: &name,
+	}
+
+	c := gomock.NewController(t)
+	defer c.Finish()
+	ctx := context.TODO()
+	mockLattice := mocks.NewMockLattice(c)
+	cloud := pkg_aws.NewDefaultCloud(mockLattice, TestCloudConfig)
+
+	mockLattice.EXPECT().FindServiceNetwork(ctx, gomock.Any()).Return(
+		&mocks.ServiceNetworkInfo{
+			SvcNetwork: item,
+			Tags:       nil,
+		}, nil)
+	// No existing association for this SN+VPC pair
+	mockLattice.EXPECT().ListServiceNetworkVpcAssociationsAsList(ctx, gomock.Any()).Return(
+		[]types.ServiceNetworkVpcAssociationSummary{}, nil)
+	// CreateServiceNetworkVpcAssociation returns a transient ConflictException
+	mockLattice.EXPECT().CreateServiceNetworkVpcAssociation(ctx, gomock.Any()).Return(
+		nil, &types.ConflictException{
+			Message: aws.String("Invalid resource status for this operation, resource id snva-xxx, status: CREATE_IN_PROGRESS."),
+		})
+
+	snMgr := NewDefaultServiceNetworkManager(gwlog.FallbackLogger, cloud)
+	_, err := snMgr.UpsertVpcAssociation(ctx, name, []string{}, nil)
+
+	assert.NotNil(t, err)
+	// Should be a retry error, NOT a ConflictError
+	assert.False(t, mocks.IsConflictError(err))
+	var retryErr *lattice_runtime.RequeueNeededAfter
+	assert.True(t, errors.As(err, &retryErr))
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-application-networking-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
bug

**Which issue does this PR fix**:
Fixes #984

**What does this PR do / Why do we need it**:
When CreateServiceNetworkVpcAssociation returns a ConflictException because the VPC is already associated with another service network, the controller now:

1. Detects the permanent conflict (vs transient CREATE_IN_PROGRESS)
2. Sets Accepted=False with reason Conflicted on the VpcAssociationPolicy
3. Stops retrying (returns nil instead of looping with backoff)

This gives users immediate visibility via kubectl instead of requiring them to check controller logs for the permanent failure.

Transient ConflictExceptions (CREATE_IN_PROGRESS) are still retried via the standard RequeueNeededAfter mechanism.


**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

**Do all end-to-end tests successfully pass when running `make e2e-test`?**:
<!--
Please provide a snippet of a successful `make e2e-test` run to confirm.
-->
```

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.